### PR TITLE
Renaming different kinds of displayed categories

### DIFF
--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
@@ -289,8 +289,8 @@ Definition compat_structures_precategory
 
 (* should this be the name of the compatible pairs category? *)
 (*
-Definition compat_structures_disp_precat
-  := sigma_disp_precat strucs_compat_disp_precat.
+Definition compat_structures_disp_cat
+  := sigma_disp_cat strucs_compat_disp_cat.
 *)
 
 

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Cats.v
@@ -8,8 +8,8 @@
 Main definitions:
 
 - [obj_ext_precat]
-- [term_fun_disp_precat], [term_fun_structure_precat]
-- [qq_structure_disp_precat], [qq_structure_precat]
+- [term_fun_disp_cat], [term_fun_structure_precat]
+- [qq_structure_disp_cat], [qq_structure_precat]
 *)
 
 Require Import UniMath.Foundations.Sets.
@@ -309,13 +309,13 @@ Proof.
   destruct eF. apply idpath.
 Qed.
  
-Definition term_fun_ob_mor : disp_precat_ob_mor (obj_ext_Precat C).
+Definition term_fun_ob_mor : disp_cat_ob_mor (obj_ext_Precat C).
 Proof.
   exists (fun X => term_fun_structure C X).
   exact @term_fun_mor.
 Defined.
 
-Definition term_fun_id_comp : disp_precat_id_comp _ term_fun_ob_mor.
+Definition term_fun_id_comp : disp_cat_id_comp _ term_fun_ob_mor.
 Proof.
   apply tpair.
   - intros X Y. simpl; unfold term_fun_mor.
@@ -338,10 +338,10 @@ Proof.
       refine (toforallpaths _ _ _ (!functor_comp (TM _) _ _) _).
 Defined.
 
-Definition term_fun_data : disp_precat_data (obj_ext_Precat C)
+Definition term_fun_data : disp_cat_data (obj_ext_Precat C)
   := (_ ,, term_fun_id_comp).
 
-Definition term_fun_axioms : disp_precat_axioms _ term_fun_data.
+Definition term_fun_axioms : disp_cat_axioms _ term_fun_data.
 Proof.
   repeat apply tpair.
   - intros. apply term_fun_mor_eq. intros.
@@ -360,15 +360,15 @@ Proof.
     repeat (apply impred_isaprop; intro). apply setproperty.
 Qed.
 
-Definition term_fun_disp_precat : disp_precat (obj_ext_Precat C)
+Definition term_fun_disp_cat : disp_cat (obj_ext_Precat C)
   := (_ ,, term_fun_axioms).
 
 Definition term_fun_structure_precat : precategory
-  := total_precat term_fun_disp_precat.
+  := total_precat term_fun_disp_cat.
 
 End Term_Fun_Structure_Precat.
 
-Arguments term_fun_disp_precat _ : clear implicits.
+Arguments term_fun_disp_cat _ : clear implicits.
 Arguments term_fun_structure_precat _ : clear implicits.
 
 (** * Precategory of _q_-morphism-structures *)
@@ -376,7 +376,7 @@ Section qq_Structure_Precat.
 
 Context {C : Precategory}.
 
-Definition qq_structure_ob_mor : disp_precat_ob_mor (obj_ext_Precat C).
+Definition qq_structure_ob_mor : disp_cat_ob_mor (obj_ext_Precat C).
 Proof.
   exists (fun X => qq_morphism_structure X).
   intros X X' Z Z' F.
@@ -394,7 +394,7 @@ Proof.
   repeat (apply impred_isaprop; intro). apply homset_property.
 Qed.
 
-Definition qq_structure_id_comp : disp_precat_id_comp _ qq_structure_ob_mor.
+Definition qq_structure_id_comp : disp_cat_id_comp _ qq_structure_ob_mor.
 Proof.
   apply tpair.
   - intros X Z; cbn.
@@ -426,23 +426,23 @@ Proof.
     apply pathsinv0, comp_ext_compare_comp_general.
 Qed.
 
-Definition qq_structure_data : disp_precat_data (obj_ext_Precat C)
+Definition qq_structure_data : disp_cat_data (obj_ext_Precat C)
   := (_ ,, qq_structure_id_comp).
 
-Definition qq_structure_axioms : disp_precat_axioms _ qq_structure_data.
+Definition qq_structure_axioms : disp_cat_axioms _ qq_structure_data.
 Proof.
   repeat apply tpair; intros;
     try apply isasetaprop; apply isaprop_qq_structure_mor.
 Qed.
 
-Definition qq_structure_disp_precat : disp_precat (obj_ext_Precat C)
+Definition qq_structure_disp_cat : disp_cat (obj_ext_Precat C)
   := (_ ,, qq_structure_axioms).
 
 Definition qq_structure_precat : precategory
-  := total_precat (qq_structure_disp_precat).
+  := total_precat (qq_structure_disp_cat).
 
 End qq_Structure_Precat.
 
-Arguments qq_structure_disp_precat _ : clear implicits.
+Arguments qq_structure_disp_cat _ : clear implicits.
 Arguments qq_structure_precat _ : clear implicits.
 

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
@@ -32,7 +32,7 @@ Section Auxiliary.
   is judgementally(!) equal to [functor_identity _]. *)
 Definition disp_functor_id_composite
   {C : Precategory}
-  {CC DD EE : disp_precat C}
+  {CC DD EE : disp_cat C}
   (FF : disp_functor (functor_identity _) CC DD)
   (GG : disp_functor (functor_identity _) DD EE)
 : disp_functor (functor_identity _) CC EE
@@ -55,8 +55,8 @@ Section Compatible_Disp_Cat.
 (* TODO: rename [strucs_compat_FOO] to [strucs_iscompat_FOO] throughout, to disambiguate these from the sigma’d displayed-precat [compat_structures]. *)
 
 Definition strucs_compat_ob_mor
-  : disp_precat_ob_mor (total_precat
-      (term_fun_disp_precat C × qq_structure_disp_precat C)).
+  : disp_cat_ob_mor (total_precat
+      (term_fun_disp_cat C × qq_structure_disp_cat C)).
 Proof.
   use tpair.
   - intros XYZ. exact (iscompatible_term_qq (pr1 (pr2 XYZ)) (pr2 (pr2 XYZ))).
@@ -65,42 +65,42 @@ Proof.
 Defined.
 
 Definition strucs_compat_id_comp
-  : disp_precat_id_comp _ strucs_compat_ob_mor.
+  : disp_cat_id_comp _ strucs_compat_ob_mor.
 Proof.
   split; intros; exact tt.
 Qed.
 
-Definition strucs_compat_data : disp_precat_data _
+Definition strucs_compat_data : disp_cat_data _
   := ( _ ,, strucs_compat_id_comp).
 
-Definition strucs_compat_axioms : disp_precat_axioms _ strucs_compat_data.
+Definition strucs_compat_axioms : disp_cat_axioms _ strucs_compat_data.
 Proof.
   repeat apply tpair; intros; try apply isasetaprop; apply isapropunit.
 Qed.
 
-Definition strucs_compat_disp_precat
-  : disp_precat (total_precat
-      (term_fun_disp_precat C × qq_structure_disp_precat C))
+Definition strucs_compat_disp_cat
+  : disp_cat (total_precat
+      (term_fun_disp_cat C × qq_structure_disp_cat C))
 := ( _ ,, strucs_compat_axioms).
 
-Definition compat_structures_disp_precat
-  := sigma_disp_precat strucs_compat_disp_precat.
+Definition compat_structures_disp_cat
+  := sigma_disp_cat strucs_compat_disp_cat.
 
 Definition compat_structures_pr1_disp_functor
   : disp_functor (functor_identity _)
-      compat_structures_disp_precat (term_fun_disp_precat C)
+      compat_structures_disp_cat (term_fun_disp_cat C)
 := disp_functor_id_composite
      (sigmapr1_disp_functor _) (dirprodpr1_disp_functor _ _).
 
 Definition compat_structures_pr2_disp_functor
   : disp_functor (functor_identity _)
-      compat_structures_disp_precat (qq_structure_disp_precat C)
+      compat_structures_disp_cat (qq_structure_disp_cat C)
 := disp_functor_id_composite
      (sigmapr1_disp_functor _) (dirprodpr2_disp_functor _ _).
 
 (* TODO: once the equivalence has been redone at the displayed level, the following are probably redundant/obsolete and should be removed. *)
 Definition compat_structures_precat
-  := total_precat (strucs_compat_disp_precat).
+  := total_precat (strucs_compat_disp_cat).
 
 Definition compat_structures_pr1_functor
   : functor compat_structures_precat (term_fun_structure_precat C)
@@ -118,14 +118,14 @@ End Compatible_Disp_Cat.
 
 (** * Lemmas towards an equivalence *)
 
-(** In the following two sections, we prove lemmas which should amount to the fact that the two projections from [compat_structures_disp_precat C] to [term_fun_disp_precat C] and [qq_structure_precat C] are each equivalences (of displayed categories).
+(** In the following two sections, we prove lemmas which should amount to the fact that the two projections from [compat_structures_disp_cat C] to [term_fun_disp_cat C] and [qq_structure_precat C] are each equivalences (of displayed categories).
 
 We don’t yet have the infrastructure on displayed categories to put it together as that fact; for now we put it together just as equivalences of _total_ precategories. *)
  
 Section Unique_QQ_From_Term.
 
-Lemma qq_from_term_ob {X : obj_ext_precat} (Y : term_fun_disp_precat C X)
-  : ∑ (Z : qq_structure_disp_precat C X), strucs_compat_disp_precat (X ,, (Y ,, Z)).
+Lemma qq_from_term_ob {X : obj_ext_precat} (Y : term_fun_disp_cat C X)
+  : ∑ (Z : qq_structure_disp_cat C X), strucs_compat_disp_cat (X ,, (Y ,, Z)).
 Proof.
   exists (qq_from_term Y).
   apply iscompatible_qq_from_term.
@@ -143,10 +143,10 @@ Proof.
 Qed.
 
 Lemma qq_from_term_mor {X X' : obj_ext_precat} {F : X --> X'}
-  {Y : term_fun_disp_precat C X} {Y'} (FY : Y -->[F] Y')
-  {Z : qq_structure_disp_precat C X} {Z'}
-  (W : strucs_compat_disp_precat (X,,(Y,,Z)))
-  (W' : strucs_compat_disp_precat (X',,(Y',,Z')))
+  {Y : term_fun_disp_cat C X} {Y'} (FY : Y -->[F] Y')
+  {Z : qq_structure_disp_cat C X} {Z'}
+  (W : strucs_compat_disp_cat (X,,(Y,,Z)))
+  (W' : strucs_compat_disp_cat (X',,(Y',,Z')))
   : ∑ (FZ : Z -->[F] Z'), W -->[(F,,(FY,,FZ))] W'.
 Proof.
   refine (_,, tt).
@@ -180,10 +180,10 @@ Proof.
 Time Qed.
 
 Lemma qq_from_term_mor_unique {X X' : obj_ext_precat} {F : X --> X'}
-  {Y : term_fun_disp_precat C X} {Y'} (FY : Y -->[F] Y')
-  {Z : qq_structure_disp_precat C X} {Z'}
-  (W : strucs_compat_disp_precat (X,,(Y,,Z)))
-  (W' : strucs_compat_disp_precat (X',,(Y',,Z')))
+  {Y : term_fun_disp_cat C X} {Y'} (FY : Y -->[F] Y')
+  {Z : qq_structure_disp_cat C X} {Z'}
+  (W : strucs_compat_disp_cat (X,,(Y,,Z)))
+  (W' : strucs_compat_disp_cat (X',,(Y',,Z')))
   : isaprop (∑ (FZ : Z -->[F] Z'), W -->[(F,,(FY,,FZ))] W').
 Proof.
   apply isofhleveltotal2.
@@ -195,8 +195,8 @@ End Unique_QQ_From_Term.
 
 Section Unique_Term_From_QQ.
 
-Lemma term_from_qq_ob {X : obj_ext_precat} (Z : qq_structure_disp_precat C X)
-  : ∑ (Y : term_fun_disp_precat C X), strucs_compat_disp_precat (X ,, (Y ,, Z)).
+Lemma term_from_qq_ob {X : obj_ext_precat} (Z : qq_structure_disp_cat C X)
+  : ∑ (Y : term_fun_disp_cat C X), strucs_compat_disp_cat (X ,, (Y ,, Z)).
 Proof.
   exists (term_from_qq Z).
   apply iscompatible_term_from_qq.
@@ -204,10 +204,10 @@ Defined.
 
 (** The next main goal is the following statement.  However, the construction of the morphism of term structures is rather large; so we factor the first component (the map of term presheaves) into several steps, going explicitly via the canonical term-structure constructed from sections [term_fun_from_qq], before returning to this in [term_from_qq_mor] below. *)
 Lemma term_from_qq_mor {X X' : obj_ext_precat} {F : X --> X'}
-  {Z : qq_structure_disp_precat C X} {Z'} (FZ : Z -->[F] Z')
-  {Y : term_fun_disp_precat C X} {Y'}
-  (W : strucs_compat_disp_precat (X,,(Y,,Z)))
-  (W' : strucs_compat_disp_precat (X',,(Y',,Z')))
+  {Z : qq_structure_disp_cat C X} {Z'} (FZ : Z -->[F] Z')
+  {Y : term_fun_disp_cat C X} {Y'}
+  (W : strucs_compat_disp_cat (X,,(Y,,Z)))
+  (W' : strucs_compat_disp_cat (X',,(Y',,Z')))
   : ∑ (FY : Y -->[F] Y'), W -->[(F,,(FY,,FZ))] W'.
 Abort.
 
@@ -220,7 +220,7 @@ Section Rename_me.
 (* TODO: naming conventions in this section clash rather with those of [ALV1.CwF_SplitTypeCat_Equivalence]. Consider! *)
 (* TODO: one would expect the type of this to be [nat_trans_data].  However, that name breaks HORRIBLY with general naming conventions: it is not the _type_ of the data (which is un-named for [nat_trans]), but is the _access function_ for that data!  Submit issue for this? *)  
 Lemma tm_from_qq_mor_data {X X' : obj_ext_precat} {F : X --> X'}
-    {Z : qq_structure_disp_precat C X} {Z'} (FZ : Z -->[F] Z')
+    {Z : qq_structure_disp_cat C X} {Z'} (FZ : Z -->[F] Z')
   : forall Γ : C, (tm_from_qq Z Γ) --> (tm_from_qq Z' Γ).
 Proof.
   intros Γ Ase.
@@ -232,7 +232,7 @@ Proof.
 Defined.
 
 Lemma tm_from_qq_mor_naturality {X X' : obj_ext_precat} {F : X --> X'}
-    {Z : qq_structure_disp_precat C X} {Z'} (FZ : Z -->[F] Z')
+    {Z : qq_structure_disp_cat C X} {Z'} (FZ : Z -->[F] Z')
   : is_nat_trans (tm_from_qq Z) (tm_from_qq Z') (tm_from_qq_mor_data FZ).
 Proof.
   intros Γ Γ' f; cbn in Γ, Γ', f.
@@ -258,7 +258,7 @@ Proof.
 Time Qed.
 
 Lemma tm_from_qq_mor_TM {X X' : obj_ext_precat} {F : X --> X'}
-    {Z : qq_structure_disp_precat C X} {Z'} (FZ : Z -->[F] Z')
+    {Z : qq_structure_disp_cat C X} {Z'} (FZ : Z -->[F] Z')
   : nat_trans (tm_from_qq Z) (tm_from_qq Z').
 Proof.
   exists (tm_from_qq_mor_data FZ).
@@ -266,7 +266,7 @@ Proof.
 Defined.
 
 Lemma tm_from_qq_mor_pp {X X' : obj_ext_precat} {F : X --> X'}
-    {Z : qq_structure_disp_precat C X} {Z'} (FZ : Z -->[F] Z')
+    {Z : qq_structure_disp_cat C X} {Z'} (FZ : Z -->[F] Z')
   : (tm_from_qq_mor_TM FZ : preShv C ⟦ _ , _ ⟧) ;; pp_from_qq Z'
   = pp_from_qq Z;; obj_ext_mor_TY F.
 Proof.
@@ -275,7 +275,7 @@ Proof.
 Qed.
 
 Lemma tm_from_qq_mor_te {X X' : obj_ext_precat} {F : X --> X'}
-    {Z : qq_structure_disp_precat C X} {Z'} (FZ : Z -->[F] Z')
+    {Z : qq_structure_disp_cat C X} {Z'} (FZ : Z -->[F] Z')
     {Γ} (A : Ty X Γ)
   : tm_from_qq_mor_TM FZ _ (te_from_qq Z A)
   = # (tm_from_qq Z') (φ F A)
@@ -329,10 +329,10 @@ Time Qed.
 End Rename_me.
 
 Definition term_from_qq_mor_TM {X X' : obj_ext_precat} {F : X --> X'}
-    {Z : qq_structure_disp_precat C X} {Z'} (FZ : Z -->[F] Z')
-    {Y : term_fun_disp_precat C X} {Y'}
-    (W : strucs_compat_disp_precat (X,,(Y,,Z)))
-    (W' : strucs_compat_disp_precat (X',,(Y',,Z')))
+    {Z : qq_structure_disp_cat C X} {Z'} (FZ : Z -->[F] Z')
+    {Y : term_fun_disp_cat C X} {Y'}
+    (W : strucs_compat_disp_cat (X,,(Y,,Z)))
+    (W' : strucs_compat_disp_cat (X',,(Y',,Z')))
   : TM (Y : term_fun_structure _ _) --> TM (Y' : term_fun_structure _ _).
 Proof.
   refine ( _ ;; (tm_from_qq_mor_TM FZ : preShv C ⟦ _ , _ ⟧) ;; _).
@@ -342,10 +342,10 @@ Defined.
 (* TODO: better, construct these three parts as maps of qq-morphism structures, and put them together directly as that. *)
 
 Lemma term_from_qq_mor {X X' : obj_ext_precat} {F : X --> X'}
-  {Z : qq_structure_disp_precat C X} {Z'} (FZ : Z -->[F] Z')
-  {Y : term_fun_disp_precat C X} {Y'}
-  (W : strucs_compat_disp_precat (X,,(Y,,Z)))
-  (W' : strucs_compat_disp_precat (X',,(Y',,Z')))
+  {Z : qq_structure_disp_cat C X} {Z'} (FZ : Z -->[F] Z')
+  {Y : term_fun_disp_cat C X} {Y'}
+  (W : strucs_compat_disp_cat (X,,(Y,,Z)))
+  (W' : strucs_compat_disp_cat (X',,(Y',,Z')))
   : ∑ (FY : Y -->[F] Y'), W -->[(F,,(FY,,FZ))] W'.
 Proof.
   simpl in W, W'; unfold iscompatible_term_qq in W, W'. (* Readability *)
@@ -369,10 +369,10 @@ Proof.
 Defined.
 
 Lemma term_from_qq_mor_unique {X X' : obj_ext_precat} {F : X --> X'}
-  {Z : qq_structure_disp_precat C X} {Z'} (FZ : Z -->[F] Z')
-  {Y : term_fun_disp_precat C X} {Y'}
-  (W : strucs_compat_disp_precat (X,,(Y,,Z)))
-  (W' : strucs_compat_disp_precat (X',,(Y',,Z')))
+  {Z : qq_structure_disp_cat C X} {Z'} (FZ : Z -->[F] Z')
+  {Y : term_fun_disp_cat C X} {Y'}
+  (W : strucs_compat_disp_cat (X,,(Y,,Z)))
+  (W' : strucs_compat_disp_cat (X',,(Y',,Z')))
   : isaprop (∑ (FY : Y -->[F] Y'), W -->[(F,,(FY,,FZ))] W').
 Proof.
   apply isofhleveltotal2.
@@ -548,7 +548,7 @@ Definition compat_structures_pr1_equiv_over_id
 
 Definition compat_structures_pr1_inverse_over_id
      : equiv_over_id
-         (term_fun_disp_precat C) compat_structures_disp_precat.
+         (term_fun_disp_cat C) compat_structures_disp_cat.
 Proof.
   exact (equiv_inv _ (compat_structures_pr1_is_equiv_over_id)).
 Defined.
@@ -607,7 +607,7 @@ Definition compat_structures_pr2_equiv_over_id
 
 Definition compat_structures_pr2_inverse_over_id
      : equiv_over_id
-         (qq_structure_disp_precat C) compat_structures_disp_precat.
+         (qq_structure_disp_cat C) compat_structures_disp_cat.
 Proof.
   exact (equiv_inv _ (compat_structures_pr2_is_equiv_over_id)).
 Defined.
@@ -620,8 +620,8 @@ Context (X : obj_ext_Precat C).
 
 Definition term_struc_to_qq_struc_fiber_functor
   : functor
-      (fiber_precategory (term_fun_disp_precat C) X)
-      (fiber_precategory (qq_structure_disp_precat C) X).
+      (fiber_precategory (term_fun_disp_cat C) X)
+      (fiber_precategory (qq_structure_disp_cat C) X).
 Proof.
   eapply functor_composite.
   - eapply fiber_functor.

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
@@ -24,7 +24,7 @@ Section Auxiliary.
 
 Lemma transportf_term_fun_mor_TM {C : Precategory}
   {X X' : obj_ext_Precat C} {F F' : X --> X'} (e : F = F')
-  {Y : term_fun_disp_precat C X} {Y'} (FY : Y -->[F] Y')
+  {Y : term_fun_disp_cat C X} {Y'} (FY : Y -->[F] Y')
   : term_fun_mor_TM (transportf _ e FY) = term_fun_mor_TM FY.
 Proof.
   destruct e; apply idpath.
@@ -276,7 +276,7 @@ Section Is_Category_Families_Strucs.
 (* TODO: inline *) 
 Lemma isaprop_whatever
   (x : obj_ext_Precat C)
-  (d d' : (term_fun_disp_precat C) x)
+  (d d' : (term_fun_disp_cat C) x)
   : isaprop (iso_disp (identity_iso x) d d').
 Proof.
   apply isofhleveltotal2.
@@ -286,7 +286,7 @@ Qed.
 
 Definition iso_disp_to_TM_eq
   (X : obj_ext_Precat C)
-  (Y Y' : (term_fun_disp_precat C) X)
+  (Y Y' : (term_fun_disp_cat C) X)
   : iso_disp (identity_iso X) Y Y'
   -> TM (Y : term_fun_structure _ X) = TM (Y' : term_fun_structure _ X).
 Proof.
@@ -304,7 +304,7 @@ Proof.
 Defined.
 
 Lemma prewhisker_iso_disp_to_TM_eq 
-  {X} {Y Y' : term_fun_disp_precat C X}
+  {X} {Y Y' : term_fun_disp_cat C X}
   (FG : iso_disp (identity_iso X) Y Y')
   {P : preShv C} (α : TM (Y : term_fun_structure _ X) --> P)
 : transportf (λ P' : preShv C, P' --> P) (iso_disp_to_TM_eq _ _ _ FG) α
@@ -316,7 +316,7 @@ Proof.
 Qed.
 
 Lemma postwhisker_iso_disp_to_TM_eq 
-  {X} {Y Y' : term_fun_disp_precat C X}
+  {X} {Y Y' : term_fun_disp_cat C X}
   (FG : iso_disp (identity_iso X) Y Y')
   {P : preShv C} (α : P --> TM (Y : term_fun_structure _ X))
 : transportf (λ P' : preShv C, P --> P') (iso_disp_to_TM_eq _ _ _ FG) α
@@ -326,7 +326,7 @@ Proof.
 Qed.
 
 Lemma idtoiso_iso_disp_to_TM_eq 
-  {X} {Y Y' : term_fun_disp_precat C X}
+  {X} {Y Y' : term_fun_disp_cat C X}
   (FG : iso_disp (identity_iso X) Y Y')
 : (idtoiso (iso_disp_to_TM_eq _ _ _ FG) : _ --> _)
   = term_fun_mor_TM (FG : _ -->[_] _).
@@ -334,9 +334,9 @@ Proof.
   refine (maponpaths pr1 (idtoiso_isotoid _ _ _ _ _)).
 Qed.
 
-Definition iso_to_id__term_fun_disp_precat
+Definition iso_to_id__term_fun_disp_cat
   {X : obj_ext_Precat C}
-  (Y Y' : term_fun_disp_precat C X)
+  (Y Y' : term_fun_disp_cat C X)
   : iso_disp (identity_iso _) Y Y' -> Y = Y'.
 Proof.
   intros i.
@@ -361,11 +361,11 @@ Proof.
 Qed.
 
 Theorem is_category_term_fun_structure
-  : is_category_disp (term_fun_disp_precat C).
+  : is_univalent_disp (term_fun_disp_cat C).
 Proof.
-  apply is_category_disp_from_fibers.
+  apply is_univalent_disp_from_fibers.
   intros X.
-  apply eq_equiv_from_retraction with iso_to_id__term_fun_disp_precat.
+  apply eq_equiv_from_retraction with iso_to_id__term_fun_disp_cat.
   - intros. apply eq_iso_disp, isaprop_term_fun_mor.
 Qed.
 
@@ -398,7 +398,7 @@ Qed.
 
 Lemma isaprop_iso_disp_qq_morphism_structure 
   (x : obj_ext_Precat C)
-  (d d' : (qq_structure_disp_precat C) x)
+  (d d' : (qq_structure_disp_cat C) x)
   : isaprop (iso_disp (identity_iso x) d d').
 Proof.
   apply (isofhleveltotal2 1).
@@ -428,7 +428,7 @@ Defined.
 
 Definition qq_structure_iso_disp_to_id
   (x : obj_ext_Precat C)
-  (d d' : (qq_structure_disp_precat C) x)
+  (d d' : (qq_structure_disp_cat C) x)
   : iso_disp (identity_iso x) d d' → d = d'.
 Proof.
   intro H. 
@@ -447,9 +447,9 @@ Proof.
 Defined.  
   
 Theorem is_category_qq_morphism
-  : is_category_disp (qq_structure_disp_precat C).
+  : is_univalent_disp (qq_structure_disp_cat C).
 Proof.
-  apply is_category_disp_from_fibers.
+  apply is_univalent_disp_from_fibers.
   intros x d d'. 
   use isweqimplimpl. 
   - apply qq_structure_iso_disp_to_id.
@@ -461,9 +461,9 @@ End Is_Category_qq_Strucs.
 
 Section Is_Category_Compat_Strucs.
 
-Lemma isaprop_iso_disp_strucs_compat_disp_precat
-  (x : total_precat (term_fun_disp_precat C × qq_structure_disp_precat C))
-  (d d' : strucs_compat_disp_precat x)
+Lemma isaprop_iso_disp_strucs_compat_disp_cat
+  (x : total_precat (term_fun_disp_cat C × qq_structure_disp_cat C))
+  (d d' : strucs_compat_disp_cat x)
   : isaprop (iso_disp (identity_iso x) d d').
 Proof.
   unfold iso_disp.
@@ -476,8 +476,8 @@ Qed.
 
 
 Definition  strucs_compat_iso_disp_to_id
-  (x : total_precat (term_fun_disp_precat C × qq_structure_disp_precat C))
-  (d d' : strucs_compat_disp_precat x)
+  (x : total_precat (term_fun_disp_cat C × qq_structure_disp_cat C))
+  (d d' : strucs_compat_disp_cat x)
   : iso_disp (identity_iso x) d d' → d = d'.
 Proof.
   intro H.
@@ -486,15 +486,15 @@ Proof.
 Defined.
 
 Theorem is_category_strucs_compat
-  : is_category_disp (@strucs_compat_disp_precat C).
+  : is_univalent_disp (@strucs_compat_disp_cat C).
 Proof.
-  apply is_category_disp_from_fibers.
+  apply is_univalent_disp_from_fibers.
   intros x d d'.
   use isweqimplimpl.
   - apply strucs_compat_iso_disp_to_id.
   - apply hlevelntosn.
     apply CwF_SplitTypeCat_Maps.isaprop_iscompatible_term_qq.
-  - apply isaprop_iso_disp_strucs_compat_disp_precat.
+  - apply isaprop_iso_disp_strucs_compat_disp_cat.
 Defined.
 
 End Is_Category_Compat_Strucs.

--- a/TypeTheory/Displayed_Cats/Codomain.v
+++ b/TypeTheory/Displayed_Cats/Codomain.v
@@ -36,14 +36,14 @@ Section Codomain_Disp.
 
 Context (C:Precategory).
 
-Definition cod_disp_ob_mor : disp_precat_ob_mor C.
+Definition cod_disp_ob_mor : disp_cat_ob_mor C.
 Proof.
   exists (fun x : C => ∑ y, y --> x).
   simpl; intros x y xx yy f. 
     exact (∑ ff : pr1 xx --> pr1 yy, ff ;; pr2 yy = pr2 xx ;; f).
 Defined.
 
-Definition cod_id_comp : disp_precat_id_comp _ cod_disp_ob_mor.
+Definition cod_id_comp : disp_cat_id_comp _ cod_disp_ob_mor.
 Proof.
   split.
   - simpl; intros.
@@ -62,10 +62,10 @@ Proof.
         apply assoc).
 Defined.
 
-Definition cod_disp_data : disp_precat_data _
+Definition cod_disp_data : disp_cat_data _
   := (cod_disp_ob_mor ,, cod_id_comp).
 
-Lemma cod_disp_axioms : disp_precat_axioms C cod_disp_data.
+Lemma cod_disp_axioms : disp_cat_axioms C cod_disp_data.
 Proof.
   repeat apply tpair; intros; try apply homset_property.
   - apply subtypeEquality.
@@ -95,7 +95,7 @@ Proof.
     + intro. apply isasetaprop. apply homset_property.
 Qed.
 
-Definition disp_codomain : disp_precat C
+Definition disp_codomain : disp_cat C
   := (cod_disp_data ,, cod_disp_axioms).
 
 End Codomain_Disp.

--- a/TypeTheory/Displayed_Cats/ComprehensionC.v
+++ b/TypeTheory/Displayed_Cats/ComprehensionC.v
@@ -30,7 +30,7 @@ Local Set Automatic Introduction.
 (* TODO: upstream to with definition of fibrations/cartesianness *)
 Definition is_cartesian_disp_functor
   {C C' : Precategory} {F : functor C C'}
-  {D : disp_precat C} {D' : disp_precat C'} (FF : disp_functor F D D') : UU
+  {D : disp_cat C} {D' : disp_cat C'} (FF : disp_functor F D D') : UU
 := ∏  {c c' : C} {f : c' --> c}
       {d : D c} {d' : D c'} (ff : d' -->[f] d),
   is_cartesian ff -> is_cartesian (#FF ff).
@@ -38,7 +38,7 @@ Definition is_cartesian_disp_functor
 
 (* TODO: upstream *)
 Lemma isaprop_is_cartesian
-    {C : Precategory} {D : disp_precat C}
+    {C : Precategory} {D : disp_cat C}
     {c c' : C} {f : c' --> c}
     {d : D c} {d' : D c'} (ff : d' -->[f] d)
   : isaprop (is_cartesian ff).
@@ -49,7 +49,7 @@ Qed.
 
 (* TODO: upstream *)
 Lemma is_cartesian_from_iso_to_cartesian
-    {C : Precategory} {D : disp_precat C}
+    {C : Precategory} {D : disp_cat C}
     {c} {d : D c} {c' : C} {f : c' --> c}
     {d0'} {ff : d0' -->[f] d} (ff_cart : is_cartesian ff)
     {d1'} {ff' : d1' -->[f] d}
@@ -97,7 +97,7 @@ Defined.
   Of course, this can only happen when the domain is a fibration; and in practice, it is useful exactly in the case where one has shown it is a fibration by exhibiting some particular construction of (mere existence of) cartesian lifts. *) 
 Lemma cartesian_functor_from_fibration
     {C C' : Precategory} {F : functor C C'}
-    {D : disp_precat C} {D' : disp_precat C'} {FF : disp_functor F D D'}
+    {D : disp_cat C} {D' : disp_cat C'} {FF : disp_functor F D D'}
     (H : forall (c c' : C) (f : c' --> c) (d : D c),
       ∥ { ff : cartesian_lift d f & is_cartesian (#FF ff) } ∥)
   : is_cartesian_disp_functor FF.
@@ -137,7 +137,7 @@ Qed.
 
 Lemma cartesian_functor_from_cleaving
     {C C' : Precategory} {F : functor C C'}
-    {D : disp_precat C} {D' : disp_precat C'} {FF : disp_functor F D D'}
+    {D : disp_cat C} {D' : disp_cat C'} {FF : disp_functor F D D'}
     (clD : cleaving D)
     (H : forall c c' f d, is_cartesian (# FF (clD c c' f d)))
   : is_cartesian_disp_functor FF.
@@ -149,7 +149,7 @@ Proof.
 Qed.
 
 Definition comprehension_cat_structure (C : Precategory) : UU 
-  := ∑ (D : disp_precat C) (H : cleaving D)
+  := ∑ (D : disp_cat C) (H : cleaving D)
      (F : disp_functor (functor_identity _ ) D (disp_codomain C)),
      is_cartesian_disp_functor F.
 

--- a/TypeTheory/Displayed_Cats/Constructions.v
+++ b/TypeTheory/Displayed_Cats/Constructions.v
@@ -73,27 +73,27 @@ Section full_subcat.
 Variable C : Precategory.
 Variable P : C -> UU.
 
-Definition disp_full_sub_ob_mor : disp_precat_ob_mor C.
+Definition disp_full_sub_ob_mor : disp_cat_ob_mor C.
 Proof.
   exists P.
   intros. exact unit.
 Defined.
 
-Definition disp_full_sub_id_comp : disp_precat_id_comp C disp_full_sub_ob_mor.
+Definition disp_full_sub_id_comp : disp_cat_id_comp C disp_full_sub_ob_mor.
 Proof.
   split; intros; apply tt.
 Qed.
 
-Definition disp_full_sub_data : disp_precat_data C 
+Definition disp_full_sub_data : disp_cat_data C 
   :=  disp_full_sub_ob_mor,, disp_full_sub_id_comp.
 
-Definition disp_full_sub_axioms : disp_precat_axioms _ disp_full_sub_data.
+Definition disp_full_sub_axioms : disp_cat_axioms _ disp_full_sub_data.
 Proof.
   repeat split; intros; try (apply proofirrelevance; apply isapropunit).
   apply isasetaprop; apply isapropunit.
 Qed.
 
-Definition disp_full_sub : disp_precat C := _ ,, disp_full_sub_axioms.                      
+Definition disp_full_sub : disp_cat C := _ ,, disp_full_sub_axioms.                      
 
 End full_subcat.
 
@@ -112,28 +112,28 @@ Variable Hid : ∏ (x : C) (a : P x), H a a (identity _ ).
 Variable Hcomp : ∏ (x y z : C) a b c (f : C⟦x,y⟧) (g : C⟦y,z⟧),
                  H a b f → H b c g → H a c (f ;; g).
 
-Definition disp_struct_ob_mor : disp_precat_ob_mor C.
+Definition disp_struct_ob_mor : disp_cat_ob_mor C.
 Proof.
   exists P.
   intros ? ? f a b; exact (H f a b ).
 Defined.
 
-Definition disp_struct_id_comp : disp_precat_id_comp _ disp_struct_ob_mor.
+Definition disp_struct_id_comp : disp_cat_id_comp _ disp_struct_ob_mor.
 Proof.
   split; cbn; intros.
   - apply Hid.
   - eapply Hcomp. apply X. apply X0.
 Qed.
 
-Definition disp_struct_data : disp_precat_data C := _ ,, disp_struct_id_comp.
+Definition disp_struct_data : disp_cat_data C := _ ,, disp_struct_id_comp.
 
-Definition disp_struct_axioms : disp_precat_axioms _ disp_struct_data.
+Definition disp_struct_axioms : disp_cat_axioms _ disp_struct_data.
 Proof.
   repeat split; intros; try (apply proofirrelevance; apply Hisprop).
   apply isasetaprop; apply Hisprop.
 Qed.
 
-Definition disp_struct : disp_precat C := _ ,, disp_struct_axioms.
+Definition disp_struct : disp_cat C := _ ,, disp_struct_axioms.
 
 End struct_hom.
 
@@ -141,20 +141,20 @@ End struct_hom.
 
 We directly define direct products of displayed categories over a base.
 
-An alternative would be to define the direct product as the [sigma_disp_precat] of the pullback to either factor.  *)
+An alternative would be to define the direct product as the [sigma_disp_cat] of the pullback to either factor.  *)
 Section Dirprod.
 
-Context {C : Precategory} (D1 D2 : disp_precat C).
+Context {C : Precategory} (D1 D2 : disp_cat C).
 
-Definition dirprod_disp_precat_ob_mor : disp_precat_ob_mor C.
+Definition dirprod_disp_cat_ob_mor : disp_cat_ob_mor C.
 Proof.
   exists (fun c => (D1 c × D2 c)).
   intros x y xx yy f.
   exact (pr1 xx -->[f] pr1 yy × pr2 xx -->[f] pr2 yy).
 Defined.
 
-Definition dirprod_disp_precat_id_comp
-  : disp_precat_id_comp _ dirprod_disp_precat_ob_mor.
+Definition dirprod_disp_cat_id_comp
+  : disp_cat_id_comp _ dirprod_disp_cat_ob_mor.
 Proof.
   apply tpair.
   - intros x xx. exact (id_disp _,, id_disp _).
@@ -162,11 +162,11 @@ Proof.
     exact ((pr1 ff ;; pr1 gg),, (pr2 ff ;; pr2 gg)).
 Defined.
 
-Definition dirprod_disp_precat_data : disp_precat_data C
-  := (_ ,, dirprod_disp_precat_id_comp).
+Definition dirprod_disp_cat_data : disp_cat_data C
+  := (_ ,, dirprod_disp_cat_id_comp).
 
-Definition dirprod_disp_precat_axioms
-  : disp_precat_axioms _ dirprod_disp_precat_data.
+Definition dirprod_disp_cat_axioms
+  : disp_cat_axioms _ dirprod_disp_cat_data.
 Proof.
   repeat apply tpair.
   - intros. apply dirprod_paths; refine (id_left_disp @ !_).
@@ -181,11 +181,11 @@ Proof.
   - intros. apply isaset_dirprod; apply homsets_disp.
 Qed.
 
-Definition dirprod_disp_precat : disp_precat C
-  := (_ ,, dirprod_disp_precat_axioms).
+Definition dirprod_disp_cat : disp_cat C
+  := (_ ,, dirprod_disp_cat_axioms).
 
 Definition dirprodpr1_disp_functor_data
-  : disp_functor_data (functor_identity C) dirprod_disp_precat (D1).
+  : disp_functor_data (functor_identity C) dirprod_disp_cat (D1).
 Proof.
   mkpair.
   - intros x xx; exact (pr1 xx).
@@ -201,12 +201,12 @@ Proof.
 Qed.
 
 Definition dirprodpr1_disp_functor
-  : disp_functor (functor_identity C) dirprod_disp_precat (D1)
+  : disp_functor (functor_identity C) dirprod_disp_cat (D1)
 := (dirprodpr1_disp_functor_data,, dirprodpr1_disp_functor_axioms).
 
 
 Definition dirprodpr2_disp_functor_data
-  : disp_functor_data (functor_identity C) dirprod_disp_precat (D2).
+  : disp_functor_data (functor_identity C) dirprod_disp_cat (D2).
 Proof.
   mkpair.
   - intros x xx; exact (pr2 xx).
@@ -222,23 +222,23 @@ Proof.
 Qed.
 
 Definition dirprodpr2_disp_functor
-  : disp_functor (functor_identity C) dirprod_disp_precat (D2)
+  : disp_functor (functor_identity C) dirprod_disp_cat (D2)
 := (dirprodpr2_disp_functor_data,, dirprodpr2_disp_functor_axioms).
 
 End Dirprod.
 
-Notation "D1 × D2" := (dirprod_disp_precat D1 D2) : disp_precat_scope.
-Delimit Scope disp_precat_scope with disp_precat.
-Bind Scope disp_precat_scope with disp_precat.
+Notation "D1 × D2" := (dirprod_disp_cat D1 D2) : disp_cat_scope.
+Delimit Scope disp_cat_scope with disp_cat.
+Bind Scope disp_cat_scope with disp_cat.
 
 (** * Sigmas of displayed (pre)categories *)
 Section Sigma.
 
 Context {C : Precategory}
-        {D : disp_precat C}
-        (E : disp_precat (total_precat D)).
+        {D : disp_cat C}
+        (E : disp_cat (total_precat D)).
 
-Definition sigma_disp_precat_ob_mor : disp_precat_ob_mor C.
+Definition sigma_disp_cat_ob_mor : disp_cat_ob_mor C.
 Proof.
   exists (fun c => ∑ (d : D c), (E (c,,d))).
   intros x y xx yy f.
@@ -246,8 +246,8 @@ Proof.
                 (pr2 xx -->[f,,fD] pr2 yy)).
 Defined.
 
-Definition sigma_disp_precat_id_comp
-  : disp_precat_id_comp _ sigma_disp_precat_ob_mor.
+Definition sigma_disp_cat_id_comp
+  : disp_cat_id_comp _ sigma_disp_cat_ob_mor.
 Proof.
   apply tpair.
   - intros x xx.
@@ -256,12 +256,12 @@ Proof.
     exists (pr1 ff ;; pr1 gg). exact (pr2 ff ;; pr2 gg).
 Defined.
 
-Definition sigma_disp_precat_data : disp_precat_data C
-  := (_ ,, sigma_disp_precat_id_comp).
+Definition sigma_disp_cat_data : disp_cat_data C
+  := (_ ,, sigma_disp_cat_id_comp).
 
 
-Definition sigma_disp_precat_axioms
-  : disp_precat_axioms _ sigma_disp_precat_data.
+Definition sigma_disp_cat_axioms
+  : disp_cat_axioms _ sigma_disp_cat_data.
 Proof.
   repeat apply tpair.
   - intros. use total2_reassoc_paths'.
@@ -282,11 +282,11 @@ Proof.
   - intros. apply isaset_total2; intros; apply homsets_disp.
 Qed.
 
-Definition sigma_disp_precat : disp_precat C
-  := (_ ,, sigma_disp_precat_axioms).
+Definition sigma_disp_cat : disp_cat C
+  := (_ ,, sigma_disp_cat_axioms).
 
 Definition sigmapr1_disp_functor_data
-  : disp_functor_data (functor_identity C) sigma_disp_precat D.
+  : disp_functor_data (functor_identity C) sigma_disp_cat D.
 Proof.
   mkpair.
   - intros x xx; exact (pr1 xx).
@@ -302,7 +302,7 @@ Proof.
 Qed.
 
 Definition sigmapr1_disp_functor
-  : disp_functor (functor_identity C) sigma_disp_precat D
+  : disp_functor (functor_identity C) sigma_disp_cat D
 := (sigmapr1_disp_functor_data,, sigmapr1_disp_functor_axioms).
 
 (* TODO: complete [sigmapr2_disp]; will be a [functor_lifting], not a [disp_functor]. *)
@@ -310,14 +310,14 @@ Definition sigmapr1_disp_functor
 (** ** Transport and isomorphism lemmas *)
 
 Lemma pr1_transportf_sigma_disp {x y : C} {f f' : x --> y} (e : f = f')
-    {xxx : sigma_disp_precat x} {yyy} (fff : xxx -->[f] yyy)
+    {xxx : sigma_disp_cat x} {yyy} (fff : xxx -->[f] yyy)
   : pr1 (transportf _ e fff) = transportf _ e (pr1 fff).
 Proof.
   destruct e; apply idpath.
 Qed.
 
 Lemma pr2_transportf_sigma_disp {x y : C} {f f' : x --> y} (e : f = f')
-    {xxx : sigma_disp_precat x} {yyy} (fff : xxx -->[f] yyy)
+    {xxx : sigma_disp_cat x} {yyy} (fff : xxx -->[f] yyy)
   : pr2 (transportf _ e fff)
   = transportf (fun ff => pr2 xxx -->[ff] _ ) (two_arg_paths_f (*total2_paths2*) e (! pr1_transportf_sigma_disp e fff))
       (pr2 fff).
@@ -334,7 +334,7 @@ Qed.
 Local Open Scope hide_transport_scope.
 
 Definition is_iso_sigma_disp_aux1
-    {x y} {xxx : sigma_disp_precat x} {yyy : sigma_disp_precat y}
+    {x y} {xxx : sigma_disp_cat x} {yyy : sigma_disp_cat y}
     {f : iso x y} (fff : xxx -->[f] yyy) 
     (ii : is_iso_disp f (pr1 fff))
     (ffi := (_,, ii) : iso_disp f (pr1 xxx) (pr1 yyy))
@@ -347,7 +347,7 @@ Proof.
 Defined.
 
 Lemma is_iso_sigma_disp_aux2
-    {x y} {xxx : sigma_disp_precat x} {yyy : sigma_disp_precat y}
+    {x y} {xxx : sigma_disp_cat x} {yyy : sigma_disp_cat y}
     {f : iso x y} (fff : xxx -->[f] yyy) 
     (ii : is_iso_disp f (pr1 fff))
     (ffi := (_,, ii) : iso_disp f (pr1 xxx) (pr1 yyy))
@@ -388,7 +388,7 @@ Proof.
 Time Qed. (* TODO: try to speed this up? *)
 
 Lemma is_iso_sigma_disp
-    {x y} {xxx : sigma_disp_precat x} {yyy : sigma_disp_precat y}
+    {x y} {xxx : sigma_disp_cat x} {yyy : sigma_disp_cat y}
     {f : iso x y} (fff : xxx -->[f] yyy) 
     (ii : is_iso_disp f (pr1 fff))
     (ffi := (_,, ii) : iso_disp f (pr1 xxx) (pr1 yyy))
@@ -400,7 +400,7 @@ Proof.
 Defined.
 
 Definition sigma_disp_iso
-    {x y} (xx : sigma_disp_precat x) (yy : sigma_disp_precat y)
+    {x y} (xx : sigma_disp_cat x) (yy : sigma_disp_cat y)
     {f : iso x y} (ff : iso_disp f (pr1 xx) (pr1 yy))
     (fff : iso_disp (@total_iso _ _ (_,,_) (_,,_) f ff) (pr2 xx) (pr2 yy))
   : iso_disp f xx yy.
@@ -411,7 +411,7 @@ Proof.
 Defined.
 
 Definition sigma_disp_iso_map
-    {x y} (xx : sigma_disp_precat x) (yy : sigma_disp_precat y)
+    {x y} (xx : sigma_disp_cat x) (yy : sigma_disp_cat y)
     (f : iso x y)
   : (∑ ff : iso_disp f (pr1 xx) (pr1 yy),
        iso_disp (@total_iso _ _ (_,,_) (_,,_) f ff) (pr2 xx) (pr2 yy))
@@ -419,7 +419,7 @@ Definition sigma_disp_iso_map
 := fun ff => sigma_disp_iso _ _ (pr1 ff) (pr2 ff).
 
 Lemma sigma_disp_iso_isweq
-    {x y} (xx : sigma_disp_precat x) (yy : sigma_disp_precat y)
+    {x y} (xx : sigma_disp_cat x) (yy : sigma_disp_cat y)
     (f : iso x y)
   : isweq (sigma_disp_iso_map xx yy f).
 Proof.
@@ -427,16 +427,16 @@ Abort.
 
 (*
 Definition sigma_disp_iso_equiv 
-    {x y} (xx : sigma_disp_precat x) (yy : sigma_disp_precat y)
+    {x y} (xx : sigma_disp_cat x) (yy : sigma_disp_cat y)
     (f : iso x y)
 := weqpair _ (sigma_disp_iso_isweq xx yy f).
 *)
 
 (*
-Lemma is_category_sigma_disp (DD : is_category_disp D) (EE : is_category_disp E)
-  : is_category_disp sigma_disp_precat.
+Lemma is_category_sigma_disp (DD : is_univalent_disp D) (EE : is_univalent_disp E)
+  : is_univalent_disp sigma_disp_cat.
 Proof.
-  apply is_category_disp_from_fibers.
+  apply is_univalent_disp_from_fibers.
   intros x xx yy.
   use weqhomot.
   - destruct xx as [xx xxx], yy as [yy yyy].
@@ -496,8 +496,8 @@ Section Functor.
 (* TODO: clean up this section a bit. *)
 
 Variables C' C : Precategory.
-Variable D' : disp_precat C'.
-Variable D : disp_precat C.
+Variable D' : disp_cat C'.
+Variable D : disp_cat C.
 
 Let FunctorsC'C := functor_Precategory C' C.
 
@@ -616,7 +616,7 @@ Proof.
 Qed.
 
 Definition disp_functor_precat : 
-  disp_precat (FunctorsC'C).
+  disp_cat (FunctorsC'C).
 Proof.
   mkpair.
   - mkpair.
@@ -879,7 +879,7 @@ End Functor.
 Section Fiber.
 
 Context {C : Precategory}
-        (D : disp_precat C)
+        (D : disp_cat C)
         (c : C).
 
 Definition fiber_precategory_data : precategory_data.
@@ -978,7 +978,7 @@ Proof.
 Defined.
     
 (** ** Univalence *)
-Variable H : is_category_disp D.
+Variable H : is_univalent_disp D.
 
 Let idto1 (a b : fiber_precategory) : a = b ≃ iso_disp (identity_iso c) a b 
   := 
@@ -1070,7 +1070,7 @@ End fix_context.
 (* TODO: consider lemma organisation in this file *)
 
 Definition is_iso_fiber_from_is_iso_disp
-  {C : Precategory} {D : disp_precat C}
+  {C : Precategory} {D : disp_cat C}
   {c : C} {d d' : D c} (ff : d -->[identity c] d')
   (Hff : is_iso_disp (identity_iso c) ff)
 : @is_iso (fiber_precategory D c) _ _ ff.

--- a/TypeTheory/Displayed_Cats/Core.v
+++ b/TypeTheory/Displayed_Cats/Core.v
@@ -728,8 +728,8 @@ Qed.
 
 End Utilities.
 
-(** ** Saturation: displayed categories *)
-Section Categories.
+(** ** Saturation: displayed univalent categories *)
+Section Univalent_Categories.
 
 (** The current [is_univalent_disp] is certainly the correct definition in the case where the base precategory [C] is a category.
 
@@ -747,23 +747,23 @@ Proof.
   intros H x x' e. destruct e. apply H.
 Qed.
 
-Definition disp_category C
+Definition disp_univalent_category C
   := ∑ D : disp_cat C, is_univalent_disp D.
 
-Definition disp_category_pair
+Definition disp_univalent_category_pair
     {C} {D : disp_cat C} (H : is_univalent_disp D)
-  : disp_category C
+  : disp_univalent_category C
 := (D,,H).
 
-Definition disp_cat_of_disp_cat {C} (D : disp_category C)
+Definition disp_cat_of_disp_univalent_cat {C} (D : disp_univalent_category C)
   : disp_cat C
 := pr1 D.
-Coercion disp_cat_of_disp_cat : disp_category >-> disp_cat.
+Coercion disp_cat_of_disp_univalent_cat : disp_univalent_category >-> disp_cat.
 
-Definition category_is_univalent_disp {C} (D : disp_category C)
+Definition disp_univalent_category_is_univalent_disp {C} (D : disp_univalent_category C)
   : is_univalent_disp D
 := pr2 D.
-Coercion category_is_univalent_disp : disp_category >-> is_univalent_disp.
+Coercion disp_univalent_category_is_univalent_disp : disp_univalent_category >-> is_univalent_disp.
 
 Definition isotoid_disp
     {C} {D : disp_cat C} (D_cat : is_univalent_disp D)
@@ -789,14 +789,14 @@ Proof.
   refine (homotinvweqweq _ _).
 Qed.
 
-End Categories.
+End Univalent_Categories.
 
 
 (** * Total categories *)
 
 (** ** Definition and forgetful functor *)
 
-(* Any displayed precategory has a total precategory, with a forgetful functor to the base category. *)
+(* Any displayed category has a total precategory, with a forgetful functor to the base category. *)
 Section Total_Precat.
 
 Context {C : Precategory} (D : disp_cat C).

--- a/TypeTheory/Displayed_Cats/Core.v
+++ b/TypeTheory/Displayed_Cats/Core.v
@@ -1,9 +1,9 @@
 (**
-A module for “displayed precategories”, based over UniMath’s [CategoryTheory] library.
+A module for “displayed categories”, based over UniMath’s [CategoryTheory] library.
 
-Roughly, a “displayed category _D_ over a precategory _C_” is analogous to “a family of types _Y_ indexed over a type _X_”.  A displayed category has a “total category” ∑ _C_ _D_, with a functor to _D_; and indeed displayed categories should be equivalent to categories over _D_, by taking fibers.
+Roughly, a “displayed category _D_ over a Precategory _C_” is analogous to “a family of types _Y_ indexed over a type _X_”.  A displayed category has a “total category” ∑ _C_ _D_, with a functor to _D_; and indeed displayed categories should be equivalent to categories over _D_, by taking fibers.
 
-In a little more detail: if [D] is a displayed precategory over [C], then [D] has a type of objects indexed over [ob C], and for each [x y : C, f : x --> y, xx : D x, yy : D y], a type of “morphisms over [f] from [xx] to [yy]”.  The identity and composition (and axioms) for [D] all overlie the corresponding structure on [C].
+In a little more detail: if [D] is a displayed category over [C], then [D] has a type of objects indexed over [ob C], and for each [x y : C, f : x --> y, xx : D x, yy : D y], a type of “morphisms over [f] from [xx] to [yy]”.  The identity and composition (and axioms) for [D] all overlie the corresponding structure on [C].
 
 Two major motivations for displayed categories:
 
@@ -12,15 +12,15 @@ Two major motivations for displayed categories:
 
 Contents:
 
-- Displayed precategories: [disp_precat C]
+- Displayed categories: [disp_cat C]
   - various access functions, etc.
   - utility lemmas
   - isomorphisms
   - saturation
-- Total precategories (and their forgetful functors)
+- Total categories (and their forgetful functors)
   - [total_precat D]
   - [pr1_precat D]
-- Functors between precategories, over functors between their bases
+- Functors between displayed categories, over functors between their bases
   - [functor_lifting], [lifted_functor]
   - [disp_functor], [total_functor]
   - properties of functors: [disp_functor_ff], …
@@ -48,7 +48,7 @@ Local Open Scope type_scope.
 
 Module Record_Preview.
 
-  Record disp_precat (C : Precategory) : UU :=
+  Record disp_cat (C : Precategory) : UU :=
     { ob_disp : C -> UU
     ; mor_disp {x y : C} : (x --> y) -> ob_disp x -> ob_disp y -> UU
     ; id_disp {x : C} (xx : ob_disp x) : mor_disp (identity x) xx xx
@@ -76,15 +76,15 @@ End Record_Preview.
 
 (** The actual definition is structured analogously to [precategory], as an iterated ∑-type:
 
-- [disp_precat]
-  - [disp_precat_data]
-    - [disp_precat_ob_mor]
+- [disp_cat]
+  - [disp_cat_data]
+    - [disp_cat_ob_mor]
       - [ob_disp]
       - [mod_disp]
-    - [disp_precat_id_comp]
+    - [disp_cat_id_comp]
       - [id_disp]
       - [comp_disp]
-  - [disp_precat_axioms]
+  - [disp_cat_axioms]
     - [id_left_disp]
     - [id_right_disp]
     - [assoc_disp]
@@ -92,42 +92,42 @@ End Record_Preview.
 
 *)
 
-Section Disp_Precat.
+Section Disp_Cat.
 
-Definition disp_precat_ob_mor (C : precategory_ob_mor)
+Definition disp_cat_ob_mor (C : precategory_ob_mor)
   := ∑ (obd : C -> UU), (∏ x y:C, obd x -> obd y -> (x --> y) -> UU).
 
-Definition ob_disp {C} (D : disp_precat_ob_mor C) : C -> UU := pr1 D.
-Coercion ob_disp : disp_precat_ob_mor >-> Funclass.
+Definition ob_disp {C} (D : disp_cat_ob_mor C) : C -> UU := pr1 D.
+Coercion ob_disp : disp_cat_ob_mor >-> Funclass.
 
-Definition mor_disp {C} {D : disp_precat_ob_mor C}
+Definition mor_disp {C} {D : disp_cat_ob_mor C}
   {x y} xx yy (f : x --> y)
 := pr2 D x y xx yy f : UU. 
 
 Local Notation "xx -->[ f ] yy" := (mor_disp xx yy f) (at level 50, yy at next level).
 
-Definition disp_precat_id_comp (C : precategory_data)
-  (D : disp_precat_ob_mor C)
+Definition disp_cat_id_comp (C : precategory_data)
+  (D : disp_cat_ob_mor C)
   : UU
 := (forall (x:C) (xx : D x), xx -->[identity x] xx)
   × (forall (x y z : C) (f : x --> y) (g : y --> z) (xx:D x) (yy:D y) (zz:D z),
            (xx -->[f] yy) -> (yy -->[g] zz) -> (xx -->[f ;; g] zz)).
 
-Definition disp_precat_data C := total2 (disp_precat_id_comp C).
+Definition disp_cat_data C := total2 (disp_cat_id_comp C).
 
-Definition disp_precat_ob_mor_from_disp_precat_data {C}
-  (D : disp_precat_data C)
-  : disp_precat_ob_mor C
+Definition disp_cat_ob_mor_from_disp_cat_data {C}
+  (D : disp_cat_data C)
+  : disp_cat_ob_mor C
 := pr1 D.
 
-Coercion disp_precat_ob_mor_from_disp_precat_data : 
- disp_precat_data >-> disp_precat_ob_mor.
+Coercion disp_cat_ob_mor_from_disp_cat_data : 
+ disp_cat_data >-> disp_cat_ob_mor.
 
-Definition id_disp {C} {D : disp_precat_data C} {x:C} (xx : D x)
+Definition id_disp {C} {D : disp_cat_data C} {x:C} (xx : D x)
   : xx -->[identity x] xx
 := pr1 (pr2 D) x xx.
 
-Definition comp_disp {C} {D : disp_precat_data C}
+Definition comp_disp {C} {D : disp_cat_data C}
   {x y z : C} {f : x --> y} {g : y --> z}
   {xx : D x} {yy} {zz} (ff : xx -->[f] yy) (gg : yy -->[g] zz)
   : xx -->[f;;g] zz
@@ -140,7 +140,7 @@ Delimit Scope mor_disp_scope with mor_disp.
 Bind Scope mor_disp_scope with mor_disp.
 Local Open Scope mor_disp_scope.
 
-Definition disp_precat_axioms (C : Precategory) (D : disp_precat_data C)
+Definition disp_cat_axioms (C : Precategory) (D : disp_cat_data C)
   : UU
 := (∏ x y (f : x --> y) (xx : D x) yy (ff : xx -->[f] yy),
      id_disp _ ;; ff
@@ -154,23 +154,23 @@ Definition disp_precat_axioms (C : Precategory) (D : disp_precat_data C)
      = transportb _ (assoc _ _ _) ((ff ;; gg) ;; hh))
    × (∏ x y f (xx : D x) (yy : D y), isaset (xx -->[f] yy)).
 
-Definition disp_precat (C : Precategory) := total2 (disp_precat_axioms C).
+Definition disp_cat (C : Precategory) := total2 (disp_cat_axioms C).
 
-Definition disp_precat_data_from_disp_precat {C} (D : disp_precat C)
- := pr1 D : disp_precat_data C.
-Coercion disp_precat_data_from_disp_precat : disp_precat >-> disp_precat_data.
+Definition disp_cat_data_from_disp_cat {C} (D : disp_cat C)
+ := pr1 D : disp_cat_data C.
+Coercion disp_cat_data_from_disp_cat : disp_cat >-> disp_cat_data.
 
 (** All the axioms are given in two versions, [foo : T1 = transportb e T2] and [foo_var : T2 = transportf e T1], so that either direction can be invoked easily in “compute left-to-right” style. *)
 
 (* TODO: consider naming conventions? *)
 (* TODO: maybe would be better to have a single [pathsinv0_dep] lemma, or something. *)
 
-Definition id_left_disp {C} {D : disp_precat C} 
+Definition id_left_disp {C} {D : disp_cat C} 
   {x y} {f : x --> y} {xx : D x} {yy} {ff : xx -->[f] yy}
 : id_disp _ ;; ff = transportb _ (id_left _) ff
 := pr1 (pr2 D) _ _ _ _ _ _.
 
-Lemma id_left_disp_var {C} {D : disp_precat C} 
+Lemma id_left_disp_var {C} {D : disp_cat C} 
   {x y} {f : x --> y} {xx : D x} {yy} {ff : xx -->[f] yy}
 : ff = transportf _ (id_left _) (id_disp _ ;; ff).
 Proof.
@@ -178,12 +178,12 @@ Proof.
   apply @pathsinv0, id_left_disp.
 Qed.
 
-Definition id_right_disp {C} {D : disp_precat C} 
+Definition id_right_disp {C} {D : disp_cat C} 
   {x y} {f : x --> y} {xx : D x} {yy} {ff : xx -->[f] yy}
   : ff ;; id_disp _ = transportb _ (id_right _) ff
 := pr1 (pr2 (pr2 D)) _ _ _ _ _ _.
 
-Definition id_right_disp_var {C} {D : disp_precat C} 
+Definition id_right_disp_var {C} {D : disp_cat C} 
   {x y} {f : x --> y} {xx : D x} {yy} {ff : xx -->[f] yy}
   : ff = transportf _ (id_right _) (ff ;; id_disp _).
 Proof.
@@ -191,13 +191,13 @@ Proof.
   apply @pathsinv0, id_right_disp.
 Qed.
 
-Definition assoc_disp {C} {D : disp_precat C}
+Definition assoc_disp {C} {D : disp_cat C}
   {x y z w} {f} {g} {h} {xx : D x} {yy : D y} {zz : D z} {ww : D w}
   {ff : xx -->[f] yy} {gg : yy -->[g] zz} {hh : zz -->[h] ww}
 : ff ;; (gg ;; hh) = transportb _ (assoc _ _ _) ((ff ;; gg) ;; hh)
 := pr1 (pr2 (pr2 (pr2 D))) _ _ _ _ _ _ _ _ _ _ _ _ _ _.
 
-Definition assoc_disp_var {C} {D : disp_precat C}
+Definition assoc_disp_var {C} {D : disp_cat C}
   {x y z w} {f} {g} {h} {xx : D x} {yy : D y} {zz : D z} {ww : D w}
   (ff : xx -->[f] yy) (gg : yy -->[g] zz) (hh : zz -->[h] ww)
 : (ff ;; gg) ;; hh = transportf _ (assoc _ _ _) (ff ;; (gg ;; hh)).
@@ -206,7 +206,7 @@ Proof.
   apply pathsinv0, assoc_disp.
 Defined.
 
-Definition homsets_disp {C} {D :disp_precat C} {x y} {f} {xx : D x} {yy : D y}
+Definition homsets_disp {C} {D :disp_cat C} {x y} {f} {xx : D x} {yy : D y}
   : isaset (xx -->[f] yy)
 := pr2 (pr2 (pr2 (pr2 D))) _ _ _ _ _.
 
@@ -216,7 +216,7 @@ Section Lemmas.
 (** [etrans_disp]: a version of [etrans_dep] for use when the equality transport in the RHS of the goal is already present, and not of the form produced by [etrans_dep], so [etrans_dep] doesn’t apply.  Where possible, [etrans_dep] should still be used, since it *produces* a RHS, whereas this does not (and so leads to lots of unsolved existentials if used where not needed). 
 
 NOTE: as with [etrans_dep], proofs using [etrans_disp] seem to typecheck more slowly than proofs using [etrans] plus other lemmas directly. *)
-Lemma pathscomp0_disp {C} {D : disp_precat C} 
+Lemma pathscomp0_disp {C} {D : disp_cat C} 
   {x y} {f f' f'' : x --> y} {e : f' = f} {e' : f'' = f'} {e'' : f'' = f}
   {xx : D x} {yy}
   {ff : xx -->[f] yy} {ff' : xx -->[f'] yy} {ff'' : xx -->[f''] yy}
@@ -230,12 +230,12 @@ Qed.
 
 Tactic Notation "etrans_disp" := eapply @pathscomp0_disp.
 
-Lemma isaprop_disp_precat_axioms (C : Precategory) (D : disp_precat_data C)
-  : isaprop (disp_precat_axioms C D).
+Lemma isaprop_disp_cat_axioms (C : Precategory) (D : disp_cat_data C)
+  : isaprop (disp_cat_axioms C D).
 Proof.
   apply isofhlevelsn.
   intro X.
-  set (XR := ( _ ,, X) : disp_precat C).
+  set (XR := ( _ ,, X) : disp_cat C).
   apply isofhleveltotal2.
   - repeat (apply impred; intro).
     apply (@homsets_disp _ XR).
@@ -248,7 +248,7 @@ Qed.
 
 (* TODO: consider naming of following few transport lemmas *)
 Lemma mor_disp_transportf_postwhisker
-    {C : precategory} {D : disp_precat_data C}
+    {C : precategory} {D : disp_cat_data C}
     {x y z : C} {f f' : x --> y} (ef : f = f') {g : y --> z}
     {xx : D x} {yy} {zz} (ff : xx -->[f] yy) (gg : yy -->[g] zz)
   : (transportf _ ef ff) ;; gg
@@ -258,7 +258,7 @@ Proof.
 Qed.
 
 Lemma mor_disp_transportf_prewhisker
-    {C : precategory} {D : disp_precat_data C}
+    {C : precategory} {D : disp_cat_data C}
     {x y z : C} {f : x --> y} {g g' : y --> z} (eg : g = g')
     {xx : D x} {yy} {zz} (ff : xx -->[f] yy) (gg : yy -->[g] zz)
   : ff ;; (transportf _ eg gg)
@@ -269,7 +269,7 @@ Qed.
 
 (* TODO: use the following lemmas in more of the displayed category proofs. Most instances of [mor_disp_transportf_Xwhisker] are places that can be simplified with these. *) 
 (* TODO: consider naming of [cancel_Xcomposition_disp].  Currently follows the UniMath base lemmas, but those are bad names — cancellation properties traditionally mean things like like [ ax = ay -> x = y ], whereas these lemmas are the converse of that. *)
-Lemma cancel_postcomposition_disp {C} {D : disp_precat C} 
+Lemma cancel_postcomposition_disp {C} {D : disp_cat C} 
   {x y z} {f f' : x --> y} {e : f' = f} {g : y --> z}
   {xx : D x} {yy} {zz}
   {ff : xx -->[f] yy} {ff' : xx -->[f'] yy} (gg : yy -->[g] zz) 
@@ -280,7 +280,7 @@ Proof.
   apply mor_disp_transportf_postwhisker.
 Qed.
 
-Lemma cancel_precomposition_disp {C} {D : disp_precat C} 
+Lemma cancel_precomposition_disp {C} {D : disp_cat C} 
   {x y z} {f : x --> y} {g g' : y --> z} {e : g' = g}
   {xx : D x} {yy} {zz}
   (ff : xx -->[f] yy) {gg : yy -->[g] zz} {gg' : yy -->[g'] zz}  
@@ -293,7 +293,7 @@ Qed.
 
 End Lemmas.
 
-End Disp_Precat.
+End Disp_Cat.
 
 (** Redeclare sectional notations globally. *)
 Notation "xx -->[ f ] yy" := (mor_disp xx yy f) (at level 50, yy at next level).
@@ -316,40 +316,40 @@ Notation "#?' x" := (transportb _ _ x) (at level 45) : hide_transport_scope.
 
 Section Isos.
 
-Definition is_iso_disp {C : Precategory} {D : disp_precat_data C}
+Definition is_iso_disp {C : Precategory} {D : disp_cat_data C}
     {x y : C} (f : iso x y) {xx : D x} {yy} (ff : xx -->[f] yy)
   : UU
 := ∑ (gg : yy -->[inv_from_iso f] xx),
      gg ;; ff = transportb _ (iso_after_iso_inv _) (id_disp _)
      × ff ;; gg = transportb _ (iso_inv_after_iso _) (id_disp _).
 
-Definition iso_disp {C : Precategory} {D : disp_precat_data C}
+Definition iso_disp {C : Precategory} {D : disp_cat_data C}
     {x y : C} (f : iso x y) (xx : D x) (yy : D y)
   := ∑ ff : xx -->[f] yy, is_iso_disp f ff.
 
-Definition iso_disp_pair {C : Precategory} {D : disp_precat_data C}
+Definition iso_disp_pair {C : Precategory} {D : disp_cat_data C}
     {x y : C} {f : iso x y} {xx : D x} {yy : D y}
     (ff : xx -->[f] yy) (is : is_iso_disp f ff)
     : iso_disp _ _ _ 
   := (ff,, is).
 
 
-Definition mor_disp_from_iso {C : Precategory} {D : disp_precat_data C}
+Definition mor_disp_from_iso {C : Precategory} {D : disp_cat_data C}
     {x y : C} {f : iso x y}{xx : D x} {yy : D y} 
     (i : iso_disp f xx yy) : _ -->[ _ ] _ := pr1 i.
 Coercion mor_disp_from_iso : iso_disp >-> mor_disp.
 
-Definition is_iso_disp_from_iso {C : Precategory} {D : disp_precat_data C}
+Definition is_iso_disp_from_iso {C : Precategory} {D : disp_cat_data C}
     {x y : C} {f : iso x y}{xx : D x} {yy : D y}
     (i : iso_disp f xx yy) : is_iso_disp f i := pr2 i.
 Coercion is_iso_disp_from_iso : iso_disp >-> is_iso_disp.
 
-Definition inv_mor_disp_from_iso {C : Precategory} {D : disp_precat_data C}
+Definition inv_mor_disp_from_iso {C : Precategory} {D : disp_cat_data C}
     {x y : C} {f : iso x y}{xx : D x} {yy : D y} 
     {ff : xx -->[f] yy} (i : is_iso_disp f ff)
   : _ -->[ _ ] _ := pr1 i.
 
-Definition iso_disp_after_inv_mor {C : Precategory} {D : disp_precat_data C}
+Definition iso_disp_after_inv_mor {C : Precategory} {D : disp_cat_data C}
     {x y : C} {f : iso x y}{xx : D x} {yy : D y} 
     {ff : xx -->[f] yy} (i : is_iso_disp f ff)
   : inv_mor_disp_from_iso i ;; ff
@@ -358,7 +358,7 @@ Proof.
   apply (pr2 i).
 Qed.
 
-Definition inv_mor_after_iso_disp {C : Precategory} {D : disp_precat_data C}
+Definition inv_mor_after_iso_disp {C : Precategory} {D : disp_cat_data C}
     {x y : C} {f : iso x y}{xx : D x} {yy : D y} 
     {ff : xx -->[f] yy} (i : is_iso_disp f ff)
   : ff ;; inv_mor_disp_from_iso i
@@ -367,7 +367,7 @@ Proof.
   apply (pr2 (pr2 i)).
 Qed.
 
-Lemma isaprop_is_iso_disp {C : Precategory} {D : disp_precat C}
+Lemma isaprop_is_iso_disp {C : Precategory} {D : disp_cat C}
     {x y : C} (f : iso x y) {xx : D x} {yy} (ff : xx -->[f] yy)
   : isaprop (is_iso_disp f ff).
 Proof.
@@ -396,7 +396,7 @@ Proof.
     apply homset_property.
 Qed.
 
-Lemma isaset_iso_disp {C : Precategory} {D : disp_precat C}
+Lemma isaset_iso_disp {C : Precategory} {D : disp_cat C}
   {x y} (f : iso x y) (xx : D x) (yy : D y)
   : isaset (iso_disp f xx yy).
 Proof.
@@ -405,7 +405,7 @@ Proof.
   - intros. apply isasetaprop, isaprop_is_iso_disp.
 Qed.
 
-Lemma eq_iso_disp {C : Precategory} {D : disp_precat C}
+Lemma eq_iso_disp {C : Precategory} {D : disp_cat C}
     {x y : C} (f : iso x y) 
     {xx : D x} {yy} (ff ff' : iso_disp f xx yy)
   : pr1 ff = pr1 ff' -> ff = ff'.
@@ -413,7 +413,7 @@ Proof.
   apply subtypeEquality; intro; apply isaprop_is_iso_disp.
 Qed.
 
-Lemma is_iso_disp_transportf {C : Precategory} {D : disp_precat C}
+Lemma is_iso_disp_transportf {C : Precategory} {D : disp_cat C}
     {x y : C} {f f' : iso x y} (e : f = f')
     {xx : D x} {yy} {ff : xx -->[f] yy}
     (is : is_iso_disp _ ff)
@@ -423,7 +423,7 @@ Proof.
   apply is.
 Qed.
 
-Lemma transportf_iso_disp {C : Precategory} {D : disp_precat C}
+Lemma transportf_iso_disp {C : Precategory} {D : disp_cat C}
     {x y : C} {xx : D x} {yy} 
     {f f' : iso x y} (e : f = f')
     (ff : iso_disp f xx yy)
@@ -433,7 +433,7 @@ Proof.
   destruct e; apply idpath.
 Qed.
 
-Definition is_iso_inv_from_iso_disp {C : Precategory} {D : disp_precat_data C}
+Definition is_iso_inv_from_iso_disp {C : Precategory} {D : disp_cat_data C}
     {x y : C} {f : iso x y}{xx : D x} {yy : D y} 
     (i : iso_disp f xx yy) 
     :
@@ -460,7 +460,7 @@ Proof.
       try apply homset_property; apply idpath ).
 Defined.
 
-Definition is_iso_inv_from_is_iso_disp {C : Precategory} {D : disp_precat_data C}
+Definition is_iso_inv_from_is_iso_disp {C : Precategory} {D : disp_cat_data C}
     {x y : C} {f : iso x y}{xx : D x} {yy : D y} 
     (ff : xx -->[f] yy)
     (i : is_iso_disp f ff) 
@@ -470,7 +470,7 @@ Proof.
   apply (is_iso_inv_from_iso_disp (ff ,, i)).
 Defined.
 
-Definition iso_inv_from_iso_disp {C : Precategory} {D : disp_precat_data C}
+Definition iso_inv_from_iso_disp {C : Precategory} {D : disp_cat_data C}
     {x y : C} {f : iso x y}{xx : D x} {yy : D y} 
     (i : iso_disp f xx yy) 
     :
@@ -480,7 +480,7 @@ Proof.
   apply is_iso_inv_from_iso_disp.
 Defined.
 
-Definition iso_disp_comp {C : Precategory} {D : disp_precat C}
+Definition iso_disp_comp {C : Precategory} {D : disp_cat C}
     {x y z : C} {f : iso x y} {g : iso y z} {xx : D x} {yy : D y} {zz : D z}
     (ff : iso_disp f xx yy) (gg : iso_disp g yy zz) 
     :
@@ -539,7 +539,7 @@ Proof.
         try apply homset_property; apply idpath.
 Defined.
 
-Definition id_is_iso_disp {C} {D : disp_precat C} {x : C} (xx : D x)
+Definition id_is_iso_disp {C} {D : disp_cat C} {x : C} (xx : D x)
   : is_iso_disp (identity_iso x) (id_disp xx).
 Proof.
   exists (id_disp _); split.
@@ -549,11 +549,11 @@ Proof.
     apply maponpaths_2, homset_property.
 Defined.
 
-Definition identity_iso_disp {C} {D : disp_precat C} {x : C} (xx : D x)
+Definition identity_iso_disp {C} {D : disp_cat C} {x : C} (xx : D x)
   : iso_disp (identity_iso x) xx xx
 := (_ ,, id_is_iso_disp _).
 
-Lemma idtoiso_disp {C} {D : disp_precat C}
+Lemma idtoiso_disp {C} {D : disp_cat C}
     {x x' : C} (e : x = x')
     {xx : D x} {xx' : D x'} (ee : transportf _ e xx = xx')
   : iso_disp (idtoiso e) xx xx'.
@@ -561,7 +561,7 @@ Proof.
   destruct e, ee; apply identity_iso_disp.
 Defined.
 
-Lemma idtoiso_fiber_disp {C} {D : disp_precat C} {x : C}
+Lemma idtoiso_fiber_disp {C} {D : disp_cat C} {x : C}
     {xx xx' : D x} (ee : xx = xx')
   : iso_disp (identity_iso x) xx xx'.
 Proof.
@@ -569,7 +569,7 @@ Proof.
 Defined.
 
 
-Lemma iso_disp_precomp {C : Precategory} {D : disp_precat C}
+Lemma iso_disp_precomp {C : Precategory} {D : disp_cat C}
     {x y : C} (f : iso x y) 
     {xx : D x} {yy} (ff : iso_disp f xx yy)
   : forall (y' : C) (f' : y --> y') (yy' : D y'), 
@@ -580,7 +580,6 @@ Proof.
   + intro X.
     set (XR := (pr1 (pr2 ff)) ;; X).
     set (XR' := transportf _ (assoc _ _ _   ) XR).
-(*    Search (inv_from_iso _  ). *)
     set (XRRT := transportf _ 
            (maponpaths (fun xyz => (xyz ;; f')%mor) (iso_after_iso_inv f)) 
            XR').
@@ -616,7 +615,7 @@ Proof.
     apply (pr2 C). apply idpath.
 Defined.
 
-Lemma iso_disp_postcomp {C : Precategory} {D : disp_precat C}
+Lemma iso_disp_postcomp {C : Precategory} {D : disp_cat C}
     {x y : C} (i : iso x y) 
     {xx : D x} {yy} (ii : iso_disp i xx yy)
   : forall (x' : C) (f' : x' --> x) (xx' : D x'), 
@@ -665,7 +664,7 @@ Defined.
 
 (* Useful when you want to prove [is_iso_disp], and you have some lemma [awesome_lemma] which gives that, but over a different (or just opaque) proof of [is_iso] in the base.  Then you can use [eapply is_iso_disp_independent_of_is_iso; apply awesome_lemma.]. *)  
 Lemma is_iso_disp_independent_of_is_iso
-    {C : Precategory} {D : disp_precat_data C}
+    {C : Precategory} {D : disp_cat_data C}
     {x y : C} (f : iso x y) {xx : D x} {yy} (ff : xx -->[f] yy)
     {H'f : is_iso f} (Hff : is_iso_disp ((f : _ --> _),,H'f) ff)
   : is_iso_disp f ff.
@@ -683,7 +682,7 @@ End Isos.
 Section Utilities.
 
 (** Note: closely analogous to [idtoiso_precompose].  We name it differently to fit the convention of naming equalities according to their LHS, for reference during calculation. *)
-Lemma transportf_precompose_disp {C} {D : disp_precat C}
+Lemma transportf_precompose_disp {C} {D : disp_cat C}
     {c d : C} (f : c --> d )
     {cc cc' : D c} (e : cc = cc') {dd} (ff : cc -->[f] dd)
   : transportf (fun xx : D c => xx -->[f] dd) e ff
@@ -698,7 +697,7 @@ Qed.
 (* TODO: add dual [transportf_postcompose_disp]. *)
 
 Definition precomp_with_iso_disp_is_inj
-    {C : Precategory} {D : disp_precat C}
+    {C : Precategory} {D : disp_cat C}
     {a b c : C} {i : iso a b} {f : b --> c}
     {aa : D a} {bb} {cc} (ii : iso_disp i aa bb) {ff ff' : bb -->[f] cc}
   : (ii ;; ff = ii ;; ff') -> ff = ff'.
@@ -732,42 +731,42 @@ End Utilities.
 (** ** Saturation: displayed categories *)
 Section Categories.
 
-(** The current [is_category_disp] is certainly the correct definition in the case where the base precategory [C] is a category.
+(** The current [is_univalent_disp] is certainly the correct definition in the case where the base precategory [C] is a category.
 
 When [C] is a general precategory, it’s not quite clear if this definition is correct, or if some other definition might be better. *)
 
-Definition is_category_disp {C} (D : disp_precat C)
+Definition is_univalent_disp {C} (D : disp_cat C)
   := forall x x' (e : x = x') {xx : D x} {xx' : D x'},
        isweq (λ ee, @idtoiso_disp _ _ _ _ e xx xx' ee).
 
 (* TODO: maybe rename further.  *)
-Lemma is_category_disp_from_fibers {C} {D : disp_precat C}
+Lemma is_univalent_disp_from_fibers {C} {D : disp_cat C}
   : (∏ x (xx xx' : D x), isweq (fun e : xx = xx' => idtoiso_fiber_disp e))
-  -> is_category_disp D.
+  -> is_univalent_disp D.
 Proof.
   intros H x x' e. destruct e. apply H.
 Qed.
 
 Definition disp_category C
-  := ∑ D : disp_precat C, is_category_disp D.
+  := ∑ D : disp_cat C, is_univalent_disp D.
 
 Definition disp_category_pair
-    {C} {D : disp_precat C} (H : is_category_disp D)
+    {C} {D : disp_cat C} (H : is_univalent_disp D)
   : disp_category C
 := (D,,H).
 
-Definition disp_precat_of_disp_cat {C} (D : disp_category C)
-  : disp_precat C
+Definition disp_cat_of_disp_cat {C} (D : disp_category C)
+  : disp_cat C
 := pr1 D.
-Coercion disp_precat_of_disp_cat : disp_category >-> disp_precat.
+Coercion disp_cat_of_disp_cat : disp_category >-> disp_cat.
 
-Definition category_is_category_disp {C} (D : disp_category C)
-  : is_category_disp D
+Definition category_is_univalent_disp {C} (D : disp_category C)
+  : is_univalent_disp D
 := pr2 D.
-Coercion category_is_category_disp : disp_category >-> is_category_disp.
+Coercion category_is_univalent_disp : disp_category >-> is_univalent_disp.
 
 Definition isotoid_disp
-    {C} {D : disp_precat C} (D_cat : is_category_disp D)
+    {C} {D : disp_cat C} (D_cat : is_univalent_disp D)
     {c c' : C} (e : c = c') {d : D c} {d'} (i : iso_disp (idtoiso e) d d')
   : transportf _ e d = d'.
 Proof.
@@ -775,7 +774,7 @@ Proof.
 Defined.
 
 Definition idtoiso_isotoid_disp
-    {C} {D : disp_precat C} (D_cat : is_category_disp D)
+    {C} {D : disp_cat C} (D_cat : is_univalent_disp D)
     {c c' : C} (e : c = c') {d : D c} {d'} (i : iso_disp (idtoiso e) d d')
   : idtoiso_disp e (isotoid_disp D_cat e i) = i.
 Proof.
@@ -783,7 +782,7 @@ Proof.
 Qed.
 
 Definition isotoid_idtoiso_disp
-    {C} {D : disp_precat C} (D_cat : is_category_disp D)
+    {C} {D : disp_cat C} (D_cat : is_univalent_disp D)
     {c c' : C} (e : c = c') {d : D c} {d'} (ee : transportf _ e d = d')
   : isotoid_disp D_cat e (idtoiso_disp e ee) = ee.
 Proof.
@@ -800,7 +799,7 @@ End Categories.
 (* Any displayed precategory has a total precategory, with a forgetful functor to the base category. *)
 Section Total_Precat.
 
-Context {C : Precategory} (D : disp_precat C).
+Context {C : Precategory} (D : disp_cat C).
 
 Definition total_precat_ob_mor : precategory_ob_mor.
 Proof.
@@ -1047,7 +1046,7 @@ Definition total_iso_equiv (xx yy : total_precat)
   ≃ iso xx yy
 := weqpair _ (total_iso_isweq xx yy).
 
-Lemma is_category_total_category (CC : is_category C) (DD : is_category_disp D)
+Lemma is_category_total_category (CC : is_category C) (DD : is_univalent_disp D)
   : is_category (total_precat).
 Proof.
   split. Focus 2. apply homset_property.
@@ -1074,7 +1073,7 @@ Arguments pr1_precat [C] D.
 
 (** * Functors 
 
-- Reindexing of displayed precats along functors: [reindex_disp_precat]
+- Reindexing of displayed precats along functors: [reindex_disp_cat]
 - Functors into displayed precats, lifting functors into the base: [functor_lifting]
 - Functors between displayed precats, over functors between the bases: [disp_functor]
 - Natural transformations between these: [disp_nat_trans] *)
@@ -1083,15 +1082,15 @@ Arguments pr1_precat [C] D.
 
 Section Reindexing.
 
-Context {C' C : Precategory} (F : functor C' C) (D : disp_precat C).
+Context {C' C : Precategory} (F : functor C' C) (D : disp_cat C).
 
-Definition reindex_disp_precat_ob_mor : disp_precat_ob_mor C'.
+Definition reindex_disp_cat_ob_mor : disp_cat_ob_mor C'.
 Proof.
   exists (fun c => D (F c)).
   intros x y xx yy f. exact (xx -->[# F f] yy).
 Defined.
 
-Definition reindex_disp_precat_id_comp : disp_precat_id_comp C' reindex_disp_precat_ob_mor.
+Definition reindex_disp_cat_id_comp : disp_cat_id_comp C' reindex_disp_cat_ob_mor.
 Proof.
   apply tpair.
   - simpl; intros x xx.
@@ -1102,10 +1101,10 @@ Proof.
     apply functor_comp. exact (ff ;; gg).    
 Defined.
 
-Definition reindex_disp_precat_data : disp_precat_data C'
-  := (_ ,, reindex_disp_precat_id_comp).
+Definition reindex_disp_cat_data : disp_cat_data C'
+  := (_ ,, reindex_disp_cat_id_comp).
 
-Definition reindex_disp_precat_axioms : disp_precat_axioms C' reindex_disp_precat_data.
+Definition reindex_disp_cat_axioms : disp_cat_axioms C' reindex_disp_cat_data.
 Proof.
   repeat apply tpair; cbn.
   - intros x y f xx yy ff. 
@@ -1136,8 +1135,8 @@ Proof.
   - intros; apply homsets_disp.
 Qed.
 
-Definition reindex_disp_precat : disp_precat C'
-  := (_ ,, reindex_disp_precat_axioms).
+Definition reindex_disp_cat : disp_cat C'
+  := (_ ,, reindex_disp_cat_axioms).
 
 End Reindexing.
 
@@ -1149,42 +1148,42 @@ We call it a _section_ (though we define it intrinsically, not as a section in a
 
 Section Sections.
 
-Definition section_disp_data {C} (D : disp_precat C) : UU
+Definition section_disp_data {C} (D : disp_cat C) : UU
   := ∑ (Fob : forall x:C, D x),
        (forall (x y:C) (f:x --> y), Fob x -->[f] Fob y).
 
-Definition section_disp_on_objects {C} {D : disp_precat C}
+Definition section_disp_on_objects {C} {D : disp_cat C}
   (F : section_disp_data D) (x : C)
 := pr1 F x : D x.
 
 Coercion section_disp_on_objects : section_disp_data >-> Funclass.
 
-Definition section_disp_on_morphisms {C} {D : disp_precat C}
+Definition section_disp_on_morphisms {C} {D : disp_cat C}
   (F : section_disp_data D) {x y : C} (f : x --> y)
 := pr2 F _ _ f : F x -->[f] F y.
 
 Notation "# F" := (section_disp_on_morphisms F)
   (at level 3) : mor_disp_scope.
 
-Definition section_disp_axioms {C} {D : disp_precat C}
+Definition section_disp_axioms {C} {D : disp_cat C}
   (F : section_disp_data D) : UU
 := ((forall x:C, # F (identity x) = id_disp (F x))
   × (forall (x y z : C) (f : x --> y) (g : y --> z),
       # F (f ;; g)%mor = (# F f) ;; (# F g))).
 
-Definition section_disp {C} (D : disp_precat C) : UU
+Definition section_disp {C} (D : disp_cat C) : UU
   := total2 (@section_disp_axioms C D).
 
-Definition section_disp_data_from_section_disp {C} {D : disp_precat C}
+Definition section_disp_data_from_section_disp {C} {D : disp_cat C}
   (F : section_disp D) := pr1 F.
 
 Coercion section_disp_data_from_section_disp
   : section_disp >-> section_disp_data.
 
-Definition section_disp_id {C} {D : disp_precat C} (F : section_disp D)
+Definition section_disp_id {C} {D : disp_cat C} (F : section_disp D)
   := pr1 (pr2 F).
 
-Definition section_disp_comp {C} {D : disp_precat C} (F : section_disp D)
+Definition section_disp_comp {C} {D : disp_cat C} (F : section_disp D)
   := pr2 (pr2 F).
 
 End Sections.
@@ -1196,8 +1195,8 @@ Notation "# F" := (section_disp_on_morphisms F)
   (at level 3) : mor_disp_scope.
 
 Definition functor_lifting
-  {C C' : Precategory} (D : disp_precat C) (F : functor C' C) 
-  := section_disp (reindex_disp_precat F D).
+  {C C' : Precategory} (D : disp_cat C) (F : functor C' C) 
+  := section_disp (reindex_disp_cat F D).
 
 Identity Coercion section_from_functor_lifting
   : functor_lifting >-> section_disp.
@@ -1205,7 +1204,7 @@ Identity Coercion section_from_functor_lifting
 (** Note: perhaps it would be better to define [functor_lifting] directly? 
   Reindexed displayed-precats are a bit confusing to work in, since a term like [id_disp xx] is ambiguous: it can mean both the identity in the original displayed category, or the identity in the reindexing, which is nearly but not quite the same.  This shows up already in the proofs of [lifted_functor_axioms] below. *)
 
-Definition lifted_functor_data {C C' : Precategory} {D : disp_precat C}
+Definition lifted_functor_data {C C' : Precategory} {D : disp_cat C}
   {F : functor C' C} (FF : functor_lifting D F)
   : functor_data C' (total_precat D).
 Proof.
@@ -1213,7 +1212,7 @@ Proof.
   intros x y f. exists (# F f)%cat. exact (# FF f).
 Defined.
 
-Definition lifted_functor_axioms {C C' : Precategory} {D : disp_precat C}
+Definition lifted_functor_axioms {C C' : Precategory} {D : disp_cat C}
   {F : functor C' C} (FF : functor_lifting D F)
   : is_functor (lifted_functor_data FF).
 Proof.
@@ -1228,7 +1227,7 @@ Proof.
     cbn. apply transportfbinv.
 Qed.
 
-Definition lifted_functor {C C' : Precategory} {D : disp_precat C}
+Definition lifted_functor {C C' : Precategory} {D : disp_cat C}
   {F : functor C' C} (FF : functor_lifting D F)
   : functor C' (total_precat D)
 := (_ ,, lifted_functor_axioms FF).
@@ -1241,7 +1240,7 @@ End Functor_Lifting.
 
 [[
 Definition disp_functor {C C' : Precategory} (F : functor C C')
-    (D : disp_precat C) (D' : disp_precat C')
+    (D : disp_cat C) (D' : disp_cat C')
   := functor_lifting D' (functor_composite (pr1_precat D) F). 
 ]]
 
@@ -1252,13 +1251,13 @@ TODO: reassess this design decision after some experience using it! *)
 Section Disp_Functor.
 
 Definition disp_functor_data {C' C : precategory_data} (F : functor_data C' C)
-  (D' : disp_precat_data C') (D : disp_precat_data C)
+  (D' : disp_cat_data C') (D : disp_cat_data C)
 := ∑ (Fob : ∏ x, D' x -> D (F x)),
      ∏ x y (xx : D' x) (yy : D' y) (f : x --> y),
        (xx -->[f] yy) -> (Fob _ xx -->[ # F f ] Fob _ yy).
 
 Definition disp_functor_on_objects {C' C : precategory_data} {F : functor_data C' C}
-    {D' : disp_precat_data C'} {D : disp_precat_data C}
+    {D' : disp_cat_data C'} {D : disp_cat_data C}
     (FF : disp_functor_data F D' D) {x : C'} (xx : D' x)
   : D (F x)
 := pr1 FF x xx.
@@ -1271,7 +1270,7 @@ Coercion disp_functor_on_objects : disp_functor_data >-> Funclass.
   If anyone knows a way to avoid this, we would be happy to hear it! *)
 
 Definition disp_functor_on_morphisms {C' C : precategory_data} {F : functor_data C' C}
-    {D' : disp_precat_data C'} {D : disp_precat_data C}
+    {D' : disp_cat_data C'} {D : disp_cat_data C}
     (FF : disp_functor_data F D' D)
     {x y : C'} {xx : D' x} {yy} {f : x --> y} (ff : xx -->[f] yy)
   : (FF _ xx) -->[ # F f ] (FF _ yy)
@@ -1281,7 +1280,7 @@ Notation "# F" := (disp_functor_on_morphisms F)
   (at level 3) : mor_disp_scope.
 
 Definition disp_functor_axioms {C' C : Precategory} {F : functor C' C}
-  {D' : disp_precat C'} {D : disp_precat C} (FF : disp_functor_data F D' D)
+  {D' : disp_cat C'} {D : disp_cat C} (FF : disp_functor_data F D' D)
 :=  (∏ x (xx : D' x),
       # FF (id_disp xx) = transportb _ (functor_id F x) (id_disp (FF _ xx)))
   × (∏ x y z (xx : D' x) yy zz (f : x --> y) (g : y --> z)
@@ -1290,7 +1289,7 @@ Definition disp_functor_axioms {C' C : Precategory} {F : functor C' C}
       = transportb _ (functor_comp F f g) (# FF ff ;; # FF gg)).
 
 Lemma isaprop_disp_functor_axioms {C' C : Precategory} {F : functor C' C}
-  {D' : disp_precat C'} {D : disp_precat C} (FF : disp_functor_data F D' D)
+  {D' : disp_cat C'} {D : disp_cat C} (FF : disp_functor_data F D' D)
   : isaprop (disp_functor_axioms FF).
 Proof.
   apply isapropdirprod;
@@ -1299,11 +1298,11 @@ Proof.
 Qed.    
 
 Definition disp_functor {C' C : Precategory} (F : functor C' C)
-  (D' : disp_precat C') (D : disp_precat C)
+  (D' : disp_cat C') (D : disp_cat C)
 := ∑ FF : disp_functor_data F D' D, disp_functor_axioms FF.
 
 Definition disp_functor_data_from_disp_functor
-    {C' C} {F} {D' : disp_precat C'} {D : disp_precat C}
+    {C' C} {F} {D' : disp_cat C'} {D : disp_cat C}
     (FF : disp_functor F D' D)
   : disp_functor_data F D' D
 := pr1 FF.
@@ -1311,13 +1310,13 @@ Definition disp_functor_data_from_disp_functor
 Coercion disp_functor_data_from_disp_functor
   : disp_functor >-> disp_functor_data.
 
-Definition disp_functor_id {C' C} {F} {D' : disp_precat C'} {D : disp_precat C}
+Definition disp_functor_id {C' C} {F} {D' : disp_cat C'} {D : disp_cat C}
     (FF : disp_functor F D' D)
     {x} (xx : D' x)
   : # FF (id_disp xx) = transportb _ (functor_id F x) (id_disp (FF _ xx))
 := pr1 (pr2 FF) x xx.
 
-Definition disp_functor_comp {C' C} {F} {D' : disp_precat C'} {D : disp_precat C}
+Definition disp_functor_comp {C' C} {F} {D' : disp_cat C'} {D : disp_cat C}
     (FF : disp_functor F D' D)
     {x y z} {xx : D' x} {yy} {zz} {f : x --> y} {g : y --> z}
     (ff : xx -->[f] yy) (gg : yy -->[g] zz)
@@ -1326,7 +1325,7 @@ Definition disp_functor_comp {C' C} {F} {D' : disp_precat C'} {D : disp_precat C
 := pr2 (pr2 FF) _ _ _ _ _ _ _ _ ff gg.
 
 (** variant access function *)
-Definition disp_functor_comp_var {C' C} {F} {D' : disp_precat C'} {D : disp_precat C}
+Definition disp_functor_comp_var {C' C} {F} {D' : disp_cat C'} {D : disp_cat C}
     (FF : disp_functor F D' D)
     {x y z} {xx : D' x} {yy} {zz} {f : x --> y} {g : y --> z}
     (ff : xx -->[f] yy) (gg : yy -->[g] zz)
@@ -1339,7 +1338,7 @@ Defined.
 
 (** Useful transport lemma for [disp_functor]. *)
 Lemma disp_functor_transportf {C' C : Precategory}
-  {D' : disp_precat C'} {D : disp_precat C}
+  {D' : disp_cat C'} {D : disp_cat C}
   (F : functor C' C) (FF : disp_functor F D' D)
   (x' x : C') (f' f : x' --> x) (p : f' = f)
   (xx' : D' x') (xx : D' x)
@@ -1402,7 +1401,7 @@ Proof.
 Defined.
 
 Definition disp_functor_identity
-    {C : Precategory} (D : disp_precat C)
+    {C : Precategory} (D : disp_cat C)
   : disp_functor (functor_identity _ ) D D.
 Proof.
   mkpair.
@@ -1420,7 +1419,7 @@ Section Functors_on_isos.
 (* TODO: functor_on_inv_from_iso should have implicit arguments *)
 
 Lemma disp_functor_on_iso_disp_aux1 {C C'} {F} 
-    {D : disp_precat C} {D' : disp_precat C'}
+    {D : disp_cat C} {D' : disp_cat C'}
     (FF : disp_functor F D D')
     {x y} {xx : D x} {yy} {f : iso x y} 
     (ff : xx -->[f] yy)
@@ -1442,7 +1441,7 @@ Proof.
 Qed.
 
 Lemma disp_functor_on_iso_disp_aux2 {C C'} {F} 
-    {D : disp_precat C} {D' : disp_precat C'}
+    {D : disp_cat C} {D' : disp_cat C'}
     (FF : disp_functor F D D')
     {x y} {xx : D x} {yy} {f : iso x y} 
     (ff : xx -->[f] yy)
@@ -1468,7 +1467,7 @@ Qed.
 (** TODO: consider naming *)
 (* Undelimit Scope transport. *)
 Definition disp_functor_on_is_iso_disp {C C'} {F} 
-    {D : disp_precat C} {D' : disp_precat C'}
+    {D : disp_cat C} {D' : disp_cat C'}
     (FF : disp_functor F D D')
     {x y} {xx : D x} {yy} {f : iso x y} 
     {ff : xx -->[f] yy} (Hff : is_iso_disp f ff)
@@ -1481,7 +1480,7 @@ Proof.
 Defined.
 
 Definition disp_functor_on_iso_disp {C C'} {F} 
-    {D : disp_precat C} {D' : disp_precat C'}
+    {D : disp_cat C} {D' : disp_cat C'}
     (FF : disp_functor F D D')
     {x y} {xx : D x} {yy} {f : iso x y} 
     (ff : iso_disp f xx yy)
@@ -1496,7 +1495,7 @@ End Functors_on_isos.
 Section Functor_Properties.
 
 Definition disp_functor_ff {C C'} {F}
-  {D : disp_precat C} {D' : disp_precat C'} (FF : disp_functor F D D')
+  {D : disp_cat C} {D' : disp_cat C'} (FF : disp_functor F D D')
 :=
   ∏ {x y} {xx : D x} {yy : D y} {f : x --> y},
     isweq (fun ff : xx -->[f] yy => # FF ff).
@@ -1506,8 +1505,8 @@ Section ff_reflects_isos.
 (* TODO: Try making FF implicit, since it can be inferred from [FF_ff]. *)
 Context {C C' : Precategory}
         {F : functor C C'}
-        {D : disp_precat C}
-        {D' : disp_precat C'}
+        {D : disp_cat C}
+        {D' : disp_cat C'}
         (FF : disp_functor F D D')
         (FF_ff : disp_functor_ff FF).
 
@@ -1578,7 +1577,7 @@ The second version is better-behaved in general; but the stricter first version 
 *)
 
 Definition disp_functor_ess_split_surj {C' C} {F}
-  {D' : disp_precat C'} {D : disp_precat C} (FF : disp_functor F D D')
+  {D' : disp_cat C'} {D : disp_cat C} (FF : disp_functor F D D')
   : UU
 :=
   ∏ {x} {xx : D' (F x)},
@@ -1588,7 +1587,7 @@ Definition disp_functor_ess_split_surj {C' C} {F}
       iso_disp (functor_on_iso F i) (FF _ yy) xx.
 
 Definition disp_functor_disp_ess_split_surj {C' C} {F}
-  {D' : disp_precat C'} {D : disp_precat C} (FF : disp_functor F D D')
+  {D' : disp_cat C'} {D : disp_cat C} (FF : disp_functor F D D')
   : UU
 := 
   ∏ {x} {xx : D' (F x)},
@@ -1603,7 +1602,7 @@ End Functor_Properties.
 Section Total_Functors.
 
 Definition total_functor_data {C' C} {F}
-    {D' : disp_precat C'} {D : disp_precat C} (FF : disp_functor F D' D)
+    {D' : disp_cat C'} {D : disp_cat C} (FF : disp_functor F D' D)
   : functor_data (total_precat D') (total_precat D).
 Proof.
   mkpair.
@@ -1612,7 +1611,7 @@ Proof.
 Defined.
 
 Definition total_functor_axioms {C' C} {F}
-    {D' : disp_precat C'} {D : disp_precat C} (FF : disp_functor F D' D)
+    {D' : disp_cat C'} {D : disp_cat C} (FF : disp_functor F D' D)
   : is_functor (total_functor_data FF).
 Proof.
   split.
@@ -1627,7 +1626,7 @@ Proof.
 Qed.
 
 Definition total_functor {C' C} {F}
-    {D' : disp_precat C'} {D : disp_precat C} (FF : disp_functor F D' D)
+    {D' : disp_cat C'} {D : disp_cat C} (FF : disp_functor F D' D)
   : functor (total_precat D') (total_precat D)
 := (total_functor_data FF,, total_functor_axioms FF).
 
@@ -1644,9 +1643,9 @@ Notation "# F" := (disp_functor_on_morphisms F)
 
 Section reindexing_disp_functor.
 
-Context {C C' : Precategory} (F : functor C C') (D' : disp_precat C').
+Context {C C' : Precategory} (F : functor C C') (D' : disp_cat C').
 
-Definition reindex_disp_functor : disp_functor F (reindex_disp_precat F D') D'.
+Definition reindex_disp_functor : disp_functor F (reindex_disp_cat F D') D'.
 Proof.
   use tpair.
   - use tpair.
@@ -1669,8 +1668,8 @@ Definition disp_nat_trans_data
   {C' C : precategory_data} 
   {F' F : functor_data C' C}
   (a : forall x, F' x --> F x)
-  {D' : disp_precat_data C'}
-  {D : disp_precat_data C}
+  {D' : disp_cat_data C'}
+  {D : disp_cat_data C}
   (R' : disp_functor_data F' D' D)
   (R : disp_functor_data F D' D) :=
 forall (x : C')  (xx : D' x), 
@@ -1688,8 +1687,8 @@ Definition disp_nat_trans_axioms
   {C' C : precategory_data} 
   {F' F : functor_data C' C}
   {a : nat_trans F' F}
-  {D' : disp_precat_data C'}
-  {D : disp_precat_data C}
+  {D' : disp_cat_data C'}
+  {D : disp_cat_data C}
   {R' : disp_functor_data F' D' D}
   {R : disp_functor_data F D' D}
   (b : disp_nat_trans_data a R' R) : UU
@@ -1704,8 +1703,8 @@ Lemma isaprop_disp_nat_trans_axioms
   {C' C : Precategory} 
   {F' F : functor_data C' C}
   (a : nat_trans F' F)
-  {D' : disp_precat_data C'}
-  {D : disp_precat C}
+  {D' : disp_cat_data C'}
+  {D : disp_cat C}
   {R' : disp_functor_data F' D' D}
   {R : disp_functor_data F D' D}
   (b : disp_nat_trans_data a R' R) 
@@ -1720,8 +1719,8 @@ Definition disp_nat_trans
   {C' C : precategory_data} 
   {F' F : functor_data C' C}
   (a : nat_trans F' F)
-  {D' : disp_precat_data C'}
-  {D : disp_precat_data C}
+  {D' : disp_cat_data C'}
+  {D : disp_cat_data C}
   (R' : disp_functor_data F' D' D)
   (R : disp_functor_data F D' D) : UU :=
   ∑ b : disp_nat_trans_data a R' R,
@@ -1731,8 +1730,8 @@ Definition disp_nat_trans_pr1
   {C' C : precategory_data} 
   {F' F : functor_data C' C}
   {a : nat_trans F' F}
-  {D' : disp_precat_data C'}
-  {D : disp_precat_data C}
+  {D' : disp_cat_data C'}
+  {D : disp_cat_data C}
   {R' : disp_functor_data F' D' D}
   {R : disp_functor_data F D' D}
   (b : disp_nat_trans a R' R) 
@@ -1746,8 +1745,8 @@ Definition disp_nat_trans_ax
   {C' C : precategory_data} 
   {F' F : functor_data C' C}
   {a : nat_trans F' F}
-  {D' : disp_precat_data C'}
-  {D : disp_precat_data C}
+  {D' : disp_cat_data C'}
+  {D : disp_cat_data C}
   {R' : disp_functor_data F' D' D}
   {R : disp_functor_data F D' D}
   (b : disp_nat_trans a R' R)
@@ -1765,8 +1764,8 @@ Lemma disp_nat_trans_ax_var
   {C' C : precategory_data} 
   {F' F : functor_data C' C}
   {a : nat_trans F' F}
-  {D' : disp_precat_data C'}
-  {D : disp_precat_data C}
+  {D' : disp_cat_data C'}
+  {D : disp_cat_data C}
   {R' : disp_functor_data F' D' D}
   {R : disp_functor_data F D' D}
   (b : disp_nat_trans a R' R)
@@ -1788,8 +1787,8 @@ Defined.
 Definition disp_nat_trans_id_ax
   {C' C : Precategory} 
   {F': functor_data C' C}
-  {D' : disp_precat_data C'}
-  {D : disp_precat C}
+  {D' : disp_cat_data C'}
+  {D : disp_cat C}
   (R' : disp_functor_data F' D' D)
   : @disp_nat_trans_axioms _ _ _ _ 
                            (nat_trans_id _ )  
@@ -1807,8 +1806,8 @@ Qed.
 Definition disp_nat_trans_id
   {C' C : Precategory} 
   {F': functor_data C' C}
-  {D' : disp_precat_data C'}
-  {D : disp_precat C}
+  {D' : disp_cat_data C'}
+  {D : disp_cat C}
   (R' : disp_functor_data F' D' D)
   : disp_nat_trans (nat_trans_id F') R' R'.
 Proof.
@@ -1826,8 +1825,8 @@ Definition disp_nat_trans_comp_ax
   {F'' F' F : functor_data C' C}
   {a' : nat_trans F'' F'}
   {a : nat_trans F' F}
-  {D' : disp_precat_data C'}
-  {D : disp_precat C}
+  {D' : disp_cat_data C'}
+  {D : disp_cat C}
   {R'' : disp_functor_data F'' D' D}
   {R' : disp_functor_data F' D' D}
   {R : disp_functor_data F D' D}
@@ -1862,8 +1861,8 @@ Definition disp_nat_trans_comp
   {F'' F' F : functor_data C' C}
   {a' : nat_trans F'' F'}
   {a : nat_trans F' F}
-  {D' : disp_precat_data C'}
-  {D : disp_precat C}
+  {D' : disp_cat_data C'}
+  {D : disp_cat C}
   {R'' : disp_functor_data F'' D' D}
   {R' : disp_functor_data F' D' D}
   {R : disp_functor_data F D' D}

--- a/TypeTheory/Displayed_Cats/DisplayedCatFromCwDM.v
+++ b/TypeTheory/Displayed_Cats/DisplayedCatFromCwDM.v
@@ -46,7 +46,7 @@ Section Displayed_Cat_of_Class_of_Maps.
 
 Context  (D : dm_sub_struct CC).
 
-Definition DM_disp_ob_mor : disp_precat_ob_mor CC.
+Definition DM_disp_ob_mor : disp_cat_ob_mor CC.
 Proof.
   exists (fun Γ => DM_over D Γ).
   simpl; intros Γ Δ p q f. 
@@ -54,8 +54,8 @@ Proof.
            ff ;; q = p ;; f).
 Defined.
 
-(* TODO: consider implicit args of [disp_precat_id_comp]. *)
-Definition DM_disp_id_comp : disp_precat_id_comp _ DM_disp_ob_mor.
+(* TODO: consider implicit args of [disp_cat_id_comp]. *)
+Definition DM_disp_id_comp : disp_cat_id_comp _ DM_disp_ob_mor.
 Proof.
   split.
   - simpl; intros.
@@ -73,10 +73,10 @@ Proof.
         eapply pathsinv0, assoc).
 Defined.
 
-Definition DM_disp_data : disp_precat_data CC
+Definition DM_disp_data : disp_cat_data CC
   := (DM_disp_ob_mor ,, DM_disp_id_comp).
 
-Lemma DM_disp_axioms : disp_precat_axioms CC DM_disp_data.
+Lemma DM_disp_axioms : disp_cat_axioms CC DM_disp_data.
 Proof.
   repeat apply tpair; intros; try apply homset_property.
   - (* id_left_disp *) 
@@ -107,7 +107,7 @@ Proof.
     + intro. apply isasetaprop. apply homset_property.
 Qed.
 
-Definition DM_disp : disp_precat CC
+Definition DM_disp : disp_cat CC
   := (DM_disp_data ,, DM_disp_axioms).
 
 (* TODO: check what naming conventions suggest for this. *)

--- a/TypeTheory/Displayed_Cats/Equivalences.v
+++ b/TypeTheory/Displayed_Cats/Equivalences.v
@@ -77,7 +77,7 @@ Section disp_adjunction.
 Definition disp_adjunction_data {C C' : Precategory} (A : adjunction_data C C') 
            (F := left_functor A) (G := right_functor A)
            (eta := adjunit A) (eps := adjcounit A)
-           (D : disp_precat C) (D' : disp_precat C') : UU
+           (D : disp_cat C) (D' : disp_cat C') : UU
   := ∑ (FF : disp_functor F D D') (GG : disp_functor G D' D),
      (disp_nat_trans eta (disp_functor_identity _ ) 
                      (disp_functor_composite FF GG))
@@ -174,7 +174,7 @@ We give the “bidirectional” version first, and then the “handed” version
 
 (* TODO: consider carefully the graph of coercions in this section; make them more systematic, and whatever we decide on, DOCUMENT the system clearly. *) 
 
-Definition disp_adjunction_id_data {C} (D D' : disp_precat C) : UU
+Definition disp_adjunction_id_data {C} (D D' : disp_cat C) : UU
 := ∑ (FF : disp_functor (functor_identity _) D D')
      (GG : disp_functor (functor_identity _) D' D),
      (disp_nat_trans (nat_trans_id _) 
@@ -183,23 +183,23 @@ Definition disp_adjunction_id_data {C} (D D' : disp_precat C) : UU
             (disp_functor_composite GG FF) (disp_functor_identity _)).
 
 (* TODO: consider naming of these access functions *)
-Definition left_adj_over_id {C} {D D' : disp_precat C}
+Definition left_adj_over_id {C} {D D' : disp_cat C}
   (A : disp_adjunction_id_data D D')
   : disp_functor _ D D'
 := pr1 A.
 Coercion left_adj_over_id
   : disp_adjunction_id_data >-> disp_functor.
 
-Definition right_adj_over_id {C} {D D' : disp_precat C}
+Definition right_adj_over_id {C} {D D' : disp_cat C}
   (A : disp_adjunction_id_data D D')
   : disp_functor _ D' D
 := pr1 (pr2 A).
 
-Definition unit_over_id {C} {D D' : disp_precat C}
+Definition unit_over_id {C} {D D' : disp_cat C}
   (A : disp_adjunction_id_data D D')
 := pr1 (pr2 (pr2 A)).
 
-Definition counit_over_id {C} {D D' : disp_precat C}
+Definition counit_over_id {C} {D D' : disp_cat C}
   (A : disp_adjunction_id_data D D')
 := pr2 (pr2 (pr2 A)).
 
@@ -211,7 +211,7 @@ This roughly follows the pattern of [univalenceStatement], [funextfunStatement],
 *)
 
 
-Definition triangle_1_statement_over_id  {C} {D D' : disp_precat C}
+Definition triangle_1_statement_over_id  {C} {D D' : disp_cat C}
     (A : disp_adjunction_id_data D D')
     (FF := left_adj_over_id A)
     (η := unit_over_id A)
@@ -220,7 +220,7 @@ Definition triangle_1_statement_over_id  {C} {D D' : disp_precat C}
 := ∏ x xx, #FF ( η x xx) ;;  ε _ (FF _ xx) 
             = transportb _ (id_left _ ) (id_disp _) .
 
-Definition triangle_2_statement_over_id  {C} {D D' : disp_precat C}
+Definition triangle_2_statement_over_id  {C} {D D' : disp_cat C}
     (A : disp_adjunction_id_data D D')
     (GG := right_adj_over_id A)
     (η := unit_over_id A)
@@ -229,25 +229,25 @@ Definition triangle_2_statement_over_id  {C} {D D' : disp_precat C}
 := ∏ x xx, η _ (GG x xx) ;; # GG (ε _ xx)
            = transportb _ (id_left _ ) (id_disp _).
 
-Definition form_disp_adjunction_id {C} {D D' : disp_precat C}
+Definition form_disp_adjunction_id {C} {D D' : disp_cat C}
     (A : disp_adjunction_id_data D D')
   : UU
 := triangle_1_statement_over_id A × triangle_2_statement_over_id A.
 
-Definition disp_adjunction_id {C} (D D' : disp_precat C) : UU
+Definition disp_adjunction_id {C} (D D' : disp_cat C) : UU
 := ∑ A : disp_adjunction_id_data D D', form_disp_adjunction_id A.
 
-Definition data_of_disp_adjunction_id {C} {D D' : disp_precat C}
+Definition data_of_disp_adjunction_id {C} {D D' : disp_cat C}
   (A : disp_adjunction_id D D')
 := pr1 A.
 Coercion data_of_disp_adjunction_id
   : disp_adjunction_id >-> disp_adjunction_id_data.
 
-Definition triangle_1_over_id {C} {D D' : disp_precat C}
+Definition triangle_1_over_id {C} {D D' : disp_cat C}
   (A : disp_adjunction_id D D')
 := pr1 (pr2 A).
 
-Definition triangle_2_over_id {C} {D D' : disp_precat C}
+Definition triangle_2_over_id {C} {D D' : disp_cat C}
   (A : disp_adjunction_id D D')
 := pr2 (pr2 A).
 
@@ -257,7 +257,7 @@ Definition triangle_2_over_id {C} {D D' : disp_precat C}
 
 Our choice here does _not_ agree with that of the base UniMath category theory library. TODO: consider these conventions, and eventually harmonise them by changing it either here or in UniMath. *)
 
-Definition right_adjoint_over_id_data {C} {D D' : disp_precat C}
+Definition right_adjoint_over_id_data {C} {D D' : disp_cat C}
   (FF : disp_functor (functor_identity _) D D') : UU
 := ∑ (GG : disp_functor (functor_identity _) D' D),
      (disp_nat_trans (nat_trans_id _) 
@@ -265,14 +265,14 @@ Definition right_adjoint_over_id_data {C} {D D' : disp_precat C}
    × (disp_nat_trans (nat_trans_id _ )
             (disp_functor_composite GG FF) (disp_functor_identity _)).
 
-Definition functor_of_right_adjoint_over_id {C} {D D' : disp_precat C}
+Definition functor_of_right_adjoint_over_id {C} {D D' : disp_cat C}
   {FF : disp_functor _ D D'}
   (GG : right_adjoint_over_id_data FF)
 := pr1 GG.
 Coercion functor_of_right_adjoint_over_id
   : right_adjoint_over_id_data >-> disp_functor.
 
-Definition adjunction_of_right_adjoint_over_id_data {C} {D D' : disp_precat C}
+Definition adjunction_of_right_adjoint_over_id_data {C} {D D' : disp_cat C}
     {FF : disp_functor _ D D'}
     (GG : right_adjoint_over_id_data FF)
   : disp_adjunction_id_data D D'
@@ -280,30 +280,30 @@ Definition adjunction_of_right_adjoint_over_id_data {C} {D D' : disp_precat C}
 Coercion adjunction_of_right_adjoint_over_id_data
   : right_adjoint_over_id_data >-> disp_adjunction_id_data.
 
-Definition right_adjoint_of_disp_adjunction_id_data {C} {D D' : disp_precat C}
+Definition right_adjoint_of_disp_adjunction_id_data {C} {D D' : disp_cat C}
     (A : disp_adjunction_id_data D D')
   : right_adjoint_over_id_data A
 := pr2 A. 
 
-Definition right_adjoint_over_id {C} {D D' : disp_precat C}
+Definition right_adjoint_over_id {C} {D D' : disp_cat C}
   (FF : disp_functor (functor_identity _) D D') : UU
 := ∑ GG : right_adjoint_over_id_data FF,
    form_disp_adjunction_id GG.
 
-Definition data_of_right_adjoint_over_id {C} {D D' : disp_precat C}
+Definition data_of_right_adjoint_over_id {C} {D D' : disp_cat C}
   {FF : disp_functor _ D D'}
   (GG : right_adjoint_over_id FF)
 := pr1 GG.
 Coercion data_of_right_adjoint_over_id
   : right_adjoint_over_id >-> right_adjoint_over_id_data.
 
-Definition adjunction_of_right_adjoint_over_id {C} {D D' : disp_precat C}
+Definition adjunction_of_right_adjoint_over_id {C} {D D' : disp_cat C}
     {FF : disp_functor _ D D'}
     (GG : right_adjoint_over_id FF)
   : disp_adjunction_id D D'
 := (adjunction_of_right_adjoint_over_id_data GG ,, pr2 GG).
 
-Definition right_adjoint_of_disp_adjunction_id {C} {D D' : disp_precat C}
+Definition right_adjoint_of_disp_adjunction_id {C} {D D' : disp_cat C}
     (A : disp_adjunction_id D D')
   : right_adjoint_over_id A
 := (right_adjoint_of_disp_adjunction_id_data A,, pr2 A).
@@ -314,7 +314,7 @@ End Adjunctions.
 Section Equivalences.
 (** ** Equivalences (adjoint and quasi) *)
 
-Definition form_equiv_over_id {C} {D D' : disp_precat C}
+Definition form_equiv_over_id {C} {D D' : disp_cat C}
     (A : disp_adjunction_id_data D D')
     (η := unit_over_id A)
     (ε := counit_over_id A)
@@ -322,44 +322,44 @@ Definition form_equiv_over_id {C} {D D' : disp_precat C}
 := (∏ x xx, is_iso_disp (identity_iso _ ) (η x xx)) 
  × (∏ x xx, is_iso_disp (identity_iso _ ) (ε x xx)).
 
-Definition is_iso_unit_over_id {C} {D D' : disp_precat C}
+Definition is_iso_unit_over_id {C} {D D' : disp_cat C}
   {A : disp_adjunction_id_data D D'}
   (E : form_equiv_over_id A)
 := pr1 E.
 
-Definition is_iso_counit_over_id {C} {D D' : disp_precat C}
+Definition is_iso_counit_over_id {C} {D D' : disp_cat C}
   {A : disp_adjunction_id_data D D'}
   (E : form_equiv_over_id A)
 := pr2 E.
 
-Definition equiv_over_id {C} (D D' : disp_precat C) : UU
+Definition equiv_over_id {C} (D D' : disp_cat C) : UU
 := ∑ A : disp_adjunction_id D D', form_equiv_over_id A.
 
-Definition adjunction_of_equiv_over_id {C} {D D' : disp_precat C}
+Definition adjunction_of_equiv_over_id {C} {D D' : disp_cat C}
   (A : equiv_over_id D D')
 := pr1 A.
 Coercion adjunction_of_equiv_over_id
   : equiv_over_id >-> disp_adjunction_id.
 
-Definition axioms_of_equiv_over_id {C} {D D' : disp_precat C}
+Definition axioms_of_equiv_over_id {C} {D D' : disp_cat C}
   (A : equiv_over_id D D')
 := pr2 A.
 Coercion axioms_of_equiv_over_id
   : equiv_over_id >-> form_equiv_over_id.
 
-Definition is_equiv_over_id {C} {D D' : disp_precat C}
+Definition is_equiv_over_id {C} {D D' : disp_cat C}
   (FF : disp_functor (functor_identity _) D D') : UU
 := ∑ GG : right_adjoint_over_id FF,
    form_equiv_over_id GG.
 
-Definition right_adjoint_of_is_equiv_over_id {C} {D D' : disp_precat C}
+Definition right_adjoint_of_is_equiv_over_id {C} {D D' : disp_cat C}
   {FF : disp_functor _ D D'}
   (E : is_equiv_over_id FF)
 := pr1 E.
 Coercion right_adjoint_of_is_equiv_over_id
   : is_equiv_over_id >-> right_adjoint_over_id.
 
-Definition equiv_of_is_equiv_over_id {C} {D D' : disp_precat C}
+Definition equiv_of_is_equiv_over_id {C} {D D' : disp_cat C}
     {FF : disp_functor _ D D'}
     (E : is_equiv_over_id FF)
   : equiv_over_id D D'
@@ -368,7 +368,7 @@ Coercion equiv_of_is_equiv_over_id
   : is_equiv_over_id >-> equiv_over_id.
 (* Again, don’t worry about the ambiguous path generated here. *)
 
-Definition is_equiv_of_equiv_over_id {CC} {DD DD' : disp_precat CC}
+Definition is_equiv_of_equiv_over_id {CC} {DD DD' : disp_cat CC}
     (E : equiv_over_id DD DD')
   : is_equiv_over_id E
 := (right_adjoint_of_disp_adjunction_id E,, axioms_of_equiv_over_id E).
@@ -382,7 +382,7 @@ Definition is_equiv_of_equiv_over_id {CC} {DD DD' : disp_precat CC}
 Local Open Scope hide_transport_scope.
 
 Lemma triangle_2_from_1_for_equiv_over_id
-  {C} {D D' : disp_precat C}
+  {C} {D D' : disp_cat C}
   (A : disp_adjunction_id_data D D')
   (E : form_equiv_over_id A)
 : triangle_1_statement_over_id A -> triangle_2_statement_over_id A.
@@ -479,7 +479,7 @@ Time Qed.
 (* TODO: [Qed.] takes about 30sec!  [etrans_dep] + [etrans_disp] make it shorter and more readable (see commit 7c1f411a), but make the typechecking time even worse. *) 
 
 Lemma triangle_1_from_2_for_equiv_over_id
-  {C} {D D' : disp_precat C}
+  {C} {D D' : disp_cat C}
   (A : disp_adjunction_id_data D D')
   (E : form_equiv_over_id A)
 : triangle_2_statement_over_id A -> triangle_1_statement_over_id A.
@@ -497,7 +497,7 @@ End Equivalences.
 Section Equiv_from_ff_plus_ess_split.
 (* TODO: consider naming throughout this section!  Especially: anything with [ses] should be fixed. *)
 
-Context {C : Precategory} {D' D : disp_precat C}
+Context {C : Precategory} {D' D : disp_cat C}
         (FF : disp_functor (functor_identity _) D' D)
         (FF_split : disp_functor_disp_ess_split_surj FF)
         (FF_ff : disp_functor_ff FF).
@@ -755,7 +755,7 @@ End Equiv_from_ff_plus_ess_split.
 
 Section Nat_Trans_Disp_Inv.
 
-Context {C : Precategory} {D' D : disp_precat C}
+Context {C : Precategory} {D' D : disp_cat C}
         {FF GG : disp_functor (functor_identity _) D' D}
         (alpha : disp_nat_trans (nat_trans_id _ ) FF GG)
         (Ha : ∏ x xx, is_iso_disp (identity_iso _ ) (alpha x xx)).
@@ -828,7 +828,7 @@ End Nat_Trans_Disp_Inv.
 
 Section Displayed_Equiv_Inv.
 
-Context {C : Precategory} {D' D : disp_precat C}
+Context {C : Precategory} {D' D : disp_cat C}
         (FF : disp_functor (functor_identity _) D' D)
         (isEquiv : is_equiv_over_id FF).
 
@@ -1004,7 +1004,7 @@ Section Equiv_Fibers.
 
 Context {C : Precategory}.
 
-Definition fiber_is_left_adj {D D' : disp_precat C}
+Definition fiber_is_left_adj {D D' : disp_cat C}
   {FF : disp_functor (functor_identity _) D D'}
   (EFF : right_adjoint_over_id FF)
   (c : C)
@@ -1031,7 +1031,7 @@ Proof.
     apply homset_property.
 Defined.
 
-Definition fiber_equiv {D D' : disp_precat C}
+Definition fiber_equiv {D D' : disp_cat C}
   {FF : disp_functor (functor_identity _) D D'}
   (EFF : is_equiv_over_id FF)
   (c : C)

--- a/TypeTheory/Displayed_Cats/Equivalences_bis.v
+++ b/TypeTheory/Displayed_Cats/Equivalences_bis.v
@@ -152,7 +152,7 @@ We give the “bidirectional” version first, and then the “handed” version
 Definition disp_adjunction_data {C C' : Precategory} (A : adjunction_data C C') 
            (F := left_functor A) (G := right_functor A)
            (eta := adjunit A) (eps := adjcounit A)
-           (D : disp_precat C) (D' : disp_precat C') : UU
+           (D : disp_cat C) (D' : disp_cat C') : UU
   := ∑ (FF : disp_functor F D D') (GG : disp_functor G D' D),
      (disp_nat_trans eta (disp_functor_identity _ ) 
                      (disp_functor_composite FF GG))
@@ -201,7 +201,7 @@ Definition triangle_2_statement_over
 
 
 Definition form_disp_adjunction {C C' : Precategory} 
-           (A : adjunction C C') {D : disp_precat C} {D' : disp_precat C'}
+           (A : adjunction C C') {D : disp_cat C} {D' : disp_cat C'}
            (AA : disp_adjunction_data A D D')
   : UU
 := triangle_1_statement_over AA × triangle_2_statement_over AA.
@@ -215,14 +215,14 @@ Coercion data_of_disp_adjunction (C C' : Precategory) (A : adjunction C C')
 
 
 Definition triangle_1_over {C C' : Precategory} 
-           {A : adjunction C C'} {D : disp_precat C}
-           {D' : disp_precat C'} (AA : disp_adjunction A D D')
+           {A : adjunction C C'} {D : disp_cat C}
+           {D' : disp_cat C'} (AA : disp_adjunction A D D')
 : triangle_1_statement_over AA
 := pr1 (pr2 AA).
 
 Definition triangle_2_over {C C' : Precategory} 
-           {A : adjunction C C'} {D : disp_precat C}
-           {D' : disp_precat C'} (AA : disp_adjunction A D D')
+           {A : adjunction C C'} {D : disp_cat C}
+           {D' : disp_cat C'} (AA : disp_adjunction A D D')
 : triangle_2_statement_over AA
 := pr2 (pr2 AA).
 
@@ -233,7 +233,7 @@ Definition triangle_2_over {C C' : Precategory}
 Our choice here does _not_ agree with that of the base UniMath category theory library. TODO: consider these conventions, and eventually harmonise them by changing it either here or in UniMath. *)
 
 Definition right_adjoint_over_data {C C' : Precategory} 
-           {A : adjunction_data C C'} {D : disp_precat C} {D' : disp_precat C'}
+           {A : adjunction_data C C'} {D : disp_cat C} {D' : disp_cat C'}
   (FF : disp_functor (left_functor A) D D') : UU
 := ∑ (GG : disp_functor (right_functor A) D' D),
      (disp_nat_trans (adjunit A) 
@@ -242,7 +242,7 @@ Definition right_adjoint_over_data {C C' : Precategory}
             (disp_functor_composite GG FF) (disp_functor_identity _)).
 
 Definition functor_of_right_adjoint_over {C C' : Precategory} 
-           {A : adjunction_data C C'} {D : disp_precat C} {D' : disp_precat C'}
+           {A : adjunction_data C C'} {D : disp_cat C} {D' : disp_cat C'}
            {FF : disp_functor (left_functor A) D D'}
   (GG : right_adjoint_over_data FF)
 := pr1 GG.
@@ -250,7 +250,7 @@ Coercion functor_of_right_adjoint_over
   : right_adjoint_over_data >-> disp_functor.
 
 Definition adjunction_of_right_adjoint_over_data {C C' : Precategory} 
-           {A : adjunction_data C C'} {D : disp_precat C} {D' : disp_precat C'}
+           {A : adjunction_data C C'} {D : disp_cat C} {D' : disp_cat C'}
            {FF : disp_functor (left_functor A) D D'}
   (GG : right_adjoint_over_data FF)
   : disp_adjunction_data A D D'
@@ -260,21 +260,21 @@ Coercion adjunction_of_right_adjoint_over_data
 
 Definition right_adjoint_of_disp_adjunction_data 
            {C C' : Precategory} {A : adjunction_data C C'} 
-           {D : disp_precat C} {D' : disp_precat C'}
+           {D : disp_cat C} {D' : disp_cat C'}
            (AA : disp_adjunction_data A D D')
   : right_adjoint_over_data (left_adj_over AA) (* coercion does not trigger *)
 := pr2 AA. 
 
 Definition right_adjoint_over 
            {C C' : Precategory} {A : adjunction C C'} 
-           {D : disp_precat C} {D' : disp_precat C'}
+           {D : disp_cat C} {D' : disp_cat C'}
            (FF : disp_functor (left_functor A) D D') : UU
 := ∑ GG : right_adjoint_over_data FF,
    form_disp_adjunction A GG.
 
 Definition data_of_right_adjoint_over 
                       {C C' : Precategory} {A : adjunction C C'} 
-                      {D : disp_precat C} {D' : disp_precat C'}
+                      {D : disp_cat C} {D' : disp_cat C'}
   {FF : disp_functor (left_functor A) D D'}
   (GG : right_adjoint_over FF)
 := pr1 GG.
@@ -282,14 +282,14 @@ Coercion data_of_right_adjoint_over
   : right_adjoint_over >-> right_adjoint_over_data.
 
 Definition adjunction_of_right_adjoint_over {C C' : Precategory}
-           {A : adjunction C C'} {D : disp_precat C} {D' : disp_precat C'}
+           {A : adjunction C C'} {D : disp_cat C} {D' : disp_cat C'}
            (FF : disp_functor (left_functor A) D D')
            (GG : right_adjoint_over FF)
 : disp_adjunction A D D'
 := (adjunction_of_right_adjoint_over_data GG ,, pr2 GG).
 
 Definition right_adjoint_of_disp_adjunction {C C' : Precategory}
-           {A : adjunction C C'} {D : disp_precat C} {D' : disp_precat C'}
+           {A : adjunction C C'} {D : disp_cat C} {D' : disp_cat C'}
            (AA : disp_adjunction A D D')
 : right_adjoint_over (left_adj_over AA)
 := (right_adjoint_of_disp_adjunction_data AA ,, pr2 AA).
@@ -303,7 +303,7 @@ Section Equivalences.
 
 
 Definition form_equiv_over {C C' : Precategory} {E : equivalence_of_precats C C'} 
-           {D : disp_precat C} {D' : disp_precat C'}
+           {D : disp_cat C} {D' : disp_cat C'}
            (AA : disp_adjunction_data E D D') : UU
   := (∏ x xx, is_iso_disp (adjunitiso E x) (unit_over AA x xx))
      ×
@@ -325,37 +325,37 @@ Definition is_iso_counit_over
 := pr2 EE.
 
 Definition equiv_over {C C' : Precategory} (E : adj_equiv C C') 
-           (D : disp_precat C) (D' : disp_precat C')
+           (D : disp_cat C) (D' : disp_cat C')
          : UU
 := ∑ AA : disp_adjunction E D D', @form_equiv_over _ _ E _  _ (pr1 AA).
 (* argument A is not inferred *)
 
 Coercion adjunction_of_equiv_over {C C' : Precategory} (E : adj_equiv C C')
-          {D : disp_precat C} {D': disp_precat C'} (EE : equiv_over E D D')
+          {D : disp_cat C} {D': disp_cat C'} (EE : equiv_over E D D')
 : disp_adjunction _ _ _ := pr1 EE.
 
 
 Coercion axioms_of_equiv_over {C C' : Precategory} (E : adj_equiv C C')
-            {D : disp_precat C} {D': disp_precat C'} 
+            {D : disp_cat C} {D': disp_cat C'} 
             (EE : equiv_over E D D') : form_equiv_over _  
 := pr2 EE.
 
 Definition is_equiv_over {C C' : Precategory} (E : adj_equiv C C')
-           {D : disp_precat C} {D': disp_precat C'} 
+           {D : disp_cat C} {D': disp_cat C'} 
            (FF : disp_functor (left_functor E) D D') : UU
   := ∑ GG : @right_adjoint_over _ _ E _ _ FF, 
             @form_equiv_over _ _ E _ _ GG.
 (* argument E is not inferred *)
 
 Definition right_adjoint_of_is_equiv_over {C C' : Precategory} (E : adj_equiv C C')
-           {D : disp_precat C} {D': disp_precat C'} 
+           {D : disp_cat C} {D': disp_cat C'} 
            {FF : disp_functor (left_functor E) D D'}
            (EE : is_equiv_over E FF) := pr1 EE.
 Coercion right_adjoint_of_is_equiv_over
   : is_equiv_over >-> right_adjoint_over.
 
 Definition equiv_of_is_equiv_over {C C' : Precategory} (E : adj_equiv C C')
-           {D : disp_precat C} {D': disp_precat C'} 
+           {D : disp_cat C} {D': disp_cat C'} 
            {FF : disp_functor (left_functor E) D D'}
            (EE : is_equiv_over E FF)
 : equiv_over E D D'
@@ -366,7 +366,7 @@ Coercion equiv_of_is_equiv_over
 
 (*
 Definition is_equiv_of_equiv_over {C C' : Precategory} (E : adj_equiv C C')
-           {D : disp_precat C} {D': disp_precat C'}
+           {D : disp_cat C} {D': disp_cat C'}
            (EE : equiv_over E D D')
 : is_equiv_over E (left_adj_over EE).
 Proof.
@@ -387,7 +387,7 @@ Local Open Scope hide_transport_scope.
 
 Lemma triangle_2_from_1_for_equiv_over
   {C C' : Precategory} (E : adj_equiv C C')
-  {D : disp_precat C} {D' : disp_precat C'}
+  {D : disp_cat C} {D' : disp_cat C'}
   (AA : disp_adjunction_data E D D')
   (EE : form_equiv_over (E:=E) AA)
 : triangle_1_statement_over (A:=E) AA -> triangle_2_statement_over (A:=E) AA.
@@ -485,7 +485,7 @@ Time Qed.
 
 Lemma triangle_1_from_2_for_equiv_over_id
       {C C' : Precategory} (E : adj_equiv C C')
-      {D : disp_precat C} {D' : disp_precat C'}
+      {D : disp_cat C} {D' : disp_cat C'}
       (AA : disp_adjunction_data E D D')
       (EE : form_equiv_over (E:=E) AA)
 : triangle_2_statement_over (A:=E) AA -> triangle_1_statement_over (A:=E) AA.
@@ -505,8 +505,8 @@ Section Equiv_from_ff_plus_ess_split.
 
 Context {C C' : Precategory} 
         {F : functor C C'}
-        {D : disp_precat C} 
-        {D' : disp_precat C'}
+        {D : disp_cat C} 
+        {D' : disp_cat C'}
         (FF : disp_functor F D D')
         (FF_split : disp_functor_disp_ess_split_surj FF)
         (FF_ff : disp_functor_ff FF).
@@ -794,7 +794,7 @@ End Equiv_from_ff_plus_ess_split.
 (*
 Section Nat_Trans_Disp_Inv.
 
-Context {C : Precategory} {D' D : disp_precat C}
+Context {C : Precategory} {D' D : disp_cat C}
         {FF GG : disp_functor (functor_identity _) D' D}
         (alpha : disp_nat_trans (nat_trans_id _ ) FF GG)
         (Ha : ∏ x xx, is_iso_disp (identity_iso _ ) (alpha x xx)).
@@ -867,7 +867,7 @@ End Nat_Trans_Disp_Inv.
 
 Section Displayed_Equiv_Inv.
 
-Context {C : Precategory} {D' D : disp_precat C}
+Context {C : Precategory} {D' D : disp_cat C}
         (FF : disp_functor (functor_identity _) D' D)
         (isEquiv : is_equiv_over_id FF).
 
@@ -1048,7 +1048,7 @@ Context {C C' : Precategory}.
 (*
 Definition fiber_is_left_adj 
   {A : adjunction C C'}
-  {D : disp_precat C} {D' : disp_precat C'}
+  {D : disp_cat C} {D' : disp_cat C'}
   {FF : disp_functor (left_functor A) D D'}
   (EFF : right_adjoint_over FF)
   (c : C)
@@ -1078,7 +1078,7 @@ Proof.
 Defined.
 *)
 (*
-Definition fiber_equiv {D D' : disp_precat C}
+Definition fiber_equiv {D D' : disp_cat C}
   {FF : disp_functor (functor_identity _) D D'}
   (EFF : is_equiv_over_id FF)
   (c : C)

--- a/TypeTheory/Displayed_Cats/Examples.v
+++ b/TypeTheory/Displayed_Cats/Examples.v
@@ -100,7 +100,7 @@ Proof.
   apply setproperty.
 Qed.
 
-Definition disp_grp : disp_precat hset_Precategory. 
+Definition disp_grp : disp_cat hset_Precategory. 
 Proof.
   use disp_struct.
   - exact grp_structure.
@@ -151,7 +151,7 @@ Proof.
 Qed.
 (** END TODO *)
 
-Definition top_disp_precat_ob_mor : disp_precat_ob_mor HSET.
+Definition top_disp_cat_ob_mor : disp_cat_ob_mor HSET.
 Proof.
   mkpair.
   - intro X. exact (isTopologicalSet (pr1hSet X)).
@@ -159,9 +159,9 @@ Proof.
     apply (@continuous (pr1hSet X,,T) (pr1hSet Y,,U) f).
 Defined.
 
-Definition top_disp_precat_data : disp_precat_data HSET.
+Definition top_disp_cat_data : disp_cat_data HSET.
 Proof.
-  exists top_disp_precat_ob_mor.
+  exists top_disp_cat_ob_mor.
   mkpair.
   - intros X XX. cbn. unfold continuous. intros. 
     unfold continuous_at. cbn. unfold is_lim. cbn.
@@ -172,13 +172,13 @@ Proof.
       assumption.
 Defined.
 
-Definition top_disp_precat_axioms : disp_precat_axioms SET top_disp_precat_data.
+Definition top_disp_cat_axioms : disp_cat_axioms SET top_disp_cat_data.
 Proof.
   repeat split; cbn; intros; try (apply proofirrelevance, isaprop_continuous).
   apply isasetaprop. apply isaprop_continuous.
 Defined.
  
-Definition disp_top : disp_precat SET := _ ,, top_disp_precat_axioms.
+Definition disp_top : disp_cat SET := _ ,, top_disp_cat_axioms.
 
 
 (** ** The displayed arrow category 
@@ -188,14 +188,14 @@ Section Arrow_Disp.
 
 Context (C:Precategory).
 
-Definition arrow_disp_ob_mor : disp_precat_ob_mor (C × C).
+Definition arrow_disp_ob_mor : disp_cat_ob_mor (C × C).
 Proof.
   exists (fun xy : (C × C) => (pr1 xy) --> (pr2 xy)).
   simpl; intros xx' yy' g h ff'. 
     exact (pr1 ff' ;; h = g ;; pr2 ff')%mor.
 Defined.
 
-Definition arrow_id_comp : disp_precat_id_comp _ arrow_disp_ob_mor.
+Definition arrow_id_comp : disp_cat_id_comp _ arrow_disp_ob_mor.
 Proof.
   split.
   - simpl; intros.
@@ -208,16 +208,16 @@ Proof.
     apply pathsinv0, assoc.
 Qed.
 
-Definition arrow_data : disp_precat_data _
+Definition arrow_data : disp_cat_data _
   := (arrow_disp_ob_mor ,, arrow_id_comp).
 
-Lemma arrow_axioms : disp_precat_axioms (C × C) arrow_data.
+Lemma arrow_axioms : disp_cat_axioms (C × C) arrow_data.
 Proof.
   repeat apply tpair; intros; try apply homset_property.
   apply isasetaprop, homset_property. 
 Qed.
 
-Definition arrow_disp : disp_precat (C × C)
+Definition arrow_disp : disp_cat (C × C)
   := (arrow_data ,, arrow_axioms).
 
 End Arrow_Disp.
@@ -233,13 +233,13 @@ Section NAction.
 
 Context (C:Precategory).
 
-Definition NAction_disp_ob_mor : disp_precat_ob_mor C.
+Definition NAction_disp_ob_mor : disp_cat_ob_mor C.
 Proof.
   exists (fun c => c --> c).
   intros x y xx yy f. exact (f ;; yy = xx ;; f)%mor.
 Defined.
 
-Definition NAction_id_comp : disp_precat_id_comp C NAction_disp_ob_mor.
+Definition NAction_id_comp : disp_cat_id_comp C NAction_disp_ob_mor.
 Proof.
   split.
   - simpl; intros.
@@ -252,16 +252,16 @@ Proof.
     apply pathsinv0, assoc.
 Qed.
 
-Definition NAction_data : disp_precat_data C
+Definition NAction_data : disp_cat_data C
   := (NAction_disp_ob_mor ,, NAction_id_comp).
 
-Lemma NAction_axioms : disp_precat_axioms C NAction_data.
+Lemma NAction_axioms : disp_cat_axioms C NAction_data.
 Proof.
   repeat apply tpair; intros; try apply homset_property.
   apply isasetaprop, homset_property. 
 Qed.
 
-Definition NAction_disp : disp_precat C
+Definition NAction_disp : disp_cat C
   := (NAction_data ,, NAction_axioms).
 
 End NAction.
@@ -276,14 +276,14 @@ A presheaf on a (pre)category can be viewed as a fiberwise discrete displayed (p
 
 Section Elements_Disp.
 
-Definition elements_ob_mor : disp_precat_ob_mor SET.
+Definition elements_ob_mor : disp_cat_ob_mor SET.
 Proof.
   use tpair.
   - simpl. exact (fun X => X).
   - simpl. intros X Y x y f. exact (f x = y).
 Defined.
 
-Lemma elements_id_comp : disp_precat_id_comp SET elements_ob_mor.
+Lemma elements_id_comp : disp_cat_id_comp SET elements_ob_mor.
 Proof.
   apply tpair; simpl.
   - intros X x. apply idpath.
@@ -291,24 +291,24 @@ Proof.
     eapply pathscomp0. apply maponpaths, e_fx_y. apply e_gy_z.
 Qed.
 
-Definition elements_data : disp_precat_data SET
+Definition elements_data : disp_cat_data SET
   := (_ ,, elements_id_comp).
 
-Lemma elements_axioms : disp_precat_axioms SET elements_data.
+Lemma elements_axioms : disp_cat_axioms SET elements_data.
 Proof.
   repeat split; intros; try apply setproperty.
   apply isasetaprop; apply setproperty.
 Qed.
 
-Definition elements_universal : disp_precat SET
+Definition elements_universal : disp_cat SET
   := (_ ,, elements_axioms).
 
-Definition disp_precat_of_elements {C : Precategory} (P : functor C SET)
-  := reindex_disp_precat P elements_universal.
+Definition disp_cat_of_elements {C : Precategory} (P : functor C SET)
+  := reindex_disp_cat P elements_universal.
 
 (* TODO: compare to other definitions of this in the library! *)
 Definition precat_of_elements {C : Precategory} (P : functor C SET)
-  := total_precat (disp_precat_of_elements P).
+  := total_precat (disp_cat_of_elements P).
 
 End Elements_Disp.
 
@@ -356,14 +356,14 @@ Proof.
   apply (!assoc _ _ _ ) .
 Qed.
 
-Definition disp_precat_functor_alg : disp_precat C
+Definition disp_cat_functor_alg : disp_cat C
   := disp_struct _ _ 
                  functor_alg_mor 
                  isaprop_functor_alg_mor 
                  functor_alg_id 
                  functor_alg_comp.                                                  
 
-Definition total_functor_alg : Precategory := total_precat disp_precat_functor_alg.
+Definition total_functor_alg : Precategory := total_precat disp_cat_functor_alg.
 
 Lemma isaset_functor_alg_ob : ∏ x : C, isaset (functor_alg_ob x).
 Proof.
@@ -371,9 +371,9 @@ Proof.
   apply homset_property.
 Qed.
 
-Lemma is_disp_category_functor_alg : is_category_disp disp_precat_functor_alg.
+Lemma is_disp_category_functor_alg : is_univalent_disp disp_cat_functor_alg.
 Proof. 
-  use is_category_disp_from_SIP_data.
+  use is_univalent_disp_from_SIP_data.
   - apply isaset_functor_alg_ob.
   - unfold functor_alg_mor.
     intros x a a' H H'.
@@ -383,7 +383,7 @@ Proof.
     apply H'.
 Defined.
 
-Definition iso_cleaving_functor_alg : iso_cleaving disp_precat_functor_alg.
+Definition iso_cleaving_functor_alg : iso_cleaving disp_cat_functor_alg.
 Proof.
   intros c c' i d.
   cbn in *.
@@ -412,10 +412,10 @@ Defined.
 Require Import UniMath.CategoryTheory.limits.graphs.colimits.
 Require Import UniMath.CategoryTheory.limits.graphs.limits.
 
-Local Notation "'π'" := (pr1_precat disp_precat_functor_alg).
+Local Notation "'π'" := (pr1_precat disp_cat_functor_alg).
 
 Definition creates_limits_functor_alg
-  : creates_limits disp_precat_functor_alg.
+  : creates_limits disp_cat_functor_alg.
 Proof.
   intros J D x L isL.
   unfold creates_limit. cbn.
@@ -479,7 +479,7 @@ Proof.
         cbn in XR.
         set (H1:= coneOutCommutes CC). simpl in H1.
         destruct x' as [c a]. cbn.
-        unfold disp_precat_functor_alg in a. cbn in a.
+        unfold disp_cat_functor_alg in a. cbn in a.
         cbn in πCC.
         transparent assert (X : (cone (mapdiagram π D) (F c))).
         { use mk_cone.
@@ -546,11 +546,11 @@ Definition isMonadAlg (Xa : FAlg) : UU
      ×
      (#T')%cat (pr2 Xa) · pr2 Xa = μ T _ · pr2 Xa.
 
-Definition disp_precat_monad_alg_over_functor_alg : disp_precat FAlg
+Definition disp_cat_monad_alg_over_functor_alg : disp_cat FAlg
   := disp_full_sub _ isMonadAlg.
 
-Definition disp_precat_monad_alg : disp_precat C 
-  := sigma_disp_precat disp_precat_monad_alg_over_functor_alg.
+Definition disp_cat_monad_alg : disp_cat C 
+  := sigma_disp_cat disp_cat_monad_alg_over_functor_alg.
 
 End monad_algebras.
 
@@ -562,7 +562,7 @@ Section over_terminal_category.
 
 Variable C : Precategory.
 
-Definition disp_over_unit_data : disp_precat_data unit_category.
+Definition disp_over_unit_data : disp_cat_data unit_category.
 Proof.
   mkpair.
   - mkpair.
@@ -574,7 +574,7 @@ Proof.
       apply (compose (C:=C) f g ).
 Defined.
 
-Definition disp_over_unit_axioms : disp_precat_axioms _ disp_over_unit_data.
+Definition disp_over_unit_axioms : disp_cat_axioms _ disp_over_unit_data.
 Proof.
   repeat split; cbn; intros.
   - apply id_left.
@@ -587,7 +587,7 @@ Proof.
   - apply homset_property.
 Qed.
 
-Definition disp_over_unit : disp_precat _ := _ ,, disp_over_unit_axioms.
+Definition disp_over_unit : disp_cat _ := _ ,, disp_over_unit_axioms.
 
 End over_terminal_category.
 
@@ -596,8 +596,8 @@ Section cartesian_product_pb.
 Variable C C' : Precategory.
 
 
-Definition disp_cartesian : disp_precat C 
-  := reindex_disp_precat (functor_to_unit C) (disp_over_unit C').
+Definition disp_cartesian : disp_cat C 
+  := reindex_disp_cat (functor_to_unit C) (disp_over_unit C').
 
 Definition cartesian : Precategory := total_precat disp_cartesian.
 
@@ -607,7 +607,7 @@ Section arrow.
 
 Variable C : Precategory.
 
-Definition disp_arrow_data : disp_precat_data (cartesian C C).
+Definition disp_arrow_data : disp_cat_data (cartesian C C).
 Proof.
   mkpair.
   - mkpair.
@@ -634,7 +634,7 @@ Proof.
       apply assoc.
 Defined.
 
-Definition disp_arrow_axioms : disp_precat_axioms _ disp_arrow_data.
+Definition disp_arrow_axioms : disp_cat_axioms _ disp_arrow_data.
 Proof.
   repeat split; intros; cbn;
     try apply homset_property.
@@ -642,11 +642,11 @@ Proof.
   apply homset_property.
 Qed.
 
-Definition disp_arrow : disp_precat (cartesian C C) := _ ,, disp_arrow_axioms.
+Definition disp_arrow : disp_cat (cartesian C C) := _ ,, disp_arrow_axioms.
 
 Definition arrow : Precategory := total_precat disp_arrow.
 
-Definition disp_domain : disp_precat C := sigma_disp_precat disp_arrow.
+Definition disp_domain : disp_cat C := sigma_disp_cat disp_arrow.
 
 Definition total_domain := total_precat disp_domain.
 
@@ -656,14 +656,14 @@ Section cartesian_product.
 
 Variables C C' : Precategory.
 
-Definition disp_cartesian_ob_mor : disp_precat_ob_mor C.
+Definition disp_cartesian_ob_mor : disp_cat_ob_mor C.
 Proof.
   mkpair.
   - exact (fun c => C').
   - cbn. intros x y x' y' f. exact (C'⟦x', y'⟧).
 Defined.
 
-Definition disp_cartesian_data : disp_precat_data C.
+Definition disp_cartesian_data : disp_cat_data C.
 Proof.
   exists disp_cartesian_ob_mor.
   mkpair; cbn. 
@@ -671,7 +671,7 @@ Proof.
   - intros ? ? ? ? ? ? ? ? f g. apply (f · g).
 Defined.
 
-Definition disp_cartesian_axioms : disp_precat_axioms _ disp_cartesian_data.
+Definition disp_cartesian_axioms : disp_cat_axioms _ disp_cartesian_data.
 Proof.
   repeat split; intros; cbn.
   - etrans. apply id_left.
@@ -689,7 +689,7 @@ Proof.
   - apply homset_property.
 Qed.
 
-Definition disp_cartesian' : disp_precat C := _ ,, disp_cartesian_axioms.
+Definition disp_cartesian' : disp_cat C := _ ,, disp_cartesian_axioms.
 
 End cartesian_product.
 

--- a/TypeTheory/Displayed_Cats/Fibrations.v
+++ b/TypeTheory/Displayed_Cats/Fibrations.v
@@ -38,32 +38,32 @@ Section Isofibrations.
 there’s some object d' in D c', and an iso φbar : d' =~ d over φ.
 *)
 
-Definition iso_cleaving {C : Precategory} (D : disp_precat C) : UU
+Definition iso_cleaving {C : Precategory} (D : disp_cat C) : UU
 := 
   forall (c c' : C) (i : iso c' c) (d : D c),
           ∑ d' : D c', iso_disp i d' d.
 
 Definition iso_fibration (C : Precategory) : UU
-  := ∑ D : disp_precat C, iso_cleaving D.
+  := ∑ D : disp_cat C, iso_cleaving D.
 
-Definition is_uncloven_iso_cleaving {C : Precategory} (D : disp_precat C) : UU
+Definition is_uncloven_iso_cleaving {C : Precategory} (D : disp_cat C) : UU
 := 
   forall (c c' : C) (i : iso c' c) (d : D c),
           ∃ d' : D c', iso_disp i d' d.
 
 Definition weak_iso_fibration (C : Precategory) : UU
-  := ∑ D : disp_precat C, is_uncloven_iso_cleaving D.
+  := ∑ D : disp_cat C, is_uncloven_iso_cleaving D.
 
 
 (** As with fibrations, there is an evident dual version.  However, in the iso case, it is self-dual: having forward (i.e. cocartesian) liftings along isos is equivalent to having backward (cartesian) liftings. *)
 
-Definition is_op_isofibration {C : Precategory} (D : disp_precat C) : UU
+Definition is_op_isofibration {C : Precategory} (D : disp_cat C) : UU
 := 
   forall (c c' : C) (i : iso c c') (d : D c),
           ∑ d' : D c', iso_disp i d d'.
 
 Lemma is_isofibration_iff_is_op_isofibration 
-    {C : Precategory} (D : disp_precat C)
+    {C : Precategory} (D : disp_cat C)
   : iso_cleaving D <-> is_op_isofibration D.
 Proof.
   (* TODO: give this! *)
@@ -74,7 +74,7 @@ End Isofibrations.
 (** * Fibrations *)
 Section Fibrations.
 
-Definition is_cartesian {C : Precategory} {D : disp_precat C}
+Definition is_cartesian {C : Precategory} {D : disp_cat C}
     {c c' : C} {f : c' --> c}
     {d : D c} {d' : D c'} (ff : d' -->[f] d)
   : UU
@@ -82,7 +82,7 @@ Definition is_cartesian {C : Precategory} {D : disp_precat C}
   ∃! (gg : d'' -->[g] d'), gg ;; ff = hh.
 
 (** See also [cartesian_factorisation'] below, for when the map one wishes to factor is not judgementally over [g;;f], but over some equal map. *)
-Definition cartesian_factorisation {C : Precategory} {D : disp_precat C}
+Definition cartesian_factorisation {C : Precategory} {D : disp_cat C}
     {c c' : C} {f : c' --> c}
     {d : D c} {d' : D c'} {ff : d' -->[f] d} (H : is_cartesian ff)
     {c''} (g : c'' --> c') {d'' : D c''} (hh : d'' -->[g;;f] d)
@@ -90,7 +90,7 @@ Definition cartesian_factorisation {C : Precategory} {D : disp_precat C}
 := pr1 (pr1 (H _ g _ hh)).
 
 Definition cartesian_factorisation_commutes
-    {C : Precategory} {D : disp_precat C}
+    {C : Precategory} {D : disp_cat C}
     {c c' : C} {f : c' --> c}
     {d : D c} {d' : D c'} {ff : d' -->[f] d} (H : is_cartesian ff)
     {c''} (g : c'' --> c') {d'' : D c''} (hh : d'' -->[g;;f] d)
@@ -99,7 +99,7 @@ Definition cartesian_factorisation_commutes
 
 (** This is essentially the third access function for [is_cartesian], but given in a more usable form than [pr2 (H …)] would be. *)
 Definition cartesian_factorisation_unique
-    {C : Precategory} {D : disp_precat C}
+    {C : Precategory} {D : disp_cat C}
     {c c' : C} {f : c' --> c}
     {d : D c} {d' : D c'} {ff : d' -->[f] d} (H : is_cartesian ff)
     {c''} {g : c'' --> c'} {d'' : D c''} (gg gg' : d'' -->[g] d')
@@ -119,7 +119,7 @@ Proof.
   apply pathsinv0, goal'.
 Qed.
 
-Definition cartesian_factorisation' {C : Precategory} {D : disp_precat C}
+Definition cartesian_factorisation' {C : Precategory} {D : disp_cat C}
     {c c' : C} {f : c' --> c}
     {d : D c} {d' : D c'} {ff : d' -->[f] d} (H : is_cartesian ff)
     {c''} (g : c'' --> c')
@@ -132,7 +132,7 @@ Proof.
 Defined.
 
 Definition cartesian_factorisation_commutes'
-    {C : Precategory} {D : disp_precat C}
+    {C : Precategory} {D : disp_cat C}
     {c c' : C} {f : c' --> c}
     {d : D c} {d' : D c'} {ff : d' -->[f] d} (H : is_cartesian ff)
     {c''} (g : c'' --> c')
@@ -144,26 +144,26 @@ Proof.
   apply cartesian_factorisation_commutes.
 Qed.
 
-Definition cartesian_lift {C : Precategory} {D : disp_precat C}
+Definition cartesian_lift {C : Precategory} {D : disp_cat C}
     {c} (d : D c) {c' : C} (f : c' --> c)
   : UU
 := ∑ (d' : D c') (ff : d' -->[f] d), is_cartesian ff.
 
-Definition object_of_cartesian_lift  {C : Precategory} {D : disp_precat C}
+Definition object_of_cartesian_lift  {C : Precategory} {D : disp_cat C}
     {c} (d : D c) {c' : C} (f : c' --> c)
     (fd : cartesian_lift d f)
   : D c'
 := pr1 fd.
 Coercion object_of_cartesian_lift : cartesian_lift >-> ob_disp.
 
-Definition mor_disp_of_cartesian_lift  {C : Precategory} {D : disp_precat C}
+Definition mor_disp_of_cartesian_lift  {C : Precategory} {D : disp_cat C}
     {c} (d : D c) {c' : C} (f : c' --> c)
     (fd : cartesian_lift d f)
   : (fd : D c') -->[f] d
 := pr1 (pr2 fd).
 Coercion mor_disp_of_cartesian_lift : cartesian_lift >-> mor_disp.
 
-Definition cartesian_lift_is_cartesian {C : Precategory} {D : disp_precat C}
+Definition cartesian_lift_is_cartesian {C : Precategory} {D : disp_cat C}
     {c} (d : D c) {c' : C} (f : c' --> c)
     (fd : cartesian_lift d f)
   : is_cartesian fd
@@ -172,7 +172,7 @@ Coercion cartesian_lift_is_cartesian : cartesian_lift >-> is_cartesian.
 
 (* TODO: should the arguments be re-ordered as in [cartesian_lift]? If so, reorder in [isofibration] etc as well, for consistency. *)
 (* TODO: consider renaming to e.g. [cleaving] to follow convention that [is_] is reserved for hprops. *)
-Definition cleaving {C : Precategory} (D : disp_precat C) : UU
+Definition cleaving {C : Precategory} (D : disp_cat C) : UU
 := 
   forall (c c' : C) (f : c' --> c) (d : D c), cartesian_lift d f.
 
@@ -180,23 +180,23 @@ Definition cleaving {C : Precategory} (D : disp_precat C) : UU
 
 Definition fibration (C : Precategory) : UU
 := 
-  ∑ D : disp_precat C, cleaving D.
+  ∑ D : disp_cat C, cleaving D.
 
 
 (** ** Weak fibration *)
 
 (* TODO: give access functions! *)
 
-Definition is_cleaving {C : Precategory} (D : disp_precat C) : UU
+Definition is_cleaving {C : Precategory} (D : disp_cat C) : UU
 := 
   forall (c c' : C) (f : c' --> c) (d : D c), ∥ cartesian_lift d f ∥.
 
 Definition weak_fibration (C : Precategory) : UU
-:= ∑ D : disp_precat C, is_cleaving D.
+:= ∑ D : disp_cat C, is_cleaving D.
 
 (** ** Connection with isofibrations *)
 
-Lemma is_iso_from_is_cartesian {C : Precategory} {D : disp_precat C}
+Lemma is_iso_from_is_cartesian {C : Precategory} {D : disp_cat C}
     {c c' : C} (i : iso c' c) {d : D c} {d'} (ff : d' -->[i] d)
   : is_cartesian ff -> is_iso_disp i ff.
 Proof.
@@ -218,7 +218,7 @@ Proof.
     apply maponpaths_2, homset_property.
 Qed.
 
-Lemma is_isofibration_from_is_fibration {C : Precategory} {D : disp_precat C}
+Lemma is_isofibration_from_is_fibration {C : Precategory} {D : disp_cat C}
   : cleaving D -> iso_cleaving D.
 Proof.
   intros D_fib c c' f d.
@@ -231,7 +231,7 @@ Defined.
 (** ** Uniqueness of cartesian lifts *)
 
 (* TODO: show that when [D] is _univalent_, cartesian lifts are literally unique, and so any uncloven fibration (isofibration, etc) is in fact cloven. *)
-Definition cartesian_lifts_iso {C : Precategory} {D : disp_precat C}
+Definition cartesian_lifts_iso {C : Precategory} {D : disp_cat C}
     {c} {d : D c} {c' : C} {f : c' --> c} (fd fd' : cartesian_lift d f)
   : iso_disp (identity_iso c') fd fd'.
 Proof.
@@ -263,7 +263,7 @@ Proof.
       apply maponpaths_2, homset_property.
 Defined.
 
-Definition cartesian_lifts_iso_commutes {C : Precategory} {D : disp_precat C}
+Definition cartesian_lifts_iso_commutes {C : Precategory} {D : disp_cat C}
     {c} {d : D c} {c' : C} {f : c' --> c} (fd fd' : cartesian_lift d f)
   : (cartesian_lifts_iso fd fd') ;; fd'
   = transportb _ (id_left _) (fd : _ -->[_] _).
@@ -273,7 +273,7 @@ Qed.
 
 (** In a displayed _category_ (i.e. _univalent_), cartesian lifts are literally unique, if they exist; that is, the type of cartesian lifts is always a proposition. *) 
 Definition isaprop_cartesian_lifts
-    {C : Precategory} {D : disp_precat C} (D_cat : is_category_disp D)
+    {C : Precategory} {D : disp_cat C} (D_cat : is_univalent_disp D)
     {c} (d : D c) {c' : C} (f : c' --> c)
   : isaprop (cartesian_lift d f).
 Proof.
@@ -301,7 +301,7 @@ Proof.
 Defined.
 
 Definition univalent_fibration_is_cloven
-    {C : Precategory} {D : disp_precat C} (D_cat : is_category_disp D)
+    {C : Precategory} {D : disp_cat C} (D_cat : is_univalent_disp D)
   : is_cleaving D -> cleaving D.
 Proof.
   intros D_fib c c' f d.
@@ -327,7 +327,7 @@ Defined.
 
 Section Discrete_Fibrations.
 
-Definition is_discrete_fibration {C : Precategory} (D : disp_precat C) : UU
+Definition is_discrete_fibration {C : Precategory} (D : disp_cat C) : UU
 := 
   (forall (c c' : C) (f : c' --> c) (d : D c),
           ∃! d' : D c', d' -->[f] d)
@@ -335,10 +335,10 @@ Definition is_discrete_fibration {C : Precategory} (D : disp_precat C) : UU
   (forall c, isaset (D c)).
 
 Definition discrete_fibration C : UU
-  := ∑ D : disp_precat C, is_discrete_fibration D.
+  := ∑ D : disp_cat C, is_discrete_fibration D.
 
-Coercion disp_precat_from_discrete_fibration C (D : discrete_fibration C)
-  : disp_precat C := pr1 D.
+Coercion disp_cat_from_discrete_fibration C (D : discrete_fibration C)
+  : disp_cat C := pr1 D.
 Definition unique_lift {C} {D : discrete_fibration C} {c c'} 
            (f : c' --> c) (d : D c) 
   : ∃! d' : D c', d' -->[f] d 
@@ -566,7 +566,7 @@ Definition functor_Disc_Fibs_to_preShvs : functor _ _
 (** *** Functor on objects *)
 
 (* TODO: split into data and properties *)
-Definition disp_precat_from_preshv (D : preShv C) : disp_precat C.
+Definition disp_cat_from_preshv (D : preShv C) : disp_cat C.
 Proof.
   mkpair.
   - mkpair.
@@ -587,7 +587,7 @@ Defined.
 Definition disc_fib_from_preshv (D : preShv C) : discrete_fibration C.
 Proof.
   mkpair.
-  - apply (disp_precat_from_preshv D).
+  - apply (disp_cat_from_preshv D).
   - cbn.
     split.
     + intros c c' f d. simpl.
@@ -730,7 +730,7 @@ Section isofibration_from_disp_over_univalent.
 
 Context (C : Precategory) 
         (Ccat : is_category C)
-        (D : disp_precat C).
+        (D : disp_cat C).
 
 Definition iso_cleaving_category : iso_cleaving D.
 Proof.

--- a/TypeTheory/Displayed_Cats/Limits.v
+++ b/TypeTheory/Displayed_Cats/Limits.v
@@ -40,7 +40,7 @@ Section Creates_Limits.
 (* TODO: consider implicitness of argument *)
 Definition creates_limit
   {C : Precategory}
-  (D : disp_precat C)
+  (D : disp_cat C)
   {J : graph} (F : diagram J (total_precat D))
   {x : C} (L : cone (mapdiagram (pr1_precat D) F)  x)
   (isL : isLimCone _ x L) : UU
@@ -51,7 +51,7 @@ Definition creates_limit
           forms_cone F (x,,d)  (λ j, (L j ,, δ j))))
   , isLimCone _ _ (mk_cone _ (pr2 (pr2 (iscontrpr1 CC)))).
          
-Definition creates_limits {C : Precategory} (D : disp_precat C) : UU
+Definition creates_limits {C : Precategory} (D : disp_cat C) : UU
 := 
   ∏ {J : graph} (F : diagram J (total_precat D))
     {x : C} (L : cone (mapdiagram (pr1_precat D) F)  x)
@@ -63,7 +63,7 @@ End Creates_Limits.
 Section creates_preserves.
 
 Context {C : Precategory}
-        (D : disp_precat C)
+        (D : disp_cat C)
         (H : creates_limits D)
         (J : graph)
         (X : Lims_of_shape J C).

--- a/TypeTheory/Displayed_Cats/SIP.v
+++ b/TypeTheory/Displayed_Cats/SIP.v
@@ -42,14 +42,14 @@ Variable Hstandard : ∏ (x : C) (a a' : P x),
 
 (** ** A displayed precategory from the data *)
 
-Definition disp_precat_from_SIP_data : disp_precat C
+Definition disp_cat_from_SIP_data : disp_cat C
   := disp_struct C P (@H) Hisprop Hid Hcomp.
 
 (** ** Displayed category from SIP data is univalent *)
 
-Lemma is_category_disp_from_SIP_data : is_category_disp disp_precat_from_SIP_data.
+Lemma is_univalent_disp_from_SIP_data : is_univalent_disp disp_cat_from_SIP_data.
 Proof.
-  apply is_category_disp_from_fibers.
+  apply is_univalent_disp_from_fibers.
   intros x a b.
   apply isweqimplimpl.
   - intro i. apply Hstandard.
@@ -58,16 +58,16 @@ Proof.
   - apply Pisset.
   - apply isofhleveltotal2.
     + apply Hisprop.
-    + intro. apply (@isaprop_is_iso_disp _ disp_precat_from_SIP_data).
+    + intro. apply (@isaprop_is_iso_disp _ disp_cat_from_SIP_data).
 Defined.
 
 (** ** The conclusion of SIP: total category is univalent *)
 
-Definition SIP : is_category (total_precat disp_precat_from_SIP_data).
+Definition SIP : is_category (total_precat disp_cat_from_SIP_data).
 Proof.
   apply is_category_total_category.
   - apply univC.
-  - apply is_category_disp_from_SIP_data.
+  - apply is_univalent_disp_from_SIP_data.
 Defined.
 
 End SIP.


### PR DESCRIPTION
- `disp_precat` -> `disp_cat`
- `is_category_disp` -> `is_univalent_disp`

Not yet renamed those identifiers referring to naming in UniMath/UniMath, e.g., `total_precat`.