### PR TITLE
adapt to foundations rearrangement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - WPATH=$PWD
   - cd ..        
   - git clone https://github.com/UniMath/UniMath
-  - cd UniMath && make PACKAGES="Foundations CategoryTheory Ktheory" install
+  - cd UniMath && make PACKAGES="Foundations Algebra CategoryTheory Ktheory" install
   - export PATH=$PATH:$PWD/sub/coq/bin/
   - cd $WPATH
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - WPATH=$PWD
   - cd ..        
   - git clone https://github.com/UniMath/UniMath
-  - cd UniMath && make PACKAGES="Foundations Algebra CategoryTheory Ktheory" install
+  - cd UniMath && make PACKAGES="Foundations Combinatorics Algebra CategoryTheory Ktheory" install
   - export PATH=$PATH:$PWD/sub/coq/bin/
   - cd $WPATH
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - WPATH=$PWD
   - cd ..        
   - git clone https://github.com/UniMath/UniMath
-  - cd UniMath && make PACKAGES="Foundations Combinatorics Algebra CategoryTheory Ktheory" install
+  - cd UniMath && make PACKAGES="Foundations Combinatorics Algebra NumberSystems CategoryTheory Ktheory" install
   - export PATH=$PATH:$PWD/sub/coq/bin/
   - cd $WPATH
 script:

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ doc: $(GLOBFILES) $(VFILES)
 # The isolated bug will appear in this file, in the TypeTheory directory:
 ISOLATED_BUG_FILE := isolated_bug.v
 # To use it, run something like this command in an interactive shell:
-#     make isolate-bug BUGGY_FILE=Foundations/Basics/PartB.v
+#     make isolate-bug BUGGY_FILE=Foundations/PartB.v
 sub/coq-tools/find-bug.py:
 	git submodule update --init sub/coq-tools
 help-find-bug:

--- a/TypeTheory/ALV1/CwF_RelUnivYoneda.v
+++ b/TypeTheory/ALV1/CwF_RelUnivYoneda.v
@@ -12,7 +12,7 @@ Contents:
   and relative universes for [ Yo : C -> preShv C ].
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.Auxiliary.Auxiliary.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
@@ -16,7 +16,7 @@ Main definitions:
 
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.Auxiliary.UnicodeNotations.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
@@ -23,7 +23,7 @@ NB: for now, we follow the literature in saying e.g. _category_ with families an
 
 
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.Auxiliary.Auxiliary.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
@@ -4,7 +4,7 @@
   Part of the [TypeTheory] library (Ahrens, Lumsdaine, Voevodsky, 2015–present).
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.Auxiliary.Auxiliary.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
@@ -5,7 +5,7 @@
 *)
 
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.Auxiliary.Auxiliary.

--- a/TypeTheory/ALV1/CwF_def.v
+++ b/TypeTheory/ALV1/CwF_def.v
@@ -11,7 +11,7 @@ Contents:
 - equivalence between this and two related ones occurring in the ALV1 paper
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.Auxiliary.Auxiliary.

--- a/TypeTheory/ALV1/RelUnivYonedaCompletion.v
+++ b/TypeTheory/ALV1/RelUnivYonedaCompletion.v
@@ -5,7 +5,7 @@
 *)
 
 (** This file provides the result: given a universe in [preShv C] relative to the Yoneda embedding [ Yo : C -> preShv C ], this transfers to a similar relative universe in [ preShv (RC C) ]. i.e. on the Rezk-completion of [C]. *)
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.Auxiliary.Auxiliary.

--- a/TypeTheory/ALV1/RelativeUniverses.v
+++ b/TypeTheory/ALV1/RelativeUniverses.v
@@ -15,7 +15,7 @@ Contents:
 
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.Auxiliary.Auxiliary.

--- a/TypeTheory/ALV1/Summary.v
+++ b/TypeTheory/ALV1/Summary.v
@@ -14,7 +14,7 @@ Contents:
 
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.ALV1.RelativeUniverses.

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Cats.v
@@ -12,7 +12,7 @@ Main definitions:
 - [qq_structure_disp_precat], [qq_structure_precat]
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.Auxiliary.UnicodeNotations.

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
@@ -4,7 +4,7 @@
   Part of the [TypeTheory] library (Ahrens, Lumsdaine, Voevodsky, 2015–present).
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.Auxiliary.Auxiliary.

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
@@ -4,7 +4,7 @@
   Part of the [TypeTheory] library (Ahrens, Lumsdaine, Voevodsky, 2015–present).
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.Auxiliary.Auxiliary.

--- a/TypeTheory/Auxiliary/Auxiliary.v
+++ b/TypeTheory/Auxiliary/Auxiliary.v
@@ -12,9 +12,9 @@ Possibly some should be upstreamed to “UniMath” eventually.
 *)
 
 
-Require Import UniMath.Foundations.Basics.PartD.
-Require Import UniMath.Foundations.Basics.Sets.
-Require Import UniMath.Foundations.Combinatorics.StandardFiniteSets.
+Require Import UniMath.Foundations.PartD.
+Require Import UniMath.Foundations.Sets.
+Require Import UniMath.Combinatorics.StandardFiniteSets.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
 Require Import UniMath.CategoryTheory.limits.graphs.pullbacks.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.

--- a/TypeTheory/Categories/category_FAM.v
+++ b/TypeTheory/Categories/category_FAM.v
@@ -7,8 +7,8 @@
     - TODO: FAM(C) saturated if C is
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
-Require Import UniMath.Foundations.Basics.UnivalenceAxiom.
+Require Import UniMath.Foundations.Sets.
+Require Import UniMath.Foundations.UnivalenceAxiom.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.

--- a/TypeTheory/Categories/category_of_elements.v
+++ b/TypeTheory/Categories/category_of_elements.v
@@ -6,7 +6,7 @@
     - not much yet
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.category_hset.

--- a/TypeTheory/Categories/ess_alg_categories.v
+++ b/TypeTheory/Categories/ess_alg_categories.v
@@ -9,7 +9,7 @@
     - axioms (including "identity morphism" map)
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 
 Require Import TypeTheory.Auxiliary.UnicodeNotations.
 

--- a/TypeTheory/Categories/ess_and_gen_alg_cats.v
+++ b/TypeTheory/Categories/ess_and_gen_alg_cats.v
@@ -16,7 +16,7 @@ In this file, we define functions back and forth and show that
 *)
 
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 

--- a/TypeTheory/Displayed_Cats/Auxiliary.v
+++ b/TypeTheory/Displayed_Cats/Auxiliary.v
@@ -14,12 +14,12 @@ Contents:
 *)
 
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 
-Require Import UniMath.Ktheory.StandardCategories. 
+Require Import UniMath.Ktheory.StandardCategories.
 
 Require Import TypeTheory.Auxiliary.UnicodeNotations.
 Require Import TypeTheory.Auxiliary.Auxiliary.

--- a/TypeTheory/Displayed_Cats/Constructions.v
+++ b/TypeTheory/Displayed_Cats/Constructions.v
@@ -11,7 +11,7 @@ Partial contents:
 - Fiber precats
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 

--- a/TypeTheory/Displayed_Cats/Core.v
+++ b/TypeTheory/Displayed_Cats/Core.v
@@ -29,7 +29,7 @@ Contents:
 
 (* TODO: this file has become large and unwieldy; should probably be split up.  Displayed functors can certainly be happily split off.  Should total precats stay here, or also be split out? *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 
@@ -378,10 +378,10 @@ Proof.
   (* TODO: think about better lemmas for this sort of calculation?
   e.g. all that repeated application of [transport_f_f], etc. *)
   - destruct i as [gg [gf fg]], i' as [gg' [gf' fg']]; simpl.
-    etrans. eapply pathsinv0, Utilities.transportfbinv.
+    etrans. eapply pathsinv0, transportfbinv.
     etrans. apply maponpaths, @pathsinv0, id_right_disp.
     etrans. apply maponpaths, maponpaths.
-      etrans. eapply pathsinv0, Utilities.transportfbinv.
+      etrans. eapply pathsinv0, transportfbinv.
       apply maponpaths, @pathsinv0, fg'.
     etrans. apply maponpaths, mor_disp_transportf_prewhisker.
     etrans. apply transport_f_f.
@@ -645,7 +645,7 @@ Lemma transportf_precompose_disp {C} {D : disp_precat C}
 Proof.
   destruct e; cbn; unfold idfun; cbn. 
   rewrite id_left_disp.
-  apply pathsinv0, Utilities.transportfbinv.
+  apply pathsinv0, transportfbinv.
 Qed.
 
 (* TODO: add dual [transportf_postcompose_disp]. *)
@@ -787,19 +787,19 @@ Proof.
       apply maponpaths, id_left_disp.
   (* Note: [transportbfi] is from [UniMath.Ktheory.Utilities].
   We currently can’t import that, due to notation clashes. *)
-    apply Utilities.transportfbinv. 
+    apply transportfbinv. 
   - intros xx yy ff; cbn.
     use total2_paths; simpl.
     apply id_right.
     eapply pathscomp0.
       apply maponpaths, id_right_disp.
-    apply Utilities.transportfbinv. 
+    apply transportfbinv. 
   - intros xx yy zz ww ff gg hh.
     use total2_paths; simpl.
     apply assoc.
     eapply pathscomp0.
       apply maponpaths, assoc_disp.
-    apply Utilities.transportfbinv. 
+    apply transportfbinv. 
 Qed.
 
 (* The “pre-pre-category” version, without homsets *)
@@ -845,11 +845,11 @@ Proof.
   - use total2_paths.
     apply (iso_inv_after_iso fi).
     etrans. apply maponpaths. apply (inv_mor_after_iso_disp ii). 
-    apply Utilities.transportfbinv.
+    apply transportfbinv.
   - use total2_paths.
     apply (iso_after_iso_inv fi).
     etrans. apply maponpaths. apply (iso_disp_after_inv_mor ii).
-    apply Utilities.transportfbinv.
+    apply transportfbinv.
 Qed.
 
 Definition is_iso_base_from_total {xx yy : total_precat} {ff : xx --> yy} (i : is_iso ff)
@@ -939,7 +939,7 @@ Proof.
   use total2_paths; cbn.
   - apply iso_inv_after_iso.
   - etrans. apply maponpaths, inv_mor_after_iso_disp. 
-    apply Utilities.transportfbinv.
+    apply transportfbinv.
 Qed.
 
 Definition total_iso_equiv_map {xx yy : total_precat}
@@ -1142,11 +1142,11 @@ Proof.
   - intros x. use total2_paths; simpl.
     apply functor_id.
     eapply pathscomp0. apply maponpaths, (section_disp_id FF).
-    cbn. apply Utilities.transportfbinv.
+    cbn. apply transportfbinv.
   - intros x y z f g. use total2_paths; simpl.
     apply functor_comp.
     eapply pathscomp0. apply maponpaths, (section_disp_comp FF).
-    cbn. apply Utilities.transportfbinv.
+    cbn. apply transportfbinv.
 Qed.
 
 Definition lifted_functor {C C' : Precategory} {D : disp_precat C}
@@ -1540,11 +1540,11 @@ Proof.
   - intros xx; use total2_paths.
       apply functor_id.
     etrans. apply maponpaths, functor_over_id.
-    apply Utilities.transportfbinv.
+    apply transportfbinv.
   - intros xx yy zz ff gg; use total2_paths; simpl.
       apply functor_comp.
     etrans. apply maponpaths, functor_over_comp.
-    apply Utilities.transportfbinv.
+    apply transportfbinv.
 Qed.
 
 Definition total_functor {C' C} {F}

--- a/TypeTheory/Displayed_Cats/Equivalences.v
+++ b/TypeTheory/Displayed_Cats/Equivalences.v
@@ -2,7 +2,7 @@
 “Displayed equivalences” of displayed (pre)categories
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.equivalences.
 Require Import UniMath.CategoryTheory.UnicodeNotations.

--- a/TypeTheory/Displayed_Cats/Examples.v
+++ b/TypeTheory/Displayed_Cats/Examples.v
@@ -9,7 +9,7 @@ A typical use for displayed categories is for constructing categories of structu
 
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 

--- a/TypeTheory/Displayed_Cats/Fibrations.v
+++ b/TypeTheory/Displayed_Cats/Fibrations.v
@@ -1,6 +1,6 @@
 (** Definitions of various kinds of _fibraitions_, using displayed categories. *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
@@ -267,7 +267,7 @@ Proof.
     refine (@functtransportf_2 (D c') _ _ (fun x => pr1) _ _ _ _). 
   cbn. etrans. apply transportf_precompose_disp.
   rewrite idtoiso_isotoid_disp.
-  refine (pathscomp0 (maponpaths _ _) (Utilities.transportfbinv _ _ _)). 
+  refine (pathscomp0 (maponpaths _ _) (transportfbinv _ _ _)). 
   apply (precomp_with_iso_disp_is_inj (cartesian_lifts_iso fd fd')).
   etrans. apply assoc_disp.
   etrans. eapply transportf_bind, cancel_postcomposition_disp.

--- a/TypeTheory/Displayed_Cats/SIP.v
+++ b/TypeTheory/Displayed_Cats/SIP.v
@@ -5,7 +5,7 @@ A short proof of the SIP (HoTT book, chapter 9.8)
 
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 

--- a/TypeTheory/OtherDefs/CwF_1.v
+++ b/TypeTheory/OtherDefs/CwF_1.v
@@ -17,7 +17,7 @@ Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.category_hset.
 Require Import UniMath.CategoryTheory.opp_precat.
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.Auxiliary.UnicodeNotations.

--- a/TypeTheory/OtherDefs/CwF_Dybjer.v
+++ b/TypeTheory/OtherDefs/CwF_Dybjer.v
@@ -9,7 +9,7 @@
 
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.opp_precat.

--- a/TypeTheory/OtherDefs/CwF_Pitts.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts.v
@@ -13,7 +13,7 @@
   http://www.cl.cam.ac.uk/~amp12/papers/nompcs/nompcs.pdf (page=9)
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import TypeTheory.Auxiliary.Auxiliary.

--- a/TypeTheory/OtherDefs/CwF_Pitts_completion.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_completion.v
@@ -6,7 +6,7 @@
     - not much yet
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.functor_categories.
 Require Import UniMath.CategoryTheory.category_hset.

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_DM.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_DM.v
@@ -11,7 +11,7 @@
 *)
 
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.limits.pullbacks.

--- a/TypeTheory/OtherDefs/DM.v
+++ b/TypeTheory/OtherDefs/DM.v
@@ -11,8 +11,8 @@
 
 *)
 
-Require Import UniMath.Foundations.Basics.UnivalenceAxiom.
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.UnivalenceAxiom.
+Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.limits.pullbacks.

--- a/TypeTheory/OtherDefs/TypeCat.v
+++ b/TypeTheory/OtherDefs/TypeCat.v
@@ -10,7 +10,7 @@ Contents:
 
 *)
 
-Require Import UniMath.Foundations.Basics.Sets.
+Require Import UniMath.Foundations.Sets.
 Require Import UniMath.CategoryTheory.precategories.
 Require Import UniMath.CategoryTheory.UnicodeNotations.
 Require Import UniMath.CategoryTheory.limits.pullbacks.


### PR DESCRIPTION
Foundations in UniMath was split into several packages. This PR adapts TypeTheory to that change.