### PR TITLE
Adapt to latest UniMath, which now has eta for pairs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - WPATH=$PWD
   - cd ..        
   - git clone https://github.com/UniMath/UniMath
-  - cd UniMath && git show && make PACKAGES="Foundations Combinatorics Algebra NumberSystems CategoryTheory Ktheory" install
+  - cd UniMath && git show && make PACKAGES="Foundations MoreFoundations Combinatorics Algebra NumberSystems CategoryTheory Ktheory" install
   - export PATH=$PATH:$PWD/sub/coq/bin/
   - cd $WPATH
 script:

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
@@ -428,7 +428,7 @@ Proof.
   (* Part 2: naturality of the transfer along [F]. *)
 
   etrans. apply @pathsinv0, assoc.
-  etrans. apply maponpaths. apply maponpaths. eapply pathsinv0. apply FZ.
+  etrans. apply maponpaths. apply maponpaths. eapply pathsinv0. use FZ.
   etrans. apply assoc.
   (* Part 3: naturality in [Γ] of the term-to-section construction from [Tm Y]. *)
   apply (Q_pp_Pb_unique Y).
@@ -507,7 +507,7 @@ Proof.
     simpl; unfold yoneda_morphisms_data; cbn.  apply maponpaths.
     etrans. apply @pathsinv0, assoc.
     etrans. apply maponpaths.
-      apply @pathsinv0.  apply maponpaths. apply FZ.
+      apply @pathsinv0.  apply maponpaths. use FZ.
     assert (XRT := @map_from_term_recover _ _ _ _ W).
     rewrite assoc.
     apply XRT.
@@ -620,7 +620,7 @@ Lemma postwhisker_iso_to_TM_eq
 : transportf (λ P' : preShv C, P --> P') (iso_to_TM_eq _ _ FG) α
   = α ;; term_fun_mor_TM (pr1 FG).
 Proof.
-  apply postwhisker_isotoid.
+  use postwhisker_isotoid.
 Qed.
 
 Definition iso_to_id_term_fun_precategory
@@ -630,7 +630,7 @@ Proof.
   intros i.
   apply subtypeEquality. { intro. apply isaprop_term_fun_structure_axioms. }
   apply total2_paths_f with (iso_to_TM_eq _ _ i).
-  etrans. refine (transportf_dirprod _ _ _ _ _ _).
+  rewrite transportf_dirprod.
   apply dirprodeq; simpl.
   - etrans. apply prewhisker_iso_to_TM_eq.
     apply term_fun_mor_pp. 
@@ -725,7 +725,7 @@ Proof.
   intro H. 
   apply qq_structure_eq.
   intros Γ Γ' f A.
-  apply (pr1 H).
+  use (pr1 H).
 Defined.  
   
 Lemma has_homsets_qq_structure_precategory

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
@@ -252,7 +252,7 @@ Proof.
     etrans. apply cancel_postcomposition. Focus 2.
       apply @pathsinv0. 
       etrans. Focus 2. apply assoc. 
-      apply maponpaths, FZ.
+      apply maponpaths. use FZ.
     etrans. Focus 2. apply @pathsinv0, assoc.
     etrans. Focus 2. apply cancel_postcomposition.
       apply @pathsinv0, Δ_φ.
@@ -349,7 +349,7 @@ Proof.
     etrans. apply @pathsinv0, assoc.
     etrans. apply maponpaths.
       etrans. apply assoc.
-      apply @pathsinv0, FZ.
+      apply @pathsinv0. use FZ.
     etrans. apply assoc.
     apply cancel_postcomposition.
   apply (map_from_term_recover W).

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
@@ -197,7 +197,7 @@ Proof.
   + etrans. apply transportf_isotoid.
     etrans. apply maponpaths_2. 
       apply inv_from_iso_from_is_z_iso.
-    apply obj_ext_mor_ax.
+    use obj_ext_mor_ax.
 Defined.
 
 (* TODO: inline *)
@@ -333,7 +333,7 @@ Proof.
   intros i.
   apply subtypeEquality. { intro. apply isaprop_term_fun_structure_axioms. }
   apply total2_paths_f with (iso_disp_to_TM_eq _ _ _ i).
-  etrans. refine (transportf_dirprod _ _ _ _ _ _).
+  rewrite transportf_dirprod.
   apply dirprodeq; simpl.
   - etrans. apply prewhisker_iso_disp_to_TM_eq.
     etrans. apply term_fun_mor_pp.

--- a/TypeTheory/Auxiliary/Auxiliary.v
+++ b/TypeTheory/Auxiliary/Auxiliary.v
@@ -292,8 +292,12 @@ Qed.
 Definition mor_total (C : precategory) : UU
   := ∑ (ab : C × C), C⟦pr2 ab, pr1 ab⟧.
 
-Definition morphism_as_total {C : precategory} {a b : C} (f : a --> b)
-  := ((_,,_),,f) : mor_total C.
+Definition morphism_as_total {C : precategory} {a b : C} (f : a --> b) : mor_total C.
+Proof.
+  exists (b,,a).
+  exact f.
+Defined.
+
 
 Definition source {C} (X : mor_total C) : C := pr2 (pr1 X).
 Definition target {C} (X : mor_total C) : C := pr1 (pr1 X).
@@ -303,8 +307,11 @@ Definition morphism_from_total {C} (X : mor_total C)
 Coercion morphism_from_total : mor_total >-> precategory_morphisms.
 
 Definition functor_on_mor_total {C D : precategory} (F : functor C D) 
-           (p : mor_total C) : mor_total D := (_ ,, _ ) ,, #F p.
-
+           (p : mor_total C) : mor_total D.
+Proof.
+  exists (F (pr1 (pr1 p)) ,, F (pr2 (pr1 p)) ).
+  exact (#F p).
+Defined.
 
 
 Definition isweq_left_adj_equivalence_on_mor_total {C D : precategory} (F : functor C D) 

--- a/TypeTheory/Categories/category_FAM.v
+++ b/TypeTheory/Categories/category_FAM.v
@@ -309,9 +309,9 @@ Proof.
   set (H' := pr2 H (finv b)). simpl in H'.
   set (x  := isopair _ H': iso (A ₂ (finv b)) (B ₂ (pr1 f (finv b)))).
   set (xinv := inv_from_iso x).
-  set (xinvtr := transportf (λ b', B ₂ b' --> A ₂ (finv b))
-         (homotweqinvweq _ _ ) xinv : B ₂ b --> A ₂ (finv b)).
-  exact xinvtr.
+  cbn in *.
+  use (transportf (λ b', B ₂ b' --> A ₂ (finv b)) (homotweqinvweq (weqpair _ (pr1 H)) _ )).
+  apply xinv.
 Defined.
 
 

--- a/TypeTheory/Displayed_Cats/Core.v
+++ b/TypeTheory/Displayed_Cats/Core.v
@@ -445,15 +445,15 @@ Proof.
     apply XR. apply i.
   - cbn.
     split.
-    + abstract (
+    + abstract ( 
       etrans ;[ apply mor_disp_transportf_postwhisker |];
-      etrans ;[ apply maponpaths; apply inv_mor_after_iso_disp |];
+      etrans ; [ apply maponpaths; apply (inv_mor_after_iso_disp i)  | ];
       etrans ;[ apply transport_f_f |];
       apply transportf_comp_lemma; apply transportf_comp_lemma_hset;
       try apply homset_property; apply idpath ).
     + abstract (
       etrans ;[ apply mor_disp_transportf_prewhisker |];
-      etrans ;[ apply maponpaths; apply iso_disp_after_inv_mor |];
+      etrans ;[ apply maponpaths; apply (iso_disp_after_inv_mor i) |];
       etrans ;[ apply transport_f_f |];
       apply transportf_comp_lemma; apply transportf_comp_lemma_hset;
       try apply homset_property; apply idpath ).
@@ -708,7 +708,7 @@ Proof.
     etrans; [ apply maponpaths_2, iso_after_iso_inv | apply id_left ].
   - apply pathsinv0.
     etrans. eapply transportf_bind.
-      eapply cancel_postcomposition_disp, iso_disp_after_inv_mor.
+      eapply cancel_postcomposition_disp, (iso_disp_after_inv_mor ii).
     rewrite id_left_disp.
     etrans. apply transport_f_f.
     refine (@maponpaths_2 _ _ _ _ _ (idpath _) _ _).
@@ -717,7 +717,7 @@ Proof.
     rewrite e.
     etrans. eapply transportf_bind, assoc_disp.
     etrans. eapply transportf_bind.
-      eapply cancel_postcomposition_disp, iso_disp_after_inv_mor.
+      eapply cancel_postcomposition_disp, (iso_disp_after_inv_mor ii).
     rewrite id_left_disp.
     etrans. apply transport_f_f.
     refine (@maponpaths_2 _ _ _ _ _ (idpath _) _ _).


### PR DESCRIPTION
Few changes necessary. Most importantly, `apply` sometimes does not work any more, in which case `use` does the job.

