### PR TITLE
Switch everything to te-based definition of CwF’s

### DIFF
--- a/TypeTheory/ALV1/.package/files
+++ b/TypeTheory/ALV1/.package/files
@@ -1,6 +1,5 @@
 CwF_def.v
 RepMaps.v
-CwF_RelUnivYoneda.v
 CwF_SplitTypeCat_Equivalence.v
 CwF_SplitTypeCat_Maps.v
 CwF_SplitTypeCat_Cats_Standalone.v

--- a/TypeTheory/ALV1/CwF_RelUnivYoneda.v
+++ b/TypeTheory/ALV1/CwF_RelUnivYoneda.v
@@ -7,9 +7,9 @@
 (**
 Contents:
 
-- Main result: an equivalence [weq_RelUnivYo_CwF]
-  between CwF-structures on a precategory [C]
-  and relative universes for [ Yo : C -> preShv C ].
+- Main result: an equivalence [weq_cwf_cwf']
+  between the canonical definition of CwF-structures on a precategory [C] 
+  and the regrouped definition based on object-extension structures.
 *)
 
 Require Import UniMath.Foundations.Sets.
@@ -17,7 +17,7 @@ Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.Auxiliary.UnicodeNotations.
-Require Import TypeTheory.ALV1.RelativeUniverses.
+Require Import TypeTheory.ALV1.CwF_def.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
 
 Set Automatic Introduction.
@@ -26,36 +26,27 @@ Section Fix_Category.
 
 Variable C : Precategory.
 
-(** a [RelUnivYo] on [C] is a [relative_universe] on [Yo : C -> preShv C], i.e.
-    - a morphism of presheaves [pp : Tm -> Ty]
-    - relative comprehension on pp, i.e. for any [X : C] and [f : Yo X -> Ty],
-       - an object [ f^*X : C ]
-       - a dependent projection [ f^*X -> X in C ]
-       - a morphism of presheaves  [ yo f^*X -> Tm ]
-       - such that the square commutes and is a pullback.
-*)
-
-Definition RelUnivYo : UU
-  := @relative_universe C _ Yo.
-
-(** a [cwf_structure] on [C] is
-    - a triple (Ty, (◂ + π)) (the object-extension structure)
-    - a triple (Tm, pp, Q) where
-      - Tm is a presheaf,
-      - pp is a morphism of presheaves Tm -> Ty
-      - Q is a family, for any Γ : C and A : Ty(Γ),
-          Q(A) : yo(Γ◂A) -> Tm
-    - such that squares commute and are pbs
+(** 
+  A [cwf'_structure] on [C] is
+  - a triple (Ty, (◂ + π)) (the object-extension structure)
+  - a triple (Tm, pp, Q) where
+    - Tm is a presheaf,
+    - pp is a morphism of presheaves Tm -> Ty
+    - te is a term, for any Γ : C and A : Ty(Γ),
+        te A : Tm (Γ◂A)
+  - such (te A) has the desired type, and square are pbs
 
   Parentheses are
-   ( (Ty, ◂, π), ( (Tm,(pp,Q)), props) )
+    ( (Ty, (◂ + π)), ( (Tm,(pp,Q)), props) )
 
-*)
+  Meanwhile, as [cwf_structure] on [C] consists of a morphism of presheaves together with a _representation_, which we will inspect in more detail below.
+
+**) 
 
 (** ** Outline of the equivalence:
 
-  We start by reordering the components of [cwf_structure],
-  so that like [RelUnivYo], the morphism of presheaves comes first:
+  We start by reordering the components of [cwf'_structure],
+  so that like [cwf_structure], the morphism of presheaves comes first:
    ( (Ty, Tm, pp), ( ((◂ + π) , Q), props ) )
 
    - the type of triples (Ty,Tm,pp) is just [mor_total (preShv C)];

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
@@ -576,7 +576,7 @@ Lemma prewhisker_iso_to_TM_eq
   (FG : iso Y Y')
   {P : preShv C} (α : TM (Y : term_fun_structure _ X) --> P)
 : transportf (λ P' : preShv C, P' --> P) (iso_to_TM_eq  _ _ FG) α
-  = term_fun_mor_TM (*pr1 (pr2 FG)*) (inv_from_iso FG) ;; α.
+  = term_fun_mor_TM (inv_from_iso FG) ;; α.
 Proof.
   etrans. apply transportf_isotoid.
   apply maponpaths_2.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
@@ -241,7 +241,6 @@ Proof.
   exact (toforallpaths _ _ _ (functor_id (TY X) _) A).
 Qed.
 
-(* TODO: unify with [bar] in […_Equivalence]? *)
 Lemma term_to_section {Y : term_fun_structure} {Γ:C} (t : Tm Y Γ) 
   (A := (pp Y : nat_trans _ _) _ t)
   : ∑ (f : Γ --> Γ ◂ A), (f ;; π _ = identity Γ).
@@ -251,7 +250,7 @@ Proof.
   exact (pr1 (pr2 sectionplus)).
 Defined.
 
-(* TODO: again, unify with lemmas following [bar] in […_Equivalence]? *)
+(* TODO: unify with lemmas following [bar] in […_Equivalence]? *)
 Lemma term_to_section_recover {Y : term_fun_structure}
   {Γ:C} (t : Tm Y Γ) (A := (pp Y : nat_trans _ _) _ t)
   : (Q Y A : nat_trans _ _) _ (pr1 (term_to_section t)) = t.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
@@ -398,38 +398,39 @@ Arguments qq_morphism_structure [_] _ .
 
 (** * CwF’s, split type-categories *)
 
-(** Details and documentation of these definitions are given with [term_fun_structure] and [qq_morphism_structure] above. *)
+(** Here, we assemble the components above (object-extension structures, term-structures, and _q_-morphism structures) into versions of the definitions of CwF’s and split type-categories.  These are reassociated compared to the canonical definitions; equivalences with those should be provided elsewhere in the library. *)
+(* TODO: give those equivalences here, once they exist. *)
 
-Definition cwf_structure (C : Precategory) : UU 
+Definition cwf'_structure (C : Precategory) : UU 
 := ∑ X : obj_ext_structure C, term_fun_structure C X.
 
-Coercion obj_ext_structure_of_cwf_structure {C : Precategory}
-:= pr1 : cwf_structure C -> obj_ext_structure C.
+Coercion obj_ext_structure_of_cwf'_structure {C : Precategory}
+:= pr1 : cwf'_structure C -> obj_ext_structure C.
 
-Coercion term_fun_structure_of_cwf_structure {C : Precategory}
-:= pr2 : forall XY : cwf_structure C, term_fun_structure C XY.
+Coercion term_fun_structure_of_cwf'_structure {C : Precategory}
+:= pr2 : forall XY : cwf'_structure C, term_fun_structure C XY.
 
-Definition cwf : UU
-:= ∑ C : Precategory, cwf_structure C.
+Definition cwf' : UU
+:= ∑ C : Precategory, cwf'_structure C.
 
-Coercion precategory_of_cwf := pr1 : cwf -> Precategory.
+Coercion precategory_of_cwf' := pr1 : cwf' -> Precategory.
 
-Coercion cwf_structure_of_cwf := pr2 : forall C : cwf, cwf_structure C.
+Coercion cwf'_structure_of_cwf' := pr2 : forall C : cwf', cwf'_structure C.
 
-Definition split_typecat_structure (C : Precategory) : UU 
+Definition split_typecat'_structure (C : Precategory) : UU 
 := ∑ X : obj_ext_structure C, qq_morphism_structure X.
 
-Coercion obj_ext_structure_of_split_typecat_structure {C : Precategory}
-:= pr1 : split_typecat_structure C -> obj_ext_structure C.
+Coercion obj_ext_structure_of_split_typecat'_structure {C : Precategory}
+:= pr1 : split_typecat'_structure C -> obj_ext_structure C.
 
-Coercion qq_morphism_structure_of_split_typecat_structure {C : Precategory}
-:= pr2 : forall XY : split_typecat_structure C, qq_morphism_structure XY.
+Coercion qq_morphism_structure_of_split_typecat'_structure {C : Precategory}
+:= pr2 : forall XY : split_typecat'_structure C, qq_morphism_structure XY.
 
-Definition split_typecat : UU
-  := ∑ C : Precategory, split_typecat_structure C.
+Definition split_typecat' : UU
+  := ∑ C : Precategory, split_typecat'_structure C.
 
-Coercion precategory_of_split_typecat
-:= pr1 : split_typecat -> Precategory.
+Coercion precategory_of_split_typecat'
+:= pr1 : split_typecat' -> Precategory.
 
-Coercion split_typecat_structure_of_split_typecat
-:= pr2 : forall C : split_typecat, split_typecat_structure C.
+Coercion split_typecat'_structure_of_split_typecat'
+:= pr2 : forall C : split_typecat', split_typecat'_structure C.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
@@ -18,7 +18,7 @@ To facilitate comparing them afterwards, we split up their definitions in a slig
 - _split type-cat structures_, [split_typecat_structure], the full structure of a split type-category on [C].
 - _split type-categories_, [split_typecat].
 
-NB: for now, we follow the literature in saying e.g. _category_ with families and split type-_category_, but these definitions do not include saturation, so are really _precategories_ with families, etc.
+NB: we follow the convention that _category_ does not include an assumption of saturation/univalence, i.e. means what is sometimes called _precategory_.
 *)
 
 
@@ -125,7 +125,7 @@ Context {C : Precategory} {X : obj_ext_structure C}.
 
 (** * Families structures 
 
-We now define the extra structure, over an object-extension structure, which constitutes a _category with families_ in the sense of Fiore, _Algebraic Type Theory_, 2008 #(<a href="http://www.cl.cam.ac.uk/~mpf23/Notes/att.pdf">link</a>)#, a reformulation of Dybjer’s original definition, replacing the functor [C --> FAM] with an arrow in [preShv C].
+We now define the extra structure, over an object-extension structure, which constitutes a _category with families_ in the sense of Fiore a reformulation of Dybjer’s original definition, replacing the functor [C --> FAM] with an arrow in [preShv C].
 
 We call this _term structure_, or a _functional_ term structure [term_fun] when necessary to disambiguate from Dybjer-style _familial_ term structures.
 
@@ -136,17 +136,30 @@ Components of [Y : term_fun_structure X]:
 - [Q Y A :  Yo (Γ ◂ A) --> TM Y]
 - [Q_pp Y A : #Yo (π A) ;; yy A = Q Y A ;; pp Y]
 - [isPullback_Q_pp Y A : isPullback _ _ _ _ (Q_pp Y A)]
+
+ See: Marcelo Fiore, slides 32–34 of _Discrete Generalised Polynomial Functors,_ from talk at ICALP 2012,
+  #(<a href="http://www.cl.cam.ac.uk/~mpf23/talks/ICALP2012.pdf">link</a>)#
+  and comments in file [CwF_def].
+
 *)
 
+Local Notation "A [ f ]" := (# (TY X : functor _ _ ) f A) (at level 4).
+
 Definition term_fun_structure_data : UU
-  := ∑ Tm : preShv C, 
-        (Tm --> TY X)
-        × (∏ (Γ : C) (A : Ty X Γ), Yo (Γ ◂ A) --> Tm).
+  := ∑ TM : preShv C, 
+        (TM --> TY X)
+        × (∏ (Γ : C) (A : Ty X Γ), (TM : functor _ _) (Γ ◂ A) : hSet).
 
 Definition TM (Y : term_fun_structure_data) : preShv C := pr1 Y.
-Definition pp Y : TM Y --> TY X := pr1 (pr2 Y).
-Definition Q Y {Γ} A : _ --> TM Y := pr2 (pr2 Y) Γ A.
 Local Notation "'Tm'" := (fun Y Γ => (TM Y : functor _ _) Γ : hSet) (at level 10).
+
+Definition pp Y : TM Y --> TY X := pr1 (pr2 Y).
+
+Definition te Y {Γ:C} A : Tm Y (Γ ◂ A)
+  := pr2 (pr2 Y) Γ A.
+
+Definition Q Y {Γ:C} (A:Ty X Γ) : Yo (Γ ◂ A) --> TM Y
+  := yy (te Y A).
 
 Lemma comp_ext_compare_Q Y Γ (A A' : Ty X Γ) (e : A = A') : 
   #Yo (comp_ext_compare e) ;; Q Y A' = Q Y A . 
@@ -156,16 +169,29 @@ Proof.
   apply id_left.
 Qed.
 
+(* Cf. [cwf_square_comm] and [_foo]. TODO: try to unify? *)
+Lemma term_fun_str_square_comm {Y : term_fun_structure_data}
+    {Γ : C} {A : Ty X Γ}
+    (e : (pp Y : nat_trans _ _) _ (te Y A) = A [ π A ])
+  : #Yo (π A) ;; yy A = Q Y A ;; pp Y.
+Proof.
+  apply pathsinv0.
+  etrans. Focus 2. apply yy_natural.
+  etrans. apply yy_comp_nat_trans.
+  apply maponpaths, e.
+Qed.
+
 Definition term_fun_structure_axioms (Y : term_fun_structure_data) :=
   ∏ Γ (A : Ty X Γ), 
-        ∑ (e : #Yo (π A) ;; yy A = Q Y A ;; pp Y), isPullback _ _ _ _ e.
+        ∑ (e : (pp Y : nat_trans _ _) _ (te Y A) = A [ π A ]),
+          isPullback _ _ _ _ (term_fun_str_square_comm e).
 
 Lemma isaprop_term_fun_structure_axioms Y
   : isaprop (term_fun_structure_axioms Y).
 Proof.
   do 2 (apply impred; intro).
   apply isofhleveltotal2.
-  - apply homset_property.
+  - apply setproperty.
   - intro. apply isaprop_isPullback.
 Qed.
 
@@ -173,15 +199,22 @@ Definition term_fun_structure : UU :=
   ∑ Y : term_fun_structure_data, term_fun_structure_axioms Y.
 Coercion term_fun_data_from_term_fun (Y : term_fun_structure) : _ := pr1 Y.
 
+
+Definition pp_te (Y : term_fun_structure) {Γ} (A : Ty X Γ)
+  : (pp Y : nat_trans _ _) _ (te Y A)
+    = A [ π A ]
+:= pr1 (pr2 Y _ A).
+
 Definition Q_pp (Y : term_fun_structure) {Γ} (A : Ty X Γ) 
   : #Yo (π A) ;; yy A = Q Y A ;; pp Y
-:= pr1 (pr2 Y _ _ ).
+:= term_fun_str_square_comm (pp_te Y A).
 
 (* TODO: rename this to [Q_pp_Pb], or [qq_π_Pb] to [isPullback_qq_π]? *)
 Definition isPullback_Q_pp (Y : term_fun_structure) {Γ} (A : Ty X Γ)
   : isPullback _ _ _ _ (Q_pp Y A)
 := pr2 (pr2 Y _ _ ).
 
+(* TODO: look if there are places these can be used to simplify things? *) 
 Definition Q_pp_Pb_pointwise (Y : term_fun_structure) (Γ' Γ : C) (A : Ty X Γ)
   := isPullback_preShv_to_pointwise (homset_property _) (isPullback_Q_pp Y A) Γ'.
 

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
@@ -12,7 +12,6 @@ Require Import TypeTheory.Auxiliary.UnicodeNotations.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Maps.
 
-(* TODO: much cleanup needed.  In particular: update terminolog conen, e.g. [qq_] etc.! *)
 Local Set Automatic Introduction.
 (* only needed since imports globally unset it *)
 
@@ -34,21 +33,9 @@ Section compatible_structures.
 
 Section canonical_TM.
 
-(* TODO: there is a lot of redundancy between the lemmas of this section and [term_to_section] and companions. *)
-
 Variable Z : qq_morphism_structure X.
 Notation ZZ := (pr2 Z).
 Variable Y : compatible_term_structure Z.
-
-(*
-Definition canonical_TM_to_given_data
-  : ∏ (Γ:C^op), (tm_from_qq Z Γ) --> (Tm Y Γ).
-Proof.
-  intros Γ Ase.
-  refine (# (TM _ : functor _ _) _ (te _ (pr1 Ase))). 
-  exact (pr1 (pr2 Ase)).
-Defined.
-*)
 
 Definition canonical_TM_to_given_data
   {Γ} (Ase : tm_from_qq Z Γ : hSet) : (Tm Y Γ).
@@ -114,6 +101,7 @@ Lemma canonical_TM_to_given_paths_adjoint {Γ:C} Ase t
 Proof.
   destruct Ase as [A [s e]].
   intros H.
+  (* This [assert] is to enable the [destruct eA] below. *)
   assert (eA : (pp Y : nat_trans _ _) _ t = A). {
     etrans. apply maponpaths, (!H).
     refine (toforallpaths _ _ _ 
@@ -124,17 +112,15 @@ Proof.
   exact (!eA).
   cbn. destruct eA; cbn. unfold idfun.
   apply subtypeEquality. { intros x; apply homset_property. }
-  cbn. refine (@maponpaths _ _ pr1 (_,,_) (_,,_) _).
-  apply proofirrelevance, isapropifcontr.
-  refine (term_to_section_aux t).
-  Unshelve.
+  set (temp := proofirrelevance _ (isapropifcontr (term_to_section_aux t))).
+  refine (maponpaths pr1 (temp (_,,_) (_,,_))).
   - cbn; split.
     + exact e.
     + exact H.
   - split.
     + apply (pr2 (pr2 (given_TM_to_canonical _ t))).
     + apply term_to_section_recover.
-Time Qed.
+Qed.
 
 Lemma canonical_to_given_to_canonical Γ
   : (canonical_TM_to_given : nat_trans _ _ )  Γ ;; given_TM_to_canonical Γ = identity _ .

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
@@ -157,6 +157,7 @@ Proof.
            canonical_TM_to_given_pointwise_iso).
   apply homset_property.
 Qed.
+(* TODO: perhaps reorganisae the above a little?  Under the current definitions, [iso_inv_from_iso canonical_TM_to_given_iso] is *not* definitionally equal to [given_TM_to_canonical], which is a little annoying downstream (lemmas about [given_TM_to_canonical] can’t be applied). *)  
 
 Definition given_TM_to_canonical
   : (TM Y) --> (tm_from_qq Z)
@@ -171,6 +172,24 @@ Proof.
 Qed.
 
 (* TODO: re-state [given_to_canonical_to_given] and [canonical_to_given_to_canonical] as composites of natural transformations? *)
+
+Lemma canonical_TM_to_given_te {Γ:C} A
+  : (canonical_TM_to_given : nat_trans _ _) (Γ ◂ A) (te_from_qq Z A) = te Y A.
+Proof.
+  cbn. unfold canonical_TM_to_given_data. cbn.
+  etrans. apply maponpaths, (pr2 Y).
+  etrans. refine (toforallpaths _ _ _ (!functor_comp (TM Y) _ _ ) _).
+  etrans. apply maponpaths_2; cbn.
+    apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). 
+  apply (toforallpaths _ _ _ (functor_id (TM Y) _) _).
+Qed.
+
+Lemma given_TM_to_canonical_te {Γ:C} A
+  : (given_TM_to_canonical : nat_trans _ _) (Γ ◂ A) (te Y A) = (te_from_qq Z A).
+Proof.
+  etrans. Focus 2. exact (toforallpaths _ _ _ (canonical_to_given_to_canonical _) _).
+  cbn. apply maponpaths, @pathsinv0, canonical_TM_to_given_te.
+Qed.
 
 End canonical_TM.
 
@@ -222,6 +241,7 @@ Proof.
       unfold i.
       rewrite idtoiso_inv.
       rewrite idtoiso_isotoid.
+      unfold canonical_TM_to_given_iso. 
       apply nat_trans_eq. 
       * apply has_homsets_HSET.
       * intro Γ. apply idpath.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
@@ -121,9 +121,6 @@ Proof.
   - cbn; split.
     + exact e.
     + exact H.
-  - split.
-    + apply (pr2 (pr2 (given_TM_to_canonical_data _ t))).
-    + apply term_to_section_recover.
 Qed.
 
 Lemma canonical_to_given_to_canonical Γ

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
@@ -64,20 +64,21 @@ Proof.
   apply is_nat_trans_canonical_TM_to_given.
 Defined.
 
-Definition given_TM_to_canonical
+(* Naturality of this direction is a bit subtle; we will deduce it below from the fact that it is pointwise inverse to [canonical_TM_to_given]. *)
+Definition given_TM_to_canonical_data
   : ∏ Γ, HSET ⟦ Tm (pr1 Y) Γ, tm_from_qq Z Γ⟧.
 Proof.
   intros Γ t.
   exists ((pp (pr1 Y) : nat_trans _ _ )  _ t).
   apply term_to_section.
-Defined.
+Defined. 
 
 Lemma given_to_canonical_to_given Γ
-  : given_TM_to_canonical Γ ;; (canonical_TM_to_given : nat_trans _ _) Γ
+  : given_TM_to_canonical_data Γ ;; (canonical_TM_to_given : nat_trans _ _) Γ
   = identity _ .
 Proof.
   apply funextsec; intro t.
-  cbn. unfold canonical_TM_to_given_data, given_TM_to_canonical.
+  cbn. unfold canonical_TM_to_given_data, given_TM_to_canonical_data.
   apply term_to_section_recover.
 Qed.
 
@@ -95,9 +96,12 @@ Proof.
   apply (toforallpaths _ _ _ (functor_id (TY X) _ ) _).
 Qed.
 
+(* Functions between sets [f : X <--> Y : g] are inverse iff they are _adjoint_, in that [ f x = y <-> x = f y ] for all x, y.
+
+Here we give one direction of that “adjunction”; combined with [given_to_canonical_to_given] above, it implies full inverseness. *) 
 Lemma canonical_TM_to_given_paths_adjoint {Γ:C} Ase t
   : (canonical_TM_to_given : nat_trans _ _) Γ Ase = t
-  -> Ase = given_TM_to_canonical Γ t.
+  -> Ase = given_TM_to_canonical_data Γ t.
 Proof.
   destruct Ase as [A [s e]].
   intros H.
@@ -118,12 +122,14 @@ Proof.
     + exact e.
     + exact H.
   - split.
-    + apply (pr2 (pr2 (given_TM_to_canonical _ t))).
+    + apply (pr2 (pr2 (given_TM_to_canonical_data _ t))).
     + apply term_to_section_recover.
 Qed.
 
 Lemma canonical_to_given_to_canonical Γ
-  : (canonical_TM_to_given : nat_trans _ _ )  Γ ;; given_TM_to_canonical Γ = identity _ .
+  : (canonical_TM_to_given : nat_trans _ _ )  Γ
+    ;; given_TM_to_canonical_data Γ
+  = identity _ .
 Proof.
   apply funextsec; intro t.
   apply pathsinv0, canonical_TM_to_given_paths_adjoint, idpath.
@@ -132,7 +138,7 @@ Qed.
 Lemma canonical_TM_to_given_pointwise_iso Γ
   : is_iso ((canonical_TM_to_given : nat_trans _ _) Γ).
 Proof.
-  apply (is_iso_qinv _ (given_TM_to_canonical Γ) ).
+  apply (is_iso_qinv _ (given_TM_to_canonical_data Γ) ).
   split.
   - apply canonical_to_given_to_canonical.
   - apply given_to_canonical_to_given.
@@ -145,6 +151,29 @@ Proof.
   apply functor_iso_if_pointwise_iso.
   apply canonical_TM_to_given_pointwise_iso.
 Defined.
+
+Definition given_TM_to_canonical_naturality
+  : is_nat_trans (TM Y : functor _ _) (tm_from_qq Z) 
+      (@given_TM_to_canonical_data).
+Proof.
+  refine (is_nat_trans_inv_from_pointwise_inv_ext _
+           canonical_TM_to_given_pointwise_iso).
+  apply homset_property.
+Qed.
+
+Definition given_TM_to_canonical
+  : (TM Y) --> (tm_from_qq Z)
+:= (_ ,, given_TM_to_canonical_naturality).
+
+Lemma pp_given_TM_to_canonical
+  : given_TM_to_canonical ;; pp_from_qq Z
+    = pp Y.
+Proof.
+  apply nat_trans_eq. apply homset_property.
+  intros Γ; apply idpath.
+Qed.
+
+(* TODO: re-state [given_to_canonical_to_given] and [canonical_to_given_to_canonical] as composites of natural transformations? *)
 
 End canonical_TM.
 

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
@@ -51,7 +51,7 @@ Proof.
   intros Γ Γ' f.
   apply funextsec; intros [A [s e]].
   unfold canonical_TM_to_given_data; cbn.
-  etrans. apply maponpaths, iscompatible_iscompatible', (pr2 Y).
+  etrans. apply maponpaths, (pr2 Y).
   etrans. apply (toforallpaths _ _ _ (!functor_comp (TM Y) _ _ ) _).
   etrans. Focus 2. apply (toforallpaths _ _ _ (functor_comp (TM Y) _ _ ) _).
   apply maponpaths_2. 
@@ -148,7 +148,7 @@ Defined.
 
 End canonical_TM.
 
-(* TODO: upstream? *)
+(* TODO: upstream this and the following lemma? *)
 Lemma transportf_pshf
     {P P' : preShv C} (e : P = P')
     {c : C} (x : (P : functor _ _) c : hSet)
@@ -171,7 +171,6 @@ Proof.
   apply maponpaths, maponpaths, idtoiso_isotoid.
 Qed.
 
-(* TODO: make name more unique *)
 Lemma compatible_term_structure_equals_canonical
   {Z : qq_morphism_structure X} (Y : compatible_term_structure Z)
   : Y = compatible_term_from_qq Z.
@@ -181,8 +180,7 @@ Proof.
                    (category_is_category _)
                    (canonical_TM_to_given_iso Z Y)).
   apply subtypeEquality.
-  { intro. do 4 (apply impred; intro).
-    apply homset_property. }
+  { intro. apply isaprop_iscompatible_term_qq. } 
   destruct Y as [Y YH]. simpl.
   apply subtypeEquality.
   { intro. apply isaprop_term_fun_structure_axioms. }
@@ -207,8 +205,7 @@ Proof.
       apply funextsec; intro A.
       etrans. apply transportf_isotoid_pshf.
       cbn. unfold canonical_TM_to_given_data. cbn.
-      etrans. apply maponpaths.
-        apply (pr1 (iscompatible_iscompatible' _ Z) YH).
+      etrans. apply maponpaths, YH.
       etrans. refine (toforallpaths _ _ _ (!functor_comp tm _ _ ) _).
       etrans. apply maponpaths_2; cbn.
         apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). 
@@ -225,52 +222,49 @@ Proof.
   apply compatible_term_structure_equals_canonical.
 Defined.
 
-Lemma compat_split_comp_eq (Y : term_fun_structure _ X) :
-  ∏ t : compatible_qq_morphism_structure Y,
-  t = compatible_qq_from_term Y.
+Lemma compatible_qq_morphism_structure_equals_canonical
+    {Y : term_fun_structure _ X} (t : compatible_qq_morphism_structure Y)
+  : t = compatible_qq_from_term Y.
 Proof.
-  intro t.
-    apply subtypeEquality.
-    { intro.
-      do 4 (apply impred; intro).
-      apply homset_property. }
-    simpl; apply subtypeEquality.
-    { intro. apply @isaprop_qq_morphism_axioms. }
-    apply subtypeEquality.
-    { intro.
-      do 4 (apply impred; intro).
-      apply isofhleveltotal2. 
-      - apply homset_property.
-      - intro. apply isaprop_isPullback. } 
-    simpl.
-    destruct t as [[t H1] H2]. simpl.
-    destruct t as [q h]; simpl.
-    apply funextsec. intro Γ.
-    apply funextsec; intro Γ'.
-    apply funextsec; intro f.
-    apply funextsec; intro A.    
-    apply (invmaponpathsweq (weqpair _ (yoneda_fully_faithful _ (homset_property _) _ _ ))).
+  apply subtypeEquality.
+  { intro. apply isaprop_iscompatible_term_qq. }
+  simpl; apply subtypeEquality.
+  { intro. apply @isaprop_qq_morphism_axioms. }
+  apply subtypeEquality.
+  { intro.
+    do 4 (apply impred; intro).
+    apply isofhleveltotal2. 
+    - apply homset_property.
+    - intro. apply isaprop_isPullback. } 
+  simpl.
+  destruct t as [[t H1] H2]. simpl.
+  destruct t as [q h]; simpl.
+  apply funextsec. intro Γ.
+  apply funextsec; intro Γ'.
+  apply funextsec; intro f.
+  apply funextsec; intro A.    
+  apply (invmaponpathsweq (weqpair _ (yoneda_fully_faithful _ (homset_property _) _ _ ))).
+  apply pathsinv0.
+  etrans. apply Yo_qq_term_Yo_of_qq.
+  unfold Yo_of_qq.
+  apply pathsinv0.
+  apply PullbackArrowUnique.
+  + etrans. apply maponpaths. cbn. apply idpath.
+    rewrite <- functor_comp.
+    etrans. eapply pathsinv0. refine (functor_comp Yo _ _).
+    apply maponpaths.
+    apply pathsinv0. apply (pr1 (h _ _ _ _ )).
+  + etrans. apply maponpaths. cbn. apply idpath.
     apply pathsinv0.
-    etrans. apply Yo_qq_term_Yo_of_qq.
-    unfold Yo_of_qq.
-    apply pathsinv0.
-    apply PullbackArrowUnique.
-    + etrans. apply maponpaths. cbn. apply idpath.
-      rewrite <- functor_comp.
-      etrans. eapply pathsinv0. refine (functor_comp Yo _ _).
-      apply maponpaths.
-      apply pathsinv0. apply (pr1 (h _ _ _ _ )).
-    + etrans. apply maponpaths. cbn. apply idpath.
-      apply pathsinv0.
-      apply H2.
+    apply (pr1 (iscompatible_iscompatible' _ _) H2).
 Time Qed.
-  
+
 
 Lemma iscontr_compatible_split_comp_structure (Y : term_fun_structure C X)
 : iscontr (compatible_qq_morphism_structure Y).
 Proof.
   exists (compatible_qq_from_term Y).
-  apply compat_split_comp_eq.
+  apply compatible_qq_morphism_structure_equals_canonical.
 Defined.
 
 End compatible_structures.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
@@ -241,6 +241,23 @@ Definition tm_from_qq : functor _ _
 
 Arguments tm_from_qq : simpl never.
 
+(* TODO: search for uses of [tm_from_qq_eq] to see where this can be used (should save a good few lines of code). *)
+Lemma tm_from_qq_eq_reindex
+    {Γ Γ' : C} (f : Γ' --> Γ)
+    (Ase : tm_from_qq Γ : hSet) (Ase' : tm_from_qq Γ' : hSet)
+    (eA : pr1 Ase' = # (TY X : functor _ _) f (pr1 Ase))
+    (es : pr1 (pr2 Ase') ;; Δ eA ;; qq Z f _ = f ;; pr1 (pr2 Ase))
+  : Ase' = # tm_from_qq f Ase.
+Proof.
+  use tm_from_qq_eq.
+  - exact eA.
+  - cbn. apply PullbackArrowUnique; cbn.
+    + etrans. apply @pathsinv0, assoc. 
+      etrans. apply maponpaths, comp_ext_compare_π.
+      apply (pr2 (pr2 Ase')).
+    + apply es.
+Qed.
+
 Lemma pr2_tm_from_qq_paths
     {Γ : C} {t t' : tm_from_qq Γ : hSet} (e : t = t')
   : pr1 (pr2 t) = pr1 (pr2 t') ;; (Δ (maponpaths pr1 (!e))) .

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
@@ -33,9 +33,11 @@ We define _compatibility_ between a term-structure and a _q_-morphism structure,
 
 Section Compatible_Structures.
 
-Definition iscompatible_term_qq (Y : term_fun_structure C X)
-         (Z : qq_morphism_structure X) : UU
-  := ∏ Γ Γ' A (f : C⟦Γ', Γ⟧),
+Definition iscompatible_term_qq
+    (Y : term_fun_structure C X)
+    (Z : qq_morphism_structure X)
+  : UU
+:= ∏ Γ Γ' A (f : C⟦Γ', Γ⟧),
      te Y A[f] = # (TM _ : functor _ _) (qq Z f A) (te Y A).
 
 Lemma isaprop_iscompatible_term_qq
@@ -47,33 +49,49 @@ Proof.
   apply setproperty.
 Qed.
 
-Definition compatible_term_structure (Z : qq_morphism_structure X) : UU
-  := ∑ Y : term_fun_structure _ X, iscompatible_term_qq Y Z.
+Definition compatible_term_structure (Z : qq_morphism_structure X)
+  : UU
+:= ∑ Y : term_fun_structure _ X, iscompatible_term_qq Y Z.
 
 Coercion term_structure_of_compatible {Z : qq_morphism_structure X}
   : compatible_term_structure Z -> term_fun_structure _ X
 := pr1.
 
-Definition compatible_qq_morphism_structure (Y : term_fun_structure _ X) : UU
-  := ∑ Z : qq_morphism_structure X, iscompatible_term_qq Y Z.
+Definition compatible_qq_morphism_structure (Y : term_fun_structure _ X)
+  : UU
+:= ∑ Z : qq_morphism_structure X, iscompatible_term_qq Y Z.
 
 Coercion qq_morphism_structure_of_compatible {Y : term_fun_structure _ X}
   : compatible_qq_morphism_structure Y -> qq_morphism_structure X
 := pr1.
 
-(* TODO: consider switching this to main definition. *)
 Definition iscompatible'_term_qq
     (Y : term_fun_structure C X)
-    (Z : qq_morphism_structure X) : UU
-  := ∏ Γ Γ' A (f : C⟦Γ', Γ⟧) , Q Y A[f] = #Yo (qq Z f A) ;; Q Y A.
+    (Z : qq_morphism_structure X)
+  : UU
+:= ∏ Γ Γ' A (f : C⟦Γ', Γ⟧) , Q Y A[f] = #Yo (qq Z f A) ;; Q Y A.
 
+(* TODO: try to eliminate older [iscompatible'] entirely, and remove both it and this lemma.  *)
 Definition iscompatible_iscompatible'
     (Y : term_fun_structure C X)
     (Z : qq_morphism_structure X)
   : iscompatible_term_qq Y Z
   <-> iscompatible'_term_qq Y Z.
-Admitted.
-(* TODO: either fix this admit, or drop older [iscompatible] entirely. *)
+Proof.
+  unfold iscompatible_term_qq, iscompatible'_term_qq.
+  split; intros H Γ Γ' A f; specialize (H Γ Γ' A f).
+  - apply nat_trans_eq. { apply homset_property. }
+    intros Γ''. cbn. unfold yoneda_objects_ob, yoneda_morphisms_data.
+    apply funextsec; intros g.
+    etrans. apply maponpaths, H.
+    refine (toforallpaths _ _ _ (!functor_comp (TM Y) _ _) _).
+  - assert (H' := nat_trans_eq_pointwise H); clear H.
+    assert (H'' := toforallpaths _ _ _ (H' _) (identity _)); clear H'.
+    cbn in H''; unfold yoneda_morphisms_data in H''.
+    refine (_ @ H'' @ _).
+    + refine (toforallpaths _ _ _ (!functor_id (TM Y) _) _).
+    + apply maponpaths_2, id_left.
+Qed.
 
 End Compatible_Structures.
 

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
@@ -58,7 +58,7 @@ Definition iscompatible'_term_qq
     (Z : qq_morphism_structure X) : UU
   := ∏ Γ Γ' A (f : C⟦Γ', Γ⟧),
     (Q Y A[f] : nat_trans _ _) _ (identity _)
-  = (#Yo (qq Z f A) ;; Q Y A : nat_trans _ _) _ (identity _).
+  = (Q Y A : nat_trans _ _) _ (qq Z f A).
 
 Definition iscompatible_iscompatible'
     (Y : term_fun_structure C X)
@@ -420,41 +420,148 @@ Proof.
     apply isPullback_Q_pp_from_qq.
 Defined.
 
-Lemma term_from_qq_pointwise_compatible
+Lemma term_from_qq_compatible_te
     {Γ Γ' : C} (A : Ty X Γ) (f : Γ'--> Γ)
-    {Γ'' : C} (g : Γ''--> Γ' ◂ A[f])
-  : (Q_from_qq A[f] : nat_trans _ _) Γ'' g
-  = (Q_from_qq A : nat_trans _ _) Γ'' (g ;; qq Z f A).
+  : (Q_from_qq A[f] : nat_trans _ _) _ (identity _)
+  = (Q_from_qq A : nat_trans _ _) _ (qq Z f A).
 Proof.
-  use tm_from_qq_eq.
-  + unfold yoneda_morphisms_data; simpl.
+  etrans.
+    apply (toforallpaths _ _ _ (functor_id tm_from_qq _)).
+  cbn.  
+  use tm_from_qq_eq; cbn.
+  - unfold Q_from_qq; simpl.
     etrans. apply (toforallpaths _ _ _ (!functor_comp (TY X) _ _ ) A).
-    eapply (maponpaths (fun k => A[k])).
-      etrans. apply @pathsinv0, (@assoc C).
-      etrans. apply maponpaths, qq_π.
-      apply (@assoc C).
-  + simpl.
-    apply PullbackArrowUnique.
-    * etrans. apply @pathsinv0, assoc.
+    etrans. Focus 2. apply (toforallpaths _ _ _ (functor_comp (TY X) _ _ ) A).
+    apply maponpaths_2; cbn.
+    apply qq_π.
+  - apply PullbackArrowUnique.
+    + cbn.
+      etrans. apply @pathsinv0, assoc.
       etrans. apply maponpaths, comp_ext_compare_π.
       apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)). 
-    * etrans. apply @pathsinv0, assoc.
-      etrans. apply maponpaths.
-        rewrite @comp_ext_compare_comp.
-        etrans. apply @pathsinv0, assoc. 
-        etrans. apply maponpaths, comp_ext_compare_qq.
-        etrans. apply maponpaths, qq_comp.
+    + apply (map_into_Pb_unique _ (qq_π_Pb Z _ _)). 
+      * cbn.
+        etrans. apply @pathsinv0, assoc.
+        etrans. apply maponpaths. apply @pathsinv0, qq_π.
         etrans. apply assoc.
-        apply cancel_postcomposition.
+        etrans. apply maponpaths_2.
+          etrans. apply @pathsinv0, assoc.
+          etrans. apply maponpaths, comp_ext_compare_π.
+          apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)).
+        etrans. apply id_left.
+        apply pathsinv0.
+        etrans. apply @pathsinv0, assoc.
+        etrans. apply maponpaths.
+          apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)).
+        apply id_right.
+      * cbn.
+        etrans. apply @pathsinv0, assoc.
+        etrans. apply @pathsinv0, assoc.
+        etrans. apply maponpaths.
+          etrans. apply maponpaths_2.
+            etrans. apply comp_ext_compare_comp.
+            etrans. apply maponpaths, comp_ext_compare_comp.
+            apply assoc.
+          etrans. apply @pathsinv0, assoc.
+          etrans. apply maponpaths.
+            etrans. apply assoc.
+            apply @pathsinv0. apply qq_comp_general.
+          etrans. apply @pathsinv0, assoc.
+          etrans. apply maponpaths, comp_ext_compare_qq.
+          etrans. apply maponpaths, qq_comp.
+          apply assoc.
         etrans. apply assoc.
-        etrans. Focus 2. apply id_left.
-        apply cancel_postcomposition.
-        etrans. apply @pathsinv0, comp_ext_compare_comp.
-        apply comp_ext_compare_id_general.
-      etrans. apply assoc.
-      apply cancel_postcomposition.
-      apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). 
+        etrans. apply maponpaths_2.
+          etrans. apply maponpaths.
+            etrans. apply assoc. 
+            etrans. apply maponpaths_2.
+              etrans. apply @pathsinv0, comp_ext_compare_comp.
+              apply comp_ext_compare_id_general.
+            apply id_left.
+          apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)).
+        etrans. apply id_left.
+        apply pathsinv0.
+        etrans. apply @pathsinv0, assoc.
+        etrans. apply maponpaths.
+          apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)).
+        apply id_right.
 Time Qed.
+
+Lemma term_from_qq_compatible_pointwise
+    {Γ Γ' : C} (A : Ty X Γ) (f : Γ'--> Γ)
+    {Γ''} (g : Γ'' --> _)
+  : (Q_from_qq A[f] : nat_trans _ _) _ g
+  = (Q_from_qq A : nat_trans _ _) _ (g ;; qq Z f A).
+Proof.
+  cbn.
+  use tm_from_qq_eq; cbn.
+  - unfold Q_from_qq; simpl.
+    etrans. apply maponpaths, (toforallpaths _ _ _ (!functor_comp (TY X) _ _ ) _).
+    etrans. apply (toforallpaths _ _ _ (!functor_comp (TY X) _ _ ) _).
+    etrans. Focus 2. apply (toforallpaths _ _ _ (functor_comp (TY X) _ _ ) A).
+    apply maponpaths_2; cbn.
+    etrans. apply maponpaths, qq_π.
+    apply assoc.
+  - apply PullbackArrowUnique.
+    + cbn.
+      etrans. apply @pathsinv0, assoc.
+      etrans. apply maponpaths, comp_ext_compare_π.
+      apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)). 
+    + apply (map_into_Pb_unique _ (qq_π_Pb Z _ _)). 
+      * cbn.
+        etrans. apply @pathsinv0, assoc.
+        etrans. apply maponpaths. apply @pathsinv0, qq_π.
+        etrans. apply assoc.
+        etrans. apply maponpaths_2.
+          etrans. apply @pathsinv0, assoc.
+          etrans. apply maponpaths, comp_ext_compare_π.
+          apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)).
+        etrans. apply id_left.
+        apply pathsinv0.
+        etrans. apply @pathsinv0, assoc.
+        etrans. apply maponpaths.
+          apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)).
+        apply id_right.
+      * cbn.
+        etrans. apply @pathsinv0, assoc.
+        etrans. apply @pathsinv0, assoc.
+        etrans. apply maponpaths.
+          etrans. apply maponpaths_2.
+            etrans. apply comp_ext_compare_comp.
+            etrans. apply maponpaths, comp_ext_compare_comp.
+            apply assoc.
+          etrans. apply @pathsinv0, assoc.
+          etrans. apply maponpaths.
+            etrans. apply assoc.
+            apply @pathsinv0. apply qq_comp_general.
+          etrans. apply @pathsinv0, assoc.
+          etrans. apply maponpaths, comp_ext_compare_qq.
+          etrans. apply maponpaths, qq_comp.
+          apply assoc.
+        etrans. apply assoc.
+        etrans. apply maponpaths_2.
+          etrans. apply maponpaths.
+            etrans. apply assoc. 
+            etrans. apply maponpaths_2.
+              etrans. apply @pathsinv0, comp_ext_compare_comp.
+              apply comp_ext_compare_id_general.
+            apply id_left.
+          apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)).
+        etrans. apply id_left.
+        apply pathsinv0.
+        etrans. apply @pathsinv0, assoc.
+        etrans. apply maponpaths.
+          apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)).
+        apply id_right.
+Time Qed.
+
+Defined.
+
+
+Definition iscompatible_term_qq (Y : term_fun_structure C X)
+         (Z : qq_morphism_structure X) : UU
+  := ∏ Γ Γ' A (f : C⟦Γ', Γ⟧) , Q Y A[f] = #Yo (qq Z f A) ;; Q Y A.
+
 
 Definition iscompatible_term_from_qq
   : iscompatible_term_qq term_from_qq Z.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
@@ -35,7 +35,8 @@ Section Compatible_Structures.
 
 Definition iscompatible_term_qq (Y : term_fun_structure C X)
          (Z : qq_morphism_structure X) : UU
-  := ∏ Γ Γ' A (f : C⟦Γ', Γ⟧) , Q Y A[f] = #Yo (qq Z f A) ;; Q Y A.
+  := ∏ Γ Γ' A (f : C⟦Γ', Γ⟧),
+     te Y A[f] = # (TM _ : functor _ _) (qq Z f A) (te Y A).
 
 Lemma isaprop_iscompatible_term_qq
   (Y : term_fun_structure C X)
@@ -43,7 +44,7 @@ Lemma isaprop_iscompatible_term_qq
   : isaprop (iscompatible_term_qq Y Z).
 Proof.
   do 4 (apply impred; intro).
-  apply homset_property.
+  apply setproperty.
 Qed.
 
 Definition compatible_term_structure (Z : qq_morphism_structure X) : UU
@@ -64,8 +65,7 @@ Coercion qq_morphism_structure_of_compatible {Y : term_fun_structure _ X}
 Definition iscompatible'_term_qq
     (Y : term_fun_structure C X)
     (Z : qq_morphism_structure X) : UU
-  := ∏ Γ Γ' A (f : C⟦Γ', Γ⟧),
-     te Y A[f] = # (TM _ : functor _ _) (qq Z f A) (te Y A).
+  := ∏ Γ Γ' A (f : C⟦Γ', Γ⟧) , Q Y A[f] = #Yo (qq Z f A) ;; Q Y A.
 
 Definition iscompatible_iscompatible'
     (Y : term_fun_structure C X)
@@ -88,7 +88,9 @@ Lemma map_from_term_recover
   : pr1 (term_to_section ((Q Y A : nat_trans _ _) Γ' f)) ;; Δ e ;; qq Z (f ;; π A) A
   = f.
 Proof.
-  unfold iscompatible_term_qq in W.
+  assert (W' : iscompatible'_term_qq Y Z).
+    apply iscompatible_iscompatible'; assumption.
+  unfold iscompatible'_term_qq in W'.
   apply (Q_pp_Pb_unique Y).
   - unfold yoneda_morphisms_data; cbn.
     etrans. apply @pathsinv0, assoc.
@@ -100,7 +102,7 @@ Proof.
     etrans. apply assoc.
     etrans. Focus 2. apply id_left. apply cancel_postcomposition.
     exact (pr2 (term_to_section _)).
-  - etrans. refine (!toforallpaths _ _ _ (nat_trans_eq_pointwise (W _ _ _ _) _) _).
+  - etrans. refine (!toforallpaths _ _ _ (nat_trans_eq_pointwise (W' _ _ _ _) _) _).
     etrans. apply Q_comp_ext_compare.
     apply term_to_section_recover.
 Time Qed.
@@ -441,8 +443,8 @@ Proof.
   apply isPullback_Q_pp_from_qq.
 Defined.
 
-Definition iscompatible'_term_from_qq
-  : iscompatible'_term_qq term_from_qq Z.
+Definition iscompatible_term_from_qq
+  : iscompatible_term_qq term_from_qq Z.
 Proof.
   intros ? ? ? ?.
   use tm_from_qq_eq; simpl.
@@ -503,13 +505,6 @@ Proof.
         apply id_right.
 Time Qed.
 
-Definition iscompatible_term_from_qq
-  : iscompatible_term_qq term_from_qq Z.
-Proof.
-  apply (pr2 (iscompatible_iscompatible' _ _)).
-  apply iscompatible'_term_from_qq.
-Qed.
-
 Definition compatible_term_from_qq : compatible_term_structure Z
   := (term_from_qq,, iscompatible_term_from_qq).
     
@@ -540,6 +535,8 @@ Let Xk := mk_Pullback _ _ _ _ _ _ (isPullback_Q_pp Y A).
 (** ** Groundwork in presheaves
 
 We first construct maps of presheaves that will be the image of the _q_-morphisms under the Yoneda embedding. *)
+
+(* TODO: see if it simplifies things to construct the q-morphisms more directly. *)
 
 Definition Yo_of_qq : _ ⟦Yo (Γ' ◂ A[f]), Yo (Γ ◂ A) ⟧.
 Proof.
@@ -683,13 +680,19 @@ Proof.
   apply is_split_qq_from_term.
 Defined.
 
-Lemma iscompatible_qq_from_term : iscompatible_term_qq Y qq_from_term.
+Lemma iscompatible'_qq_from_term : iscompatible'_term_qq Y qq_from_term.
 Proof.
   intros Γ Γ' A f.
   assert (XR:= Yo_of_qq_commutes_2).
   apply pathsinv0.
   rewrite Yo_qq_term_Yo_of_qq.
   apply XR.
+Qed.
+
+Lemma iscompatible_qq_from_term : iscompatible_term_qq Y qq_from_term.
+Proof.
+  apply (pr2 (iscompatible_iscompatible' _ _)).
+  apply iscompatible'_qq_from_term.
 Qed.
 
 Definition compatible_qq_from_term : compatible_qq_morphism_structure Y

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
@@ -65,7 +65,7 @@ Definition iscompatible_iscompatible'
     (Z : qq_morphism_structure X)
   : iscompatible_term_qq Y Z
   <-> iscompatible'_term_qq Y Z.
-Admitted.
+Admitted. (* TODO: don’t bother to fix this admit; wait till changing to te-based definition of cwf. *)
 
 End Compatible_Structures.
 
@@ -487,88 +487,18 @@ Proof.
         apply id_right.
 Time Qed.
 
-Lemma term_from_qq_compatible_pointwise
-    {Γ Γ' : C} (A : Ty X Γ) (f : Γ'--> Γ)
-    {Γ''} (g : Γ'' --> _)
-  : (Q_from_qq A[f] : nat_trans _ _) _ g
-  = (Q_from_qq A : nat_trans _ _) _ (g ;; qq Z f A).
+
+Definition iscompatible'_term_from_qq
+  : iscompatible'_term_qq term_from_qq Z.
 Proof.
-  cbn.
-  use tm_from_qq_eq; cbn.
-  - unfold Q_from_qq; simpl.
-    etrans. apply maponpaths, (toforallpaths _ _ _ (!functor_comp (TY X) _ _ ) _).
-    etrans. apply (toforallpaths _ _ _ (!functor_comp (TY X) _ _ ) _).
-    etrans. Focus 2. apply (toforallpaths _ _ _ (functor_comp (TY X) _ _ ) A).
-    apply maponpaths_2; cbn.
-    etrans. apply maponpaths, qq_π.
-    apply assoc.
-  - apply PullbackArrowUnique.
-    + cbn.
-      etrans. apply @pathsinv0, assoc.
-      etrans. apply maponpaths, comp_ext_compare_π.
-      apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)). 
-    + apply (map_into_Pb_unique _ (qq_π_Pb Z _ _)). 
-      * cbn.
-        etrans. apply @pathsinv0, assoc.
-        etrans. apply maponpaths. apply @pathsinv0, qq_π.
-        etrans. apply assoc.
-        etrans. apply maponpaths_2.
-          etrans. apply @pathsinv0, assoc.
-          etrans. apply maponpaths, comp_ext_compare_π.
-          apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)).
-        etrans. apply id_left.
-        apply pathsinv0.
-        etrans. apply @pathsinv0, assoc.
-        etrans. apply maponpaths.
-          apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)).
-        apply id_right.
-      * cbn.
-        etrans. apply @pathsinv0, assoc.
-        etrans. apply @pathsinv0, assoc.
-        etrans. apply maponpaths.
-          etrans. apply maponpaths_2.
-            etrans. apply comp_ext_compare_comp.
-            etrans. apply maponpaths, comp_ext_compare_comp.
-            apply assoc.
-          etrans. apply @pathsinv0, assoc.
-          etrans. apply maponpaths.
-            etrans. apply assoc.
-            apply @pathsinv0. apply qq_comp_general.
-          etrans. apply @pathsinv0, assoc.
-          etrans. apply maponpaths, comp_ext_compare_qq.
-          etrans. apply maponpaths, qq_comp.
-          apply assoc.
-        etrans. apply assoc.
-        etrans. apply maponpaths_2.
-          etrans. apply maponpaths.
-            etrans. apply assoc. 
-            etrans. apply maponpaths_2.
-              etrans. apply @pathsinv0, comp_ext_compare_comp.
-              apply comp_ext_compare_id_general.
-            apply id_left.
-          apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)).
-        etrans. apply id_left.
-        apply pathsinv0.
-        etrans. apply @pathsinv0, assoc.
-        etrans. apply maponpaths.
-          apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)).
-        apply id_right.
-Time Qed.
-
-Defined.
-
-
-Definition iscompatible_term_qq (Y : term_fun_structure C X)
-         (Z : qq_morphism_structure X) : UU
-  := ∏ Γ Γ' A (f : C⟦Γ', Γ⟧) , Q Y A[f] = #Yo (qq Z f A) ;; Q Y A.
-
+  intros ? ? ? ?. apply term_from_qq_compatible_te.
+Qed.
 
 Definition iscompatible_term_from_qq
   : iscompatible_term_qq term_from_qq Z.
 Proof.
-  intros Γ Γ' A f; apply nat_trans_eq. 
-  - apply has_homsets_HSET.
-  - intro; apply funextsec; unfold homot; apply term_from_qq_pointwise_compatible.
+  apply (pr2 (iscompatible_iscompatible' _ _)).
+  apply iscompatible'_term_from_qq.
 Qed.
 
 Definition compatible_term_from_qq : compatible_term_structure Z
@@ -576,7 +506,6 @@ Definition compatible_term_from_qq : compatible_term_structure Z
     
 End compatible_term_structure_from_qq.
 
-Arguments Q_from_qq_data _ {_} _ _ _ : simpl never.
 Arguments Q_from_qq _ {_} _ : simpl never.
 Arguments tm_from_qq : simpl never.
 Arguments pp_from_qq : simpl never.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
@@ -520,6 +520,8 @@ Arguments Q_from_qq _ {_} _ : simpl never.
 
 Key definitions: [qq_from_term], [iscompatible_qq_from_term] *)
 
+(* TODO: see if this section can be simplified to construct the q-morphisms more directly. *)
+
 Section compatible_comp_structure_from_term.
 
 Variable Y : term_fun_structure C X.
@@ -535,8 +537,6 @@ Let Xk := mk_Pullback _ _ _ _ _ _ (isPullback_Q_pp Y A).
 (** ** Groundwork in presheaves
 
 We first construct maps of presheaves that will be the image of the _q_-morphisms under the Yoneda embedding. *)
-
-(* TODO: see if it simplifies things to construct the q-morphisms more directly. *)
 
 Definition Yo_of_qq : _ ⟦Yo (Γ' ◂ A[f]), Yo (Γ ◂ A) ⟧.
 Proof.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
@@ -47,10 +47,18 @@ Proof.
 Qed.
 
 Definition compatible_term_structure (Z : qq_morphism_structure X) : UU
-  := ∑ Y : term_fun_structure C X, iscompatible_term_qq Y Z.
+  := ∑ Y : term_fun_structure _ X, iscompatible_term_qq Y Z.
 
-Definition compatible_qq_morphism_structure (Y : term_fun_structure C X) : UU
+Coercion term_structure_of_compatible {Z : qq_morphism_structure X}
+  : compatible_term_structure Z -> term_fun_structure _ X
+:= pr1.
+
+Definition compatible_qq_morphism_structure (Y : term_fun_structure _ X) : UU
   := ∑ Z : qq_morphism_structure X, iscompatible_term_qq Y Z.
+
+Coercion qq_morphism_structure_of_compatible {Y : term_fun_structure _ X}
+  : compatible_qq_morphism_structure Y -> qq_morphism_structure X
+:= pr1.
 
 (* TODO: consider switching this to main definition. *)
 Definition iscompatible'_term_qq

--- a/TypeTheory/ALV1/CwF_def.v
+++ b/TypeTheory/ALV1/CwF_def.v
@@ -7,11 +7,8 @@
 (**
 Contents:
 
-- the canonical standalone definition of a (Fiore-style) CwF as per
-  Marcelo Fiore, slides for a talk on "Discrete Generalised Polynomial Functors."  
-  In 39th International Colloquium on Automata, Languages and Programming (ICALP 2012)
-  http://www.cl.cam.ac.uk/~mpf23/talks/ICALP2012.pdf
-- equivalence between cwf structures and two related ones occurring in the ALV1 paper
+- the definition of CwFs à la Fiore: [cwf_structure]
+- equivalence between cwf structures and relative universe structures on Yoneda.
 
 *)
 
@@ -41,8 +38,16 @@ End Auxiliary.
 A (Fiore-style) CwF consists of:
 
 - a base category C;
-- a morphism Tm —p—> Ty of presheaves on C;
-- a _representation_ of p.
+- two presheaves on C, connected by a morphism Tm —p—> Ty;
+- a _representation_ of p (see below).
+
+  This is a mild reformulation of Dybjer’s original definition of CwF’s, replacing the functor [C --> FAM] with an arrow in [preShv C].
+
+  Specifically, we follow: Marcelo Fiore, slides 32–34 of _Discrete Generalised Polynomial Functors,_ from talk at ICALP 2012,
+  #(<a href="http://www.cl.cam.ac.uk/~mpf23/talks/ICALP2012.pdf">link</a>)#
+
+  See also: Marcelo Fiore, _Algebraic Type Theory_, 2008
+  #(<a href="http://www.cl.cam.ac.uk/~mpf23/Notes/att.pdf">link</a>)#
 
 *)
 
@@ -55,7 +60,7 @@ Definition Tm (pp : mor_total (preShv C)) : functor _ _ := source pp.
 
 (** ** Representations of maps of presheaves 
 
-A *representation* of a map Tm —p—> Ty of presheaves consists of data exhibiting, for each (A : Ty Γ), the fiber of p over A as represented by some object Γ.A over Γ. *)
+A *representation* of a map Tm —p—> Ty of presheaves consists of data giving, for each (A : Ty Γ), some object and map (π A) : Γ.A Γ, along with a term (te A) over A which is “universal”, in that it represents the fiber of p over A. *)
 
 Section Representation.
 
@@ -92,6 +97,7 @@ Definition cwf_fiber_representation : UU
 Definition cwf_fiber_rep_data : UU
   := ∑ (ΓA : C), C ⟦ΓA, Γ⟧ × (Tm pp ΓA : hSet).
 
+(* TODO: consolidate this with [cwf_square_comm], and make organisation/documentation clearer *)
 Section stuff.
 
 Variable ΓAπt : cwf_fiber_rep_data.
@@ -264,6 +270,11 @@ End Representation.
 
 Definition cwf_structure : UU := ∑ pp, (cwf_representation pp).
 
+(* TODO:
+
+- move the following out of this file, into CwF_RelUniv_Yoneda
+- add definition of “CwF”
+*)
 
 (** ** Equivalence with relative universe structures on Yoneda *)
 

--- a/TypeTheory/ALV1/Summary.v
+++ b/TypeTheory/ALV1/Summary.v
@@ -21,7 +21,6 @@ Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.ALV1.RelativeUniverses.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
 Require Import TypeTheory.ALV1.RelUnivYonedaCompletion.
-Require Import TypeTheory.ALV1.CwF_RelUnivYoneda.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Equivalence.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Cats_Standalone.
 Require Import TypeTheory.ALV1.CwF_def.
@@ -49,12 +48,12 @@ Type hierarchy is collapsed (logic is inconsistent)
 *)
 
 (** * Equivalence between type of CwF structures on [C] and of rel univs on [Yo C] *)
-Definition weq_RelUnivYo_cwf_structures
-     : ∏ C : Precategory, RelUnivYo C ≃ CwF_SplitTypeCat_Defs.cwf_structure C.
+Definition weq_cwf_structure_RelUnivYo
+     : ∏ C : Precategory, cwf_structure C ≃ @relative_universe C _ Yo.
 Proof.
-  exact weq_RelUnivYo_CwF.
+  exact weq_cwf_structure_RelUnivYo.
 Defined.
-(* Print Assumptions weq_RelUnivYo_cwf_structures. *)
+(* Print Assumptions weq_cwf_structure_RelUnivYo. *)
 (** 
 <<
 Axioms:

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
@@ -242,7 +242,8 @@ Proof.
       etrans. apply maponpaths, comp_ext_compare_π.
       etrans. apply @pathsinv0, assoc.
       etrans. apply maponpaths, obj_ext_mor_ax.
-      refine (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _) _ _ _ _).
+      refine (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ (qq_π_Pb _ f A))
+                                          _ _ _ _).
     * cbn in FZ; cbn.
       etrans. apply maponpaths_2, @pathsinv0, assoc.
       etrans. apply @pathsinv0, assoc.
@@ -331,7 +332,8 @@ Proof.
       etrans. apply maponpaths, comp_ext_compare_qq.
       etrans. apply maponpaths_2, @pathsinv0, assoc.
       etrans. apply @pathsinv0, assoc.
-      etrans. apply maponpaths, @pathsinv0, FZ. (* TODO: give access function [qq_structure_mor_ax]! *)
+      etrans. apply maponpaths, @pathsinv0. use FZ.
+        (* TODO: give access function [qq_structure_mor_ax]! *)
       etrans. apply assoc.
       etrans. apply maponpaths_2.
         apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)).

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
@@ -214,6 +214,10 @@ Abort.
 
 (* We start by showing that a map of _q_-morphism structures induces a map of term-structures between their canonical term-structures of sections. *)
 
+
+(* TODO: rename and move this section! *)
+Section Rename_me.
+
 (* TODO: naming conventions in this section clash rather with those of [ALV1.CwF_SplitTypeCat_Equivalence]. Consider! *)
 (* TODO: one would expect the type of this to be [nat_trans_data].  However, that name breaks HORRIBLY with general naming conventions: it is not the _type_ of the data (which is un-named for [nat_trans]), but is the _access function_ for that data!  Submit issue for this? *)  
 Lemma tm_from_qq_mor_data {X X' : obj_ext_precat} {F : X --> X'}
@@ -238,13 +242,13 @@ Proof.
   - cbn. exact (toforallpaths _ _ _
                   (nat_trans_ax (obj_ext_mor_TY _) _ _ _) _).
   - cbn. apply PullbackArrowUnique. 
-    * etrans. cbn. apply @pathsinv0, assoc.
+    + etrans. cbn. apply @pathsinv0, assoc.
       etrans. apply maponpaths, comp_ext_compare_π.
       etrans. apply @pathsinv0, assoc.
       etrans. apply maponpaths, obj_ext_mor_ax.
-      refine (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ (qq_π_Pb _ f A))
-                                          _ _ _ _).
-    * cbn in FZ; cbn.
+      refine (PullbackArrow_PullbackPr1
+                (mk_Pullback _ _ _ _ _ _ (qq_π_Pb _ f A)) _ _ _ _).
+    + cbn in FZ; cbn.
       etrans. apply maponpaths_2, @pathsinv0, assoc.
       etrans. apply @pathsinv0, assoc.
       etrans. apply maponpaths, @pathsinv0, FZ.
@@ -271,23 +275,6 @@ Proof.
   intros Γ. apply idpath.
 Qed.
 
-(* TODO: upstream to with [tm_from_qq_eq]; and search for uses of that to see where this can be used (should save a good few lines of code). *)
-Lemma tm_from_qq_eq' {X : obj_ext_structure C} (Z : qq_morphism_structure X)
-    {Γ Γ' : C} (f : Γ' --> Γ)
-    (Ase : tm_from_qq Z Γ : hSet) (Ase' : tm_from_qq Z Γ' : hSet)
-    (eA : pr1 Ase' = # (TY X : functor _ _) f (pr1 Ase))
-    (es : pr1 (pr2 Ase') ;; Δ eA ;; qq Z f _ = f ;; pr1 (pr2 Ase))
-  : Ase' = # (tm_from_qq Z : functor _ _) f Ase.
-Proof.
-  use tm_from_qq_eq.
-  - exact eA.
-  - cbn. apply PullbackArrowUnique; cbn.
-    + etrans. apply @pathsinv0, assoc. 
-      etrans. apply maponpaths, comp_ext_compare_π.
-      apply (pr2 (pr2 Ase')).
-    + apply es.
-Qed. (* TODO: why does this take so long? *)
-
 Lemma tm_from_qq_mor_te {X X' : obj_ext_precat} {F : X --> X'}
     {Z : qq_structure_disp_precat C X} {Z'} (FZ : Z -->[F] Z')
     {Γ} (A : Ty X Γ)
@@ -296,7 +283,7 @@ Lemma tm_from_qq_mor_te {X X' : obj_ext_precat} {F : X --> X'}
       (te_from_qq Z' ((obj_ext_mor_TY F : nat_trans _ _) _ A)).
 Proof.
   cbn.
-  use tm_from_qq_eq'.
+  use tm_from_qq_eq_reindex.
   - cbn.
   (* Putting these equalities under [abstract] shaves a couple of seconds off the overall Qed time, but makes the proof script rather less readable. *) 
     etrans. Focus 2. exact (toforallpaths _ _ _ (functor_comp (TY _) _ _) _).
@@ -339,6 +326,8 @@ Proof.
         apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)).
       apply id_left.
 Time Qed.
+
+End Rename_me.
 
 Definition term_from_qq_mor_TM {X X' : obj_ext_precat} {F : X --> X'}
     {Z : qq_structure_disp_precat C X} {Z'} (FZ : Z -->[F] Z')

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
@@ -351,6 +351,7 @@ Proof.
   - refine (given_TM_to_canonical _ _ (Y,,W)).
   - refine (canonical_TM_to_given _ _ (Y',,W')).
 Defined.
+(* TODO: better, construct these three parts as maps of qq-morphism structures, and put them together directly as that. *)
 
 Lemma term_from_qq_mor {X X' : obj_ext_precat} {F : X --> X'}
   {Z : qq_structure_disp_precat C X} {Z'} (FZ : Z -->[F] Z')
@@ -369,45 +370,15 @@ Proof.
     etrans. apply @pathsinv0, assoc.
     etrans. apply maponpaths, tm_from_qq_mor_pp.
     etrans. apply assoc.
-    apply maponpaths_2, (pp_given_TM_to_canonical _ _ (_,,W)).
-  - admit.
-    (* TODO: this should be a combination of [tm_from_qq_mor_te] above, and similar lemmas for [given_TM_to_canonical] and vice versa. Essentially the point is that all these three are displayed morphisms of term-structures.  Perhaps they should even be given as such, and composed as such for this lemma. *)
-
-(*
-
-  - intros Γ'. unfold yoneda_morphisms_data, yoneda_objects_ob; cbn.
-    apply funextsec; intros f.
-    etrans.
-      (* TODO: consider changing direction of [Q_comp_ext_compare]?*)
-      apply @pathsinv0. simple refine (Q_comp_ext_compare _ _); simpl.
-        exact ((obj_ext_mor_TY F : nat_trans _ _) _ 
-                 (# (TY _ : functor _ _) (f ;; π _) A)). 
-      apply maponpaths.
-      refine (!toforallpaths _ _ _ (nat_trans_eq_pointwise (Q_pp _ _) _) _).
+    apply maponpaths_2, (pp_given_TM_to_canonical _ _ (_,,_)).
+  - unfold term_from_qq_mor_TM.
     cbn.
-    Arguments Δ [_ _ _ _ _ _]. idtac.
-    etrans. apply maponpaths.
-      etrans. apply @pathsinv0, assoc.
-      etrans. apply maponpaths, @pathsinv0, Δ_φ.
-      apply assoc.
-    etrans. 
-      apply @pathsinv0. simple refine (Q_comp_ext_compare _ _); simpl.
-        exact (# (TY _ : functor _ _) (f ;; π _)
-                 ((obj_ext_mor_TY F : nat_trans _ _) _ A)).
-      exact (toforallpaths _ _ _ (nat_trans_ax (obj_ext_mor_TY F) _ _ _) _).
-    cbn.
-    etrans. exact (toforallpaths _ _ _ (nat_trans_eq_pointwise (W' _ _ _ _) _) _).
-    simpl; unfold yoneda_morphisms_data; cbn.  apply maponpaths.
-    etrans. apply @pathsinv0, assoc.
-    etrans. apply @pathsinv0, assoc.
-    etrans. apply maponpaths.
-      etrans. apply assoc.
-      apply @pathsinv0. use FZ.
-    etrans. apply assoc.
-    apply cancel_postcomposition.
-  apply (map_from_term_recover W).
-*)
-Admitted.
+    etrans. apply maponpaths, maponpaths, given_TM_to_canonical_te.
+    etrans. apply maponpaths, (tm_from_qq_mor_te FZ).
+    etrans. apply (toforallpaths _ _ _
+                     (nat_trans_ax (canonical_TM_to_given _ _ (_,,_)) _ _ _) _).
+    cbn. apply maponpaths. apply (canonical_TM_to_given_te _ _ (_,,_)).
+Defined.
 
 Lemma term_from_qq_mor_unique {X X' : obj_ext_precat} {F : X --> X'}
   {Z : qq_structure_disp_precat C X} {Z'} (FZ : Z -->[F] Z')

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
@@ -130,6 +130,17 @@ Proof.
   apply iscompatible_qq_from_term.
 Defined.
 
+(* TODO: upstream *)
+Lemma comp_ext_compare_te
+    {X : obj_ext_structure C}
+    {Y : term_fun_structure C X}
+    {Γ:C} {A A' : Ty X Γ} (e : A = A')
+  : # (TM Y : functor _ _) (Δ e) (te Y A') = te Y A.
+Proof.
+  destruct e; cbn.
+  exact (toforallpaths _ _ _ (functor_id (TM _) _) _). 
+Qed.
+
 Lemma qq_from_term_mor {X X' : obj_ext_precat} {F : X --> X'}
   {Y : term_fun_disp_precat C X} {Y'} (FY : Y -->[F] Y')
   {Z : qq_structure_disp_precat C X} {Z'}
@@ -154,23 +165,18 @@ Proof.
     etrans. apply @pathsinv0, assoc.
     etrans. apply maponpaths. apply comp_ext_compare_π.
     apply obj_ext_mor_ax.
-  (* Maybe worth abstracting the following pointwise application of [W],
-   [term_fun_mor_Q], etc. as lemmas? *)
-  - etrans.
-      exact (!toforallpaths _ _ _
-        (nat_trans_eq_pointwise (term_fun_mor_Q FY _) _) _).
-    etrans. apply maponpaths, @pathsinv0, id_left.
-    etrans. cbn. apply maponpaths.
-      exact (!toforallpaths _ _ _
-        (nat_trans_eq_pointwise (W _ _ _ _) _) _).
+  - etrans. exact (toforallpaths _ _ _ (functor_comp (TM _) _ _) _).
+    etrans. cbn. apply maponpaths, @pathsinv0, (term_fun_mor_te FY).
+    etrans. refine (toforallpaths _ _ _
+                      (!nat_trans_ax (term_fun_mor_TM _) _ _ _) _).
+    etrans. cbn. apply maponpaths, @pathsinv0, W.
+    etrans. apply term_fun_mor_te.
     apply pathsinv0.
-    etrans.
-      exact (!toforallpaths _ _ _
-        (nat_trans_eq_pointwise (W' _ _ _ _) _) _).
-    etrans. apply Q_comp_ext_compare.
-    etrans. apply maponpaths, @pathsinv0, id_left.
-    exact (!toforallpaths _ _ _
-      (nat_trans_eq_pointwise (term_fun_mor_Q FY _) _) _).
+    etrans. exact (toforallpaths _ _ _ (functor_comp (TM _) _ _) _).
+    etrans. cbn. apply maponpaths, @pathsinv0, W'.
+    etrans. exact (toforallpaths _ _ _ (functor_comp (TM _) _ _) _).
+    cbn. apply maponpaths. 
+    apply comp_ext_compare_te.
 Time Qed.
 
 Lemma qq_from_term_mor_unique {X X' : obj_ext_precat} {F : X --> X'}

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
@@ -325,6 +325,15 @@ Proof.
   apply postwhisker_isotoid.
 Qed.
 
+Lemma idtoiso_iso_disp_to_TM_eq 
+  {X} {Y Y' : term_fun_disp_precat C X}
+  (FG : iso_disp (identity_iso X) Y Y')
+: (idtoiso (iso_disp_to_TM_eq _ _ _ FG) : _ --> _)
+  = term_fun_mor_TM (FG : _ -->[_] _).
+Proof.
+  refine (maponpaths pr1 (idtoiso_isotoid _ _ _ _ _)).
+Qed.
+
 Definition iso_to_id__term_fun_disp_precat
   {X : obj_ext_Precat C}
   (Y Y' : term_fun_disp_precat C X)
@@ -334,7 +343,7 @@ Proof.
   apply subtypeEquality. { intro. apply isaprop_term_fun_structure_axioms. }
   apply total2_paths_f with (iso_disp_to_TM_eq _ _ _ i).
   rewrite transportf_dirprod.
-  apply dirprodeq; simpl.
+  apply dirprodeq.
   - etrans. apply prewhisker_iso_disp_to_TM_eq.
     etrans. apply term_fun_mor_pp.
     exact (id_right (pp _)).
@@ -342,10 +351,13 @@ Proof.
     apply funextsec; intros Γ.
     etrans. refine (transportf_forall _ _ _).
     apply funextsec; intros A.
-    etrans. refine (postwhisker_iso_disp_to_TM_eq i (Q _ _)).
-    etrans. apply term_fun_mor_Q.
-    etrans. Focus 2. exact (id_left (Q _ A)).
-    apply maponpaths_2. apply functor_id.
+    etrans. apply CwF_SplitTypeCat_Equivalence.transportf_pshf.
+    etrans.
+      refine (toforallpaths _ _ _ _ (te _ _)).
+      refine (toforallpaths _ _ _ _ _).
+      apply maponpaths, idtoiso_iso_disp_to_TM_eq.
+    etrans. apply term_fun_mor_te.
+    refine (toforallpaths _ _ _ (functor_id (TM _) _) _).
 Qed.
 
 Theorem is_category_term_fun_structure
@@ -470,7 +482,7 @@ Definition  strucs_compat_iso_disp_to_id
 Proof.
   intro H.
   do 4 (apply funextsec; intro).
-  apply homset_property.
+  apply setproperty.
 Defined.
 
 Theorem is_category_strucs_compat


### PR DESCRIPTION
Switched `term_fun_structure` to have `te` instead of `Q` as basic, so all constructions now use this version.

Major outstanding to-do: equivalence between `cwf_structure` (the canonical standalone definition, from `CwF_def.v`) and `cwf'_structure` (the definition based on object-extension structures, from `CwF_SplitTypeCat_Defs.v`).  Much of this can hopefully be cannibalised from the old `CwF_RelUnivYoneda.v`, which is now otherwise redundant and has been dropped from the build.