### PR TITLE
repair compilation after withdrawal of Ltac def. mkpair in Foundations

### DIFF
--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
@@ -297,11 +297,11 @@ Definition compat_structures_disp_cat
 Definition compat_structures_pr1_functor
   : functor compat_structures_precategory term_fun_precategory.
 Proof.
-  mkpair.
-  - mkpair.
+  use tpair.
+  - use tpair.
     + exact (fun YZp => pr1 (pr1 YZp)).
     + intros a b f. apply (pr1 f).
-  - mkpair.
+  - use tpair.
     + intro c. apply idpath.
     + intros a b c f g. apply idpath.
 Defined.
@@ -309,11 +309,11 @@ Defined.
 Definition compat_structures_pr2_functor
   : functor compat_structures_precategory qq_structure_precategory.
 Proof.
-  mkpair.
-  - mkpair.
+  use tpair.
+  - use tpair.
     + exact (fun YZp => pr2 (pr1 YZp)).
     + intros a b f. apply (pr2 f).
-  - mkpair.
+  - use tpair.
     + intro c. apply idpath.
     + intros a b c f g. apply idpath.
 Defined.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
@@ -647,9 +647,9 @@ End qq_from_term.
 
 Definition qq_from_term_data : qq_morphism_data X.
 Proof.
-  mkpair.
+  use tpair.
   - intros. apply qq_term.
-  - intros. simpl.
+  - cbn. intros. simpl.
     exists (qq_commutes_1 _ _ _ _ ).
     apply isPullback_qq.
 Defined.

--- a/TypeTheory/ALV1/RelativeUniverses.v
+++ b/TypeTheory/ALV1/RelativeUniverses.v
@@ -528,7 +528,7 @@ Proof.
     { apply propproperty. } 
     intros [ip' Hip'].
     apply hinhpr.
-    repeat mkpair.
+    repeat (use tpair).
     + apply Xf.
     + exact ip'.
     + set (hi := (α : nat_trans _ _ ) Xf). cbn in hi.

--- a/TypeTheory/ALV1/TypeCat_Reassoc.v
+++ b/TypeTheory/ALV1/TypeCat_Reassoc.v
@@ -123,28 +123,27 @@ Abort.
 
 Definition l_to_r_reassoc_direct : split_struct -> reassoc_split_struct.
 Proof.
-    intros S.
-    mkpair.
-      mkpair.
-        exists ((pr1 (pr1 (pr1 S)),, pr1 (pr2 S)),, pr2 (pr2 (pr1 (pr1 S)))).
-        exact (pr1 (pr1 (pr2 (pr2 S))),, pr1 (pr2 (pr2 (pr2 S)))).
-      exact (pr1 (pr2 (pr1 (pr1 S))),, pr1 (pr2 (pr1 S))).
-    exists (pr2 (pr2 (pr1 S))).
-    cbn.
+  intros S.
+  use tpair.
+  - use tpair.
+    + exists ((pr1 (pr1 (pr1 S)),, pr1 (pr2 S)),, pr2 (pr2 (pr1 (pr1 S)))).
+      exact (pr1 (pr1 (pr2 (pr2 S))),, pr1 (pr2 (pr2 (pr2 S)))).
+    + exact (pr1 (pr2 (pr1 (pr1 S))),, pr1 (pr2 (pr1 S))).
+  - exists (pr2 (pr2 (pr1 S))).
     exact (pr2 (pr1 (pr2 (pr2 S))),, pr2 (pr2 (pr2 (pr2 S)))).
 Defined.
 
 Definition r_to_l_reassoc_direct : reassoc_split_struct -> split_struct.
 Proof.
   intros S.
-  mkpair.
-    exists (pr1 (pr1 (pr1 (pr1 (pr1 S)))) ,,
+  use tpair.
+  - exists (pr1 (pr1 (pr1 (pr1 (pr1 S)))) ,,
                 (pr1 (pr2 (pr1 S)) ,, (pr2 (pr1 (pr1 (pr1 S)))))).
     exact (pr2 (pr2 (pr1 S)),, pr1 (pr2 S)).
-  repeat apply dirprodpair; simpl.
-  - exact (pr2 (pr1 (pr1 (pr1 (pr1 S))))).
-  - exact (pr1 (pr2 (pr1 (pr1 S))),, pr1 (pr2 (pr2 S))).
-  - exact (pr2 (pr2 (pr1 (pr1 S))),, pr2 (pr2 (pr2 S))).
+  - repeat apply dirprodpair; simpl.
+    + exact (pr2 (pr1 (pr1 (pr1 (pr1 S))))).
+    + exact (pr1 (pr2 (pr1 (pr1 S))),, pr1 (pr2 (pr2 S))).
+    + exact (pr2 (pr2 (pr1 (pr1 S))),, pr2 (pr2 (pr2 S))).
 Defined.
 
 Theorem weq_reassoc_direct : split_struct ≃ reassoc_split_struct.

--- a/TypeTheory/Auxiliary/Auxiliary.v
+++ b/TypeTheory/Auxiliary/Auxiliary.v
@@ -650,7 +650,7 @@ Lemma form_adjunction_comp
       (functor_composite F F') (functor_composite G' G)
       unit_comp counit_comp.
 Proof.
-  mkpair; cbn in *; simpl in *.
+  use tpair; cbn in *; simpl in *.
   (* The proof of each triangle identity roughly goes as follows:
      - overall, we have a composite of four arrows;
      - apply naturality to pull the middle two past each other;
@@ -734,11 +734,11 @@ Definition comp_adj_equivalence_of_precats
   : adj_equivalence_of_precats (functor_composite F F').
 Proof.
   exists (comp_adjunction HF HF').
-  mkpair.
+  use tpair.
   - intro. apply is_iso_comp_is_iso.
     + apply (pr1 (pr2 HF)).
     + simpl. apply functor_is_iso_is_iso, (pr1 (pr2 HF')).
-  - intro. apply is_iso_comp_is_iso.
+  - cbn. intro. apply is_iso_comp_is_iso.
     + apply functor_is_iso_is_iso, (pr2 (pr2 HF)).
     + apply (pr2 (pr2 HF')).
 Defined.
@@ -806,9 +806,9 @@ Qed.
 
 Definition is_left_adjoint_inv : is_left_adjoint G.
 Proof.
-  mkpair.
+  use tpair.
   - apply F.
-  - mkpair.
+  - use tpair.
     exists (pr1 (iso_inv_from_iso εiso)).
     exact (pr1 (iso_inv_from_iso ηiso)).
     apply form_adjunction_inv.
@@ -847,7 +847,7 @@ Let Finv {a b} g := (invweq (weq_from_fully_faithful Fff a b) g).
 
 Definition G_ff_split_data : functor_data B A.
 Proof.
-  mkpair.
+  use tpair.
   - intro b. exact (pr1 (Fses b)).
   - intros b b' f'; cbn.
     apply Finv.
@@ -893,7 +893,7 @@ Qed.
 Definition ε_ff_split
   : nat_trans (functor_composite G_ff_split F) (functor_identity B).
 Proof.
-  mkpair.
+  use tpair.
   - intro b.
     exact (pr2 (Fses b)).
   - apply is_nat_trans_ε_ff_split.
@@ -922,7 +922,7 @@ Qed.
 
 Definition η_ff_split : nat_trans (functor_identity A) (functor_composite F G_ff_split).
 Proof.
-  mkpair.
+  use tpair.
   -  intro a.
      apply Finv.
      apply (inv_from_iso (pr2 (Fses _ ))).
@@ -952,9 +952,9 @@ Qed.
 
 Definition adj_equivalence_of_precats_ff_split : adj_equivalence_of_precats F.
 Proof.
-  mkpair.
+  use tpair.
   - exists G_ff_split.
-    mkpair.
+    use tpair.
     + exists η_ff_split. 
       exact ε_ff_split. 
     + apply form_adjunction_ff_split. 
@@ -1181,7 +1181,7 @@ Definition nat_iso_from_pointwise_iso (D E : precategory)
   : iso F G.
 Proof.
   use functor_iso_from_pointwise_iso .
-  mkpair.
+  use tpair.
   - intro d. apply a.
   - apply H.
   - intro d. apply (pr2 (a d)).
@@ -1543,7 +1543,7 @@ Proof.
     apply (toforallpaths _ _ _ ehk).
     split. apply (toforallpaths _ _ _ eh). apply (toforallpaths _ _ _ ek).
     split. apply (toforallpaths _ _ _ eh'). apply (toforallpaths _ _ _ ek').
-  - mkpair. 
+  - use tpair. 
     + intros x. refine (pr1 (H_existence (h x) (k x) _)). apply (toforallpaths _ _ _ ehk).
     + simpl.
       split; apply funextsec; intro x.
@@ -1665,7 +1665,7 @@ Proof.
         + exact (Empty_set_rect _ ).
     }
     specialize (XR HC).
-    mkpair.
+    use tpair.
   - exists (pr1 (iscontrpr1 XR)).
     split.
     + apply (pr2 (pr1 XR) One).

--- a/TypeTheory/Displayed_Cats/ComprehensionC.v
+++ b/TypeTheory/Displayed_Cats/ComprehensionC.v
@@ -217,11 +217,11 @@ Qed.
 
 Definition comp_cat_of_dm :  comprehension_cat_structure C.
 Proof.
-  mkpair.
+  use tpair.
   - apply DM_disp. apply H.
-  - mkpair. 
+  - use tpair. 
     + apply is_fibration_DM_disp.
-    + mkpair. 
+    + use tpair. 
       * apply comprehension_of_dm_structure.
       * apply is_cartesian_comprehension_of_dm_structure.
 Defined.

--- a/TypeTheory/Instances/Presheaves.v
+++ b/TypeTheory/Instances/Presheaves.v
@@ -213,7 +213,7 @@ Definition mkTermIn {Γ : PreShv C} (A : Γ ⊢)
   (Hu : ∏ I J (f : C ⟦ J, I ⟧) (ρ : pr1 ((pr1 Γ) I)),
         # (pr1 A) (mor_to_el_mor f ρ) (u I ρ) = u J (# (pr1 Γ) f ρ)) : Γ ⊢ A.
 Proof.
-mkpair.
+use tpair.
 - exact u.
 - abstract (exact Hu).
 Defined.
@@ -228,13 +228,13 @@ Qed.
 Definition ctx_ext {Γ : PreShv C} (A : Γ ⊢) : PreShv C.
 Proof.
 use mk_functor.
-- mkpair.
+- use tpair.
   + simpl; intros I.
     use total2_hSet.
     * apply (pr1 Γ I).
     * intros ρ.
       apply (pr1 A (make_ob I ρ)).
-  + intros I J f ρu.
+  + cbn. intros I J f ρu.
     exists (# (pr1 Γ) f (pr1 ρu)).
     apply (# (pr1 A) (mor_to_el_mor f (pr1 ρu)) (pr2 ρu)).
 - split.
@@ -488,7 +488,7 @@ Definition TermInSection {Γ : PreShv C} (A : Γ ⊢) : UU :=
 Lemma TermIn_to_TermInSection {Γ : PreShv C} (A : Γ ⊢) : TermIn A → TermInSection A.
 Proof.
 intros a.
-mkpair.
+use tpair.
 - apply (term_to_subst _ a).
 - abstract (apply (nat_trans_eq has_homsets_HSET);
             now intros I; simpl; apply funextfun).
@@ -589,7 +589,7 @@ Local Notation "Γ ⋆ A" := (@ctx_ext _ Γ A) (at level 30).
 
 Definition PreShv_TypeCat : typecat_structure (PreShv C).
 Proof.
-mkpair.
+use tpair.
 - exists (λ Γ, Γ ⊢).
   exists (λ Γ A, Γ ⋆ A).
   intros Γ A Δ σ.
@@ -626,7 +626,7 @@ Defined.
 
 Lemma PreShv_reindx_structure : reindx_structure PreShv_tt_structure.
 Proof.
-mkpair.
+use tpair.
 - intros Γ Δ A σ.
   exact (A⦃σ⦄).
 - intros Γ Δ A a σ.
@@ -635,7 +635,7 @@ Defined.
 
 Definition PreShv_tt_reindx_type_struct : tt_reindx_type_struct (PreShv C).
 Proof.
-mkpair.
+use tpair.
 + exists (PreShv_tt_structure,,PreShv_reindx_structure).
   intros Γ A.
   exists (Γ ⋆ A).
@@ -649,13 +649,13 @@ Defined.
 
 Lemma PreShv_reindx_laws : reindx_laws PreShv_tt_reindx_type_struct.
 Proof.
-mkpair.
-- mkpair.
+use tpair.
+- use tpair.
   + intros Γ A.
     apply subst_type_id.
   + intros Γ Δ Θ σ1 σ2 A.
     apply (subst_type_comp hsC).
-- mkpair.
+- use tpair.
   + intros Γ A a.
     apply (subst_term_id hsC a).
   + intros Γ Δ Θ σ1 σ2 A a.


### PR DESCRIPTION
replace invocations of mkpair by use tpair, sometimes an extra cbn is needed