### PR TITLE
more use of "use" or "exact" in ALV1 and ALV2 in place of "refine"

### DIFF
--- a/TypeTheory/ALV1/CwF_Defs_Equiv.v
+++ b/TypeTheory/ALV1/CwF_Defs_Equiv.v
@@ -182,7 +182,7 @@ Definition weq_rep2_rep1_data (pp : mor_total (preShv C))
 Proof.
   unfold rep1_data, rep2_data.
   eapply weqcomp. apply weqonsecfibers; intro; apply weqforalltototal.
-  refine (weqforalltototal _ _).
+  use weqforalltototal.
 Defined.
 
 Definition rep2 (pp : mor_total (preShv C)) : UU 
@@ -191,16 +191,16 @@ Definition rep2 (pp : mor_total (preShv C)) : UU
 Definition weq_rep1_representation (pp : mor_total (preShv C))
   : rep1 pp ≃ cwf_representation pp.
 Proof.
-  simple refine (weqcomp _ _). { exact (rep2 pp). }
+  use weqcomp. { exact (rep2 pp). }
     eapply invweq, weqfp.
   unfold rep2, cwf_representation.
   eapply weqcomp. 
     unfold rep2_data, rep1_axioms.
-    refine (@weqtotaltoforall C (fun Γ => (Ty pp Γ : hSet) -> _)
+    use (@weqtotaltoforall C (fun Γ => (Ty pp Γ : hSet) -> _)
       (fun Γ Y => forall A, rep1_fiber_axioms A (pr2 (pr1 (Y A))) (pr2 (Y A)))).
   apply weqonsecfibers; intro Γ.
   eapply weqcomp.
-    refine (@weqtotaltoforall _ _
+    use (@weqtotaltoforall _ _
       (fun A ΓAπt => rep1_fiber_axioms A (pr2 (pr1 ΓAπt)) (pr2 ΓAπt))).
   apply weqonsecfibers; intro A.
   unfold cwf_fiber_representation.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
@@ -83,7 +83,7 @@ Proof.
   intros Γ'; simpl in Γ'.
   unfold yoneda_objects_ob. apply funextsec; intros f.
   etrans. 
-    refine (toforallpaths _ _ _ (nat_trans_ax (term_fun_mor_TM FF) _ _ _) _).
+    use (toforallpaths _ _ _ (nat_trans_ax (term_fun_mor_TM FF) _ _ _)).
   cbn. apply maponpaths, term_fun_mor_te.
 Qed.
 
@@ -117,7 +117,7 @@ Proof.
     simpl in Pb.
   apply (pullback_HSET_elements_unique Pb); clear Pb.
   - unfold yoneda_morphisms_data; cbn.
-    etrans. refine (pr2 (term_to_section t')). apply pathsinv0.
+    etrans. use (pr2 (term_to_section t')). apply pathsinv0.
     etrans. Focus 2. refine (pr2 (term_to_section t)).
     etrans. apply @pathsinv0, assoc.
     apply maponpaths.
@@ -210,9 +210,9 @@ Definition qq_structure_ob_mor : precategory_ob_mor.
 Proof.
   exists (qq_morphism_structure X).
   intros Z Z'.
-  refine (∏ Γ' Γ (f : C ⟦ Γ' , Γ ⟧) (A : Ty X Γ), _).
-  refine (qq Z f A  = _).
-  refine (qq Z' f _ ).
+  use (∏ Γ' Γ (f : C ⟦ Γ' , Γ ⟧) (A : Ty X Γ), _).
+  use (qq Z f A  = _).
+  use (qq Z' f).
 Defined.
 
 Lemma isaprop_qq_structure_mor
@@ -344,8 +344,8 @@ Proof.
   - etrans. apply qq_π.
     apply pathsinv0, qq_π.
   - etrans. cbn. apply maponpaths, @pathsinv0, (term_fun_mor_te FY).
-    etrans. refine (toforallpaths _ _ _
-                      (!nat_trans_ax (term_fun_mor_TM _) _ _ _) _).
+    etrans. use (toforallpaths _ _ _
+                      (!nat_trans_ax (term_fun_mor_TM _) _ _ _)).
     etrans. cbn. apply maponpaths, @pathsinv0, W.
     etrans. apply term_fun_mor_te.
     apply W'.
@@ -401,9 +401,9 @@ Proof.
   use tm_from_qq_eq.
   - apply idpath.
   - etrans. apply id_right.
-    cbn. apply PullbackArrowUnique. 
-    + refine (PullbackArrow_PullbackPr1
-                (mk_Pullback _ _ _ _ _ _ (qq_π_Pb _ f A)) _ _ _ _).
+    cbn. apply PullbackArrowUnique.
+    + use (PullbackArrow_PullbackPr1
+                (mk_Pullback _ _ _ _ _ _ (qq_π_Pb _ f A))).
     + cbn; cbn in FZ. etrans. apply maponpaths, @pathsinv0, FZ.
       apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). 
 Qed.
@@ -447,9 +447,9 @@ Definition term_from_qq_mor_TM
     (W' : iscompatible_term_qq Y' Z')
   : TM (Y : term_fun_structure _ _) --> TM (Y' : term_fun_structure _ _).
 Proof.
-  refine ( _ ;; (tm_from_qq_mor_TM FZ : preShv C ⟦ _ , _ ⟧) ;; _).
-  - refine (given_TM_to_canonical _ _ (Y,,W)).
-  - refine (canonical_TM_to_given _ _ (Y',,W')).
+  use ( _ ;; (tm_from_qq_mor_TM FZ : preShv C ⟦ _ , _ ⟧) ;; _).
+  - exact (given_TM_to_canonical _ _ (Y,,W)).
+  - exact (canonical_TM_to_given _ _ (Y',,W')).
 Defined.
 
 Lemma term_from_qq_mor
@@ -590,7 +590,7 @@ Lemma idtoiso_iso_to_TM_eq
 : (idtoiso (iso_to_TM_eq _ _ FG) : _ --> _)
   = term_fun_mor_TM (FG : _ --> _).
 Proof.
-  refine (maponpaths pr1 (idtoiso_isotoid _ _ _ _ _)).
+  use (maponpaths pr1 (idtoiso_isotoid _ _ _ _ _)).
 Qed.
 
 Definition iso_to_id_term_fun_precategory
@@ -604,9 +604,9 @@ Proof.
   apply dirprodeq.
   - etrans. apply prewhisker_iso_to_TM_eq.
     apply term_fun_mor_pp. 
-  - etrans. refine (transportf_forall _ _ _).
+  - etrans. use transportf_forall.
     apply funextsec; intros Γ.
-    etrans. refine (transportf_forall _ _ _).
+    etrans. use transportf_forall.
     apply funextsec; intros A.
     etrans. apply transportf_pshf.
     etrans.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
@@ -344,7 +344,7 @@ Lemma comp_ext_compare_qq_general (Z : qq_morphism_data)
   : comp_ext_compare eA ;; qq Z f' A
   = qq Z f A.
 Proof.
-  refine (_ @ comp_ext_compare_qq _ e A).
+  use (_ @ comp_ext_compare_qq _ e A).
   apply maponpaths_2, maponpaths, setproperty.
 Qed.
 

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
@@ -42,7 +42,7 @@ Variable Y : compatible_term_structure Z.
 Definition canonical_TM_to_given_data
   {Γ} (Ase : tm_from_qq Z Γ : hSet) : (Tm Y Γ).
 Proof.
-  refine (# (TM _ : functor _ _) _ (te _ (pr1 Ase))). 
+  use (# (TM _ : functor _ _) _ (te _ (pr1 Ase))). 
   exact (pr1 (pr2 Ase)).
 Defined.
 
@@ -110,16 +110,15 @@ Proof.
   (* This [assert] is to enable the [destruct eA] below. *)
   assert (eA : (pp Y : nat_trans _ _) _ t = A). {
     etrans. apply maponpaths, (!H).
-    refine (toforallpaths _ _ _ 
-      (nat_trans_eq_pointwise pp_canonical_TM_to_given _)
-      _).
+    use (toforallpaths _ _ _ 
+      (nat_trans_eq_pointwise pp_canonical_TM_to_given _)).
   }
   use total2_paths_f.
   exact (!eA).
   cbn. destruct eA; cbn. unfold idfun.
   apply subtypeEquality. { intros x; apply homset_property. }
   set (temp := proofirrelevance _ (isapropifcontr (term_to_section_aux t))).
-  refine (maponpaths pr1 (temp (_,,_) (_,,_))).
+  use (maponpaths pr1 (temp (_,,_) (_,,_))).
   - cbn; split.
     + exact e.
     + exact H.
@@ -155,7 +154,7 @@ Definition given_TM_to_canonical_naturality
   : is_nat_trans (TM Y : functor _ _) (tm_from_qq Z) 
       (@given_TM_to_canonical_data).
 Proof.
-  refine (is_nat_trans_inv_from_pointwise_inv_ext _
+  use (is_nat_trans_inv_from_pointwise_inv_ext _
            canonical_TM_to_given_pointwise_iso).
   apply homset_property.
 Qed.
@@ -180,7 +179,7 @@ Lemma canonical_TM_to_given_te {Γ:C} A
 Proof.
   cbn. unfold canonical_TM_to_given_data. cbn.
   etrans. apply maponpaths, (pr2 Y).
-  etrans. refine (toforallpaths _ _ _ (!functor_comp (TM Y) _ _ ) _).
+  etrans. use (toforallpaths _ _ _ (!functor_comp (TM Y) _ _ )).
   etrans. apply maponpaths_2; cbn.
     apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). 
   apply (toforallpaths _ _ _ (functor_id (TM Y) _) _).
@@ -231,7 +230,7 @@ Proof.
       etrans. apply transportf_isotoid_pshf.
       cbn. unfold canonical_TM_to_given_data. cbn.
       etrans. apply maponpaths, YH.
-      etrans. refine (toforallpaths _ _ _ (!functor_comp tm _ _ ) _).
+      etrans. use (toforallpaths _ _ _ (!functor_comp tm _ _ )).
       etrans. apply maponpaths_2; cbn.
         apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). 
       apply (toforallpaths _ _ _ (functor_id tm _) _).
@@ -278,7 +277,7 @@ Proof.
   apply PullbackArrowUnique.
   + etrans. apply maponpaths. cbn. apply idpath.
     rewrite <- functor_comp.
-    etrans. eapply pathsinv0. refine (functor_comp Yo _ _).
+    etrans. eapply pathsinv0. use (functor_comp Yo).
     apply maponpaths.
     apply (pr1 (h _ _ _ _ )).
   + etrans. apply maponpaths. cbn. apply idpath.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
@@ -94,12 +94,12 @@ Proof.
     intros Γ''. cbn. unfold yoneda_objects_ob, yoneda_morphisms_data.
     apply funextsec; intros g.
     etrans. apply maponpaths, H.
-    refine (toforallpaths _ _ _ (!functor_comp (TM Y) _ _) _).
+    use (toforallpaths _ _ _ (!functor_comp (TM Y) _ _)).
   - assert (H' := nat_trans_eq_pointwise H); clear H.
     assert (H'' := toforallpaths _ _ _ (H' _) (identity _)); clear H'.
     cbn in H''; unfold yoneda_morphisms_data in H''.
     refine (_ @ H'' @ _).
-    + refine (toforallpaths _ _ _ (!functor_id (TM Y) _) _).
+    + use (toforallpaths _ _ _ (!functor_id (TM Y) _)).
     + apply maponpaths_2, id_left.
 Qed.
 
@@ -175,7 +175,7 @@ Defined.
 Definition tm_from_qq_functor_data : functor_data C^op HSET.
 Proof.
   exists tm_from_qq_functor_ob.
-  refine tm_from_qq_functor_mor.
+  exact tm_from_qq_functor_mor.
 Defined.
 
 Lemma section_eq_from_tm_from_qq_eq {Γ}
@@ -198,7 +198,7 @@ Proof.
   use total2_paths_f; simpl.
     apply eA.
   apply subtypeEquality. intro; apply homset_property.
-  simpl. eapply pathscomp0. refine (pr1_transportf _ _ _ _ _ eA _).
+  simpl. eapply pathscomp0. use (pr1_transportf _ _ _ _ _ eA).
   simpl. eapply pathscomp0. apply functtransportf.
   eapply pathscomp0. eapply pathsinv0. apply idtoiso_postcompose.
   exact es.
@@ -372,7 +372,7 @@ Proof.
   etrans. {
     apply maponpaths_2.
     apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). }
-  refine (_ @ id_right _).  
+  use (_ @ id_right _).  
   etrans. apply @pathsinv0, assoc.
   apply maponpaths.
   apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)).
@@ -391,7 +391,7 @@ Proof.
     use tm_from_qq_eq. cbn. 
     + etrans.
         apply @pathsinv0.
-        refine (toforallpaths _ _ _ (functor_comp (TY X) _ _ ) A).
+        use (toforallpaths _ _ _ (functor_comp (TY X) _ _ ) A).
       apply maponpaths_2.
       cbn.
       etrans. apply @pathsinv0, assoc. 
@@ -401,13 +401,13 @@ Proof.
       apply id_left.
     + use (map_into_Pb_unique _ (qq_π_Pb Z _ _  )).
       * cbn.
-        refine (_ @ !e).
+        use (_ @ !e).
         etrans. apply @pathsinv0, assoc.
         etrans. apply @maponpaths, comp_ext_compare_π.
         apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)).
       * etrans. apply @pathsinv0, assoc.
-        simple refine (maponpaths _ _ @ _).
-            { refine (qq Z _ _ ;; qq Z _ _). }
+        use (maponpaths _ _ @ _).
+            { use (qq Z _ _ ;; qq Z _ _). }
           { etrans. Focus 2. {
             eapply iso_inv_on_right.
             etrans. Focus 2. apply @pathsinv0, assoc. 
@@ -440,7 +440,7 @@ Proof.
     apply maponpaths.
     etrans. apply maponpaths.
       apply @pathsinv0, iso_inv_on_right.
-      refine (_ @ !assoc _ _ _).
+      use (_ @ !assoc _ _ _).
       apply qq_comp.
     etrans. Focus 2. 
       exact (comp_ext_compare_qq Z (!e1) _).
@@ -565,7 +565,7 @@ We first construct maps of presheaves that will be the image of the _q_-morphism
 
 Definition Yo_of_qq : _ ⟦Yo (Γ' ◂ A[f]), Yo (Γ ◂ A) ⟧.
 Proof.
-  simple refine (PullbackArrow Xk _ _ _ _ ).
+  use (PullbackArrow Xk).
   - apply (#Yo (π _) ;; #Yo f ). 
   - apply (Q Y).
   - abstract (
@@ -665,7 +665,7 @@ Proof.
     apply PullbackArrowUnique. 
     + etrans. apply maponpaths. cbn. apply idpath. 
       rewrite <- functor_comp.
-      etrans. eapply pathsinv0. refine (functor_comp Yo _ _).
+      etrans. eapply pathsinv0. use (functor_comp Yo).
       apply maponpaths. rewrite (@comp_ext_compare_π _ X).
       apply pathsinv0. apply id_right.
     + etrans. apply maponpaths. cbn. apply idpath.
@@ -676,7 +676,7 @@ Proof.
     sym. apply PullbackArrowUnique.
     + etrans. apply maponpaths. cbn. apply idpath.
       rewrite <- functor_comp.
-      etrans. eapply pathsinv0. refine (functor_comp Yo _ _).
+      etrans. eapply pathsinv0. use (functor_comp Yo).
       apply maponpaths.
       rewrite <- assoc. rewrite qq_commutes_1 .
       repeat rewrite assoc.

--- a/TypeTheory/ALV1/CwF_def.v
+++ b/TypeTheory/ALV1/CwF_def.v
@@ -143,7 +143,7 @@ Proof.
     apply (toforallpaths _ _ _ (functor_id (Tm pp) _)).
   etrans. 
     assert (e' := nat_trans_eq_pointwise e ΓA); clear e; cbn in e'.
-    refine (toforallpaths _ _ _ (!e') (identity _)).
+    use (toforallpaths _ _ _ (!e') (identity _)).
   unfold yoneda_morphisms_data.
   apply maponpaths_2, id_left.
 Qed.
@@ -208,7 +208,7 @@ Proof.
   destruct x' as [ΓA' m']. cbn in *.
   destruct H as [H isP].
   destruct H' as [H' isP'].
-  simple refine (total2_paths_f _ _ ).
+  use (total2_paths_f).
   - set (T1 := mk_Pullback _ _ _ _ _ _ isP).
     set (T2 := mk_Pullback _ _ _ _ _ _ isP').
     set (i := iso_from_Pullback_to_Pullback T1 T2). cbn in i.
@@ -273,7 +273,7 @@ Proof.
       match goal with |[|- PullbackArrow _ _ _ _ ?E4    ;; _ = _ ] 
                        => set (e4 := E4) end.
       apply (PullbackArrow_PullbackPr2 PT e1 e2 e3 e4).
-Qed.      
+Qed.   
 
 Lemma isaprop_cwf_fiber_representation {Γ:C} (A : Ty pp Γ : hSet)
   : is_univalent C -> isaprop (cwf_fiber_representation pp A).
@@ -319,13 +319,13 @@ Proof.
     apply weqtotal2asstor'.
   eapply weqcomp. Focus 2.
     eapply weqtotal2asstol.
-  eapply weqcomp. Focus 2.
+    eapply weqcomp. Focus 2.
     refine (weqfibtototal _ _ _).
     intro. apply weqtotal2asstor'.
   (* convert the term argument under [yy] *)
   apply weqfibtototal. intros [ΓA π]; simpl.
-  simple refine (weqbandf _ _ _ _).
-    simple refine (weqbandf _ _ _ _).
+  use weqbandf.
+    use weqbandf.
       apply yy.
   (* show the two forms of the equality axiom are equivalent *)
   - intros v; simpl.
@@ -333,7 +333,7 @@ Proof.
     + apply @cwf_square_comm.
     + apply @cwf_square_comm_converse.
     + apply setproperty.
-    + refine (homset_property (preShv C) _ _ _
+    + use (homset_property (preShv C) _ _ _
         (fq _
           (ΓA,, π,, invmap (yoneda_weq C (homset_property C) ΓA (Tm pp)) v)
         ;; _)).
@@ -348,7 +348,7 @@ Proof.
   apply weqonsecfibers. intro Γ.
   (* convert the type argument under [yy] *) 
   eapply weqcomp.
-    Focus 2. eapply invweq. 
+    Focus 2. eapply invweq.
     refine (weqonsecbase _ _). apply yy.
   apply weqonsecfibers. intro A.
   apply  weq_cwf_fiber_representation_fpullback.

--- a/TypeTheory/ALV1/RelativeUniverses.v
+++ b/TypeTheory/ALV1/RelativeUniverses.v
@@ -110,7 +110,7 @@ Proof.
     destruct x' as [a' m']. cbn in *.
     destruct H as [H isP].
     destruct H' as [H' isP'].
-    simple refine (total2_paths_f _ _ ).
+    use total2_paths_f.
     + unfold fpullback_prop in *.
       set (T1 := mk_Pullback _ _ _ _ _ _ isP).
       set (T2 := mk_Pullback _ _ _ _ _ _ isP').
@@ -284,13 +284,13 @@ Proof.
   destruct A as [e isPb]. cbn in e, isPb.
   assert (Sfp := S_pb _ _ _ _ _ _ _ _ _ isPb); clear S_pb.
   set (HSfp := functor_on_square D D' S e) in *; clearbody HSfp.
-  simple refine (tpair _ _ _ ).
+  use tpair.
   { exists (R Xf); split.
     - exact (#R p ;; i).
     - refine (α' Xf ;; #S q).
   }
   cbn. unfold fpullback_prop.
-  simple refine (commutes_and_is_pullback_transfer_iso _ _ _ _ _ Sfp).
+  use (commutes_and_is_pullback_transfer_iso _ _ _ _ _ Sfp).
   - apply identity_iso.
   - refine (iso_comp _ (functor_on_iso J' i)).
     exists (α _); apply α_iso.
@@ -343,13 +343,13 @@ Proof.
   destruct A as [e isPb]. cbn in e, isPb.
   assert (Sfp := S_pb _ _ _ _ _ _ _ _ _ isPb); clear S_pb.
   set (HSfp := functor_on_square D D' S e) in *; clearbody HSfp.
-  simple refine (tpair _ _ _ ).
+  use tpair.
   { exists (R Xf); split.
     - exact (#R p ;; i).
     - refine (α' Xf ;; #S q).
   }
   cbn. unfold fpullback_prop.
-  simple refine (commutes_and_is_pullback_transfer_iso _ _ _ _ _ Sfp).
+  use (commutes_and_is_pullback_transfer_iso _ _ _ _ _ Sfp).
   - apply identity_iso.
   - refine (iso_comp _ (functor_on_iso J' i)).
     exists (α _); apply α_iso.
@@ -465,13 +465,13 @@ Proof.
   assert (Sfp := S_pb _ _ _ _ _ _ _ _ _ isPb); clear S_pb.
   set (HSfp := functor_on_square D D' S e) in *; clearbody HSfp.
   apply hinhpr.
-  simple refine (tpair _ _ _ ).
+  use tpair.
   { exists (R Xf); split.
     - exact (#R p ;; i).
     - refine (α' Xf ;; #S q).
   }
   cbn. unfold fpullback_prop.
-  simple refine (commutes_and_is_pullback_transfer_iso _ _ _ _ _ Sfp).
+  use (commutes_and_is_pullback_transfer_iso _ _ _ _ _ Sfp).
   - apply identity_iso.
   - refine (iso_comp _ (functor_on_iso J' i)).
     exists (α _). apply α_iso. apply is_iso_α.

--- a/TypeTheory/ALV1/TypeCat_Reassoc.v
+++ b/TypeTheory/ALV1/TypeCat_Reassoc.v
@@ -148,10 +148,7 @@ Defined.
 
 Theorem weq_reassoc_direct : split_struct ≃ reassoc_split_struct.
 Proof.
-  refine (weq_iso
-            l_to_r_reassoc_direct
-            r_to_l_reassoc_direct
-            _ _).
+  use (weq_iso l_to_r_reassoc_direct r_to_l_reassoc_direct).
   - intros [[[ty [ext reind]] [dpr q_etc]] [set [[reind_id q_id] [reind_comp q_comp]]]].
     apply idpath.
   - intros [[[[[ty set] reind] [reind_id reind_comp]] [ext dpr]] [q_etc [q_id q_comp]]].
@@ -252,10 +249,7 @@ Definition weq_standalone_structural_explicit
         T_ty T_ext T_dpr T_reind T_q_etc
         T_set T_reind_id T_q_id T_reind_comp T_q_comp.
 Proof.
-  refine (weq_iso
-            standalone_to_structural
-            structural_to_standalone
-            _ _).
+  use (weq_iso standalone_to_structural structural_to_standalone).
   - intros; apply idpath.
   - intros; apply idpath.
 Defined.

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Cats.v
@@ -85,20 +85,20 @@ Proof.
     apply e_TY.
   apply funextsec; intros Γ; apply funextsec; intros A.
   use total2_paths_f. Focus 2. apply homset_property.
-  refine (_ @ e_comp Γ A).
+  use (_ @ e_comp Γ A).
   etrans.
     apply maponpaths.
     refine (toforallpaths _ _ _ _ _).
     etrans. refine (toforallpaths _ _ _ _ _).
       refine (transportf_forall _ _ _). simpl.
     refine (transportf_forall _ _ _). simpl.
-  etrans. refine (pr1_transportf (nat_trans _ _) _ _ _ _ _ _).
+  etrans. use (pr1_transportf (nat_trans _ _)).
   simpl.
-  etrans. refine (@functtransportf (nat_trans _ _) _ _ _ _ _ _ _).
+  etrans. use (@functtransportf (nat_trans _ _)).
   etrans. apply @pathsinv0, idtoiso_postcompose.
   apply maponpaths.
   etrans. apply maponpaths, maponpaths. apply @pathsinv0.
-    refine (@maponpathscomp (nat_trans _ _) _ _ _ _ _ _ _).
+    use (@maponpathscomp (nat_trans _ _)).
   apply (maponpaths Δ), setproperty.
 Qed.
 
@@ -228,9 +228,9 @@ Proof.
 (* Insert [cbn] to see what’s actually happening; removed for compile speed. *)
   unfold yoneda_objects_ob. apply funextsec; intros f.
   etrans. 
-    refine (toforallpaths _ _ _ (nat_trans_ax (term_fun_mor_TM FF) _ _ _) _).
+    use (toforallpaths _ _ _ (nat_trans_ax (term_fun_mor_TM FF) _ _ _)).
   etrans. cbn. apply maponpaths, term_fun_mor_te.
-  refine (toforallpaths _ _ _ (!functor_comp (TM Y') _ _ ) _).
+  use (toforallpaths _ _ _ (!functor_comp (TM Y') _ _ )).
 Qed.
 
 (* TODO: inline in [isaprop_term_fun_mor]? *)
@@ -263,8 +263,8 @@ Proof.
     simpl in Pb.
   apply (pullback_HSET_elements_unique Pb); clear Pb.
   - unfold yoneda_morphisms_data; cbn.
-    etrans. refine (pr2 (term_to_section t')). apply pathsinv0.
-    etrans. Focus 2. refine (pr2 (term_to_section t)).
+    etrans. use (pr2 (term_to_section t')). apply pathsinv0.
+    etrans. Focus 2. use (pr2 (term_to_section t)).
     etrans. apply @pathsinv0, assoc.
     etrans. apply @pathsinv0, assoc.
     apply maponpaths.
@@ -322,7 +322,7 @@ Proof.
     exists (identity _). apply tpair.
     + etrans. apply id_left. apply pathsinv0, id_right.
     + intros Γ A; cbn.
-      refine (toforallpaths _ _ _ (!functor_id (TM _) _) _).
+      use (toforallpaths _ _ _ (!functor_id (TM _) _)).
   - intros X0 X1 X2 F G Y0 Y1 Y2 FF GG.
     exists (term_fun_mor_TM FF ;; term_fun_mor_TM GG). apply tpair.
     + etrans. apply @pathsinv0. apply assoc.
@@ -332,10 +332,10 @@ Proof.
       apply pathsinv0. apply assoc.
     + intros Γ A.
       etrans. cbn. apply maponpaths, term_fun_mor_te.
-      etrans. refine (toforallpaths _ _ _
-                        (nat_trans_ax (term_fun_mor_TM _) _ _ _) _).
+      etrans. use (toforallpaths _ _ _
+                        (nat_trans_ax (term_fun_mor_TM _) _ _ _)).
       etrans. cbn. apply maponpaths, term_fun_mor_te.
-      refine (toforallpaths _ _ _ (!functor_comp (TM _) _ _) _).
+      use (toforallpaths _ _ _ (!functor_comp (TM _) _ _)).
 Defined.
 
 Definition term_fun_data : disp_cat_data (obj_ext_Precat C)
@@ -380,11 +380,11 @@ Definition qq_structure_ob_mor : disp_cat_ob_mor (obj_ext_Precat C).
 Proof.
   exists (fun X => qq_morphism_structure X).
   intros X X' Z Z' F.
-  refine (∏ Γ' Γ (f : C ⟦ Γ' , Γ ⟧) (A : Ty X Γ), _).
-  refine (qq Z f A ;; φ F A = _).
-  refine (φ F _ ;; Δ _ ;; qq Z' f _).
+  use (∏ Γ' Γ (f : C ⟦ Γ' , Γ ⟧) (A : Ty X Γ), _).
+  use (qq Z f A ;; φ F A = _).
+  use (φ F _ ;; Δ _ ;; qq Z' f _).
   revert A; apply toforallpaths.
-  refine (nat_trans_ax (obj_ext_mor_TY F) _ _ _).
+  use (nat_trans_ax (obj_ext_mor_TY F)).
 Defined.
 
 Lemma isaprop_qq_structure_mor

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
@@ -149,7 +149,7 @@ Lemma qq_from_term_mor {X X' : obj_ext_precat} {F : X --> X'}
   (W' : strucs_compat_disp_cat (X',,(Y',,Z')))
   : ∑ (FZ : Z -->[F] Z'), W -->[(F,,(FY,,FZ))] W'.
 Proof.
-  refine (_,, tt).
+  use (_,, tt).
   intros Γ' Γ f A.
   cbn in W, W', FY. unfold iscompatible_term_qq in *. 
   unfold term_fun_mor in FY.
@@ -167,8 +167,8 @@ Proof.
     apply obj_ext_mor_ax.
   - etrans. exact (toforallpaths _ _ _ (functor_comp (TM _) _ _) _).
     etrans. cbn. apply maponpaths, @pathsinv0, (term_fun_mor_te FY).
-    etrans. refine (toforallpaths _ _ _
-                      (!nat_trans_ax (term_fun_mor_TM _) _ _ _) _).
+    etrans. use (toforallpaths _ _ _
+                      (!nat_trans_ax (term_fun_mor_TM _) _ _ _)).
     etrans. cbn. apply maponpaths, @pathsinv0, W.
     etrans. apply term_fun_mor_te.
     apply pathsinv0.
@@ -245,8 +245,8 @@ Proof.
       etrans. apply maponpaths, comp_ext_compare_π.
       etrans. apply @pathsinv0, assoc.
       etrans. apply maponpaths, obj_ext_mor_ax.
-      refine (PullbackArrow_PullbackPr1
-                (mk_Pullback _ _ _ _ _ _ (qq_π_Pb _ f A)) _ _ _ _).
+      use (PullbackArrow_PullbackPr1
+                (mk_Pullback _ _ _ _ _ _ (qq_π_Pb _ f A))).
     + cbn in FZ; cbn.
       etrans. apply maponpaths_2, @pathsinv0, assoc.
       etrans. apply @pathsinv0, assoc.
@@ -335,9 +335,9 @@ Definition term_from_qq_mor_TM {X X' : obj_ext_precat} {F : X --> X'}
     (W' : strucs_compat_disp_cat (X',,(Y',,Z')))
   : TM (Y : term_fun_structure _ _) --> TM (Y' : term_fun_structure _ _).
 Proof.
-  refine ( _ ;; (tm_from_qq_mor_TM FZ : preShv C ⟦ _ , _ ⟧) ;; _).
-  - refine (given_TM_to_canonical _ _ (Y,,W)).
-  - refine (canonical_TM_to_given _ _ (Y',,W')).
+  use ( _ ;; (tm_from_qq_mor_TM FZ : preShv C ⟦ _ , _ ⟧) ;; _).
+  - exact (given_TM_to_canonical _ _ (Y,,W)).
+  - exact (canonical_TM_to_given _ _ (Y',,W')).
 Defined.
 (* TODO: better, construct these three parts as maps of qq-morphism structures, and put them together directly as that. *)
 
@@ -350,7 +350,7 @@ Lemma term_from_qq_mor {X X' : obj_ext_precat} {F : X --> X'}
 Proof.
   simpl in W, W'; unfold iscompatible_term_qq in W, W'. (* Readability *)
   simpl in Y, Y'.  (* To avoid needing casts [Y : term_fun_structure _]. *)
-  refine (_,,tt). simpl; unfold term_fun_mor.
+  use (_,,tt). simpl; unfold term_fun_mor.
   exists (term_from_qq_mor_TM FZ W W').
   apply dirprodpair; try intros Γ A.
   - etrans. apply @pathsinv0, assoc.
@@ -417,12 +417,12 @@ Proof.
       set (cd := iscontrpr1 (H (pr1 ab) (pr2 ab))). 
         exact ((pr1 ab,, (pr2 ab,, pr1 cd)),, pr2 cd).
     + intros abcd; destruct abcd as [ [a [b c] ] d]; simpl.
-      refine (@maponpaths _ _ 
+      use (@maponpaths _ _ 
         (fun cd : ∑ c' : C a, (D a b c') => (a,, b,, (pr1 cd)),, (pr2 cd))
-        _ (_,, _) _).
+        _ (_,, _)).
       apply proofirrelevancecontr, H.
     + intros ab; destruct ab as [a b]. apply idpath. }
-  use (structural_lemma _ _ _ (fun _ _ _ => unit) _ ).
+  use (structural_lemma _ _ _ (fun _ _ _ => unit)).
 (* these are all the arguments to structural_lemma 
          (obj_ext_mor X X') 
                         (fun f' => term_fun_mor Y Y' f') 
@@ -479,12 +479,12 @@ Proof.
       set (bd := iscontrpr1 (H (pr1 ac) (pr2 ac))). 
         exact ((pr1 ac,, (pr1 bd,, pr2 ac)),, pr2 bd).
     + intros abcd; destruct abcd as [ [a [b c] ] d]; simpl.
-      refine (@maponpaths _ _ 
+      use (@maponpaths _ _ 
         (fun bd : ∑ b' : B a, (D a b' c) => (a,, (pr1 bd),, c),, (pr2 bd))
-        _ (_,, _) _).
+        _ (_,, _)).
       apply proofirrelevancecontr, H.
     + intros ac; destruct ac as [a c]. apply idpath. }
-  simple refine (structural_lemma _ _ _ (fun _ _ _ => unit) _).
+  use (structural_lemma _ _ _ (fun _ _ _ => unit)).
   intros FX FY. apply iscontraprop1.
   - exact (term_from_qq_mor_unique FY W W').
   - exact (term_from_qq_mor FY W W').
@@ -523,12 +523,12 @@ Proof.
       set (cd := iscontrpr1 (H b)). 
         exact ((b,,pr1 cd),, pr2 cd).
     + intros bcd; destruct bcd as [ [b c] d]; simpl.
-      refine (@maponpaths _ _ 
+      use (@maponpaths _ _ 
         (fun cd : ∑ c', (D b c') => (b,, (pr1 cd)),, (pr2 cd))
-        _ (_,, _) _).
+        _ (_,, _)).
       apply proofirrelevancecontr, H.
     + intros b; apply idpath. }
-  simple refine (structural_lemma _ _ (fun _ _  => unit) _).
+  use (structural_lemma _ _ (fun _ _  => unit)).
   intros FY. apply iscontraprop1.
   - exact (qq_from_term_mor_unique FY W W').
   - exact (qq_from_term_mor FY W W').
@@ -582,12 +582,12 @@ Proof.
       set (bd := iscontrpr1 (H c)). 
         exact ((pr1 bd,,c),, pr2 bd).
     + intros bcd; destruct bcd as [ [b c] d]; simpl.
-      refine (@maponpaths _ _ 
+      use (@maponpaths _ _ 
         (fun bd : ∑ b', (D b' c) => ((pr1 bd),, c),, (pr2 bd))
-        _ (_,, _) _).
+        _ (_,, _)).
       apply proofirrelevancecontr, H.
     + intros c; apply idpath. }
-  simple refine (structural_lemma _ _ (fun _ _ => unit) _).
+  use (structural_lemma _ _ (fun _ _ => unit)).
   intros FY. apply iscontraprop1.
   - exact (term_from_qq_mor_unique FY W W').
   - exact (term_from_qq_mor FY W W').

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Comparison.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Comparison.v
@@ -52,7 +52,7 @@ Section Equiv_of_Types_from_Cats.
 Definition term_struc_to_qq_struc_equiv_types (X : obj_ext_Precat C)
   : term_fun_structure C X ≃ qq_morphism_structure X.
 Proof.
-  refine (weq_on_objects_from_adj_equiv_of_cats _ _ _ _ _ 
+  use (weq_on_objects_from_adj_equiv_of_cats _ _ _ _ _ 
          (term_struc_to_qq_struc_is_equiv _)).
   - apply is_univalent_fiber, is_univalent_term_fun_structure.
   - apply is_univalent_fiber, is_univalent_qq_morphism.
@@ -79,7 +79,7 @@ Lemma qq_compat_implies_eq (Y : term_fun_structure C X) {Z Z'}
   -> Z = Z'.
 Proof.
   intros W W'.
-  refine (@maponpaths _ _ pr1 (Z,,W) (Z',,W') _).
+  use (@maponpaths _ _ pr1 (Z,,W) (Z',,W')).
   apply isapropifcontr, iscontr_compatible_split_comp_structure.
 Defined.
 

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
@@ -166,7 +166,7 @@ Proof.
     refine (toforallpaths _ _ _ _ A).
     refine (toforallpaths _ _ _ _ Γ).
     eapply pathsinv0, maponpaths.
-    refine (maponpaths pr1 (functor_on_iso_inv _ _ obj_ext_to_preShv_functor _ _ _)).
+    use (maponpaths pr1 (functor_on_iso_inv _ _ obj_ext_to_preShv_functor _ _ _)).
   }
   set (F' := inv_from_iso F).
   set (FF' := iso_after_iso_inv F).
@@ -214,7 +214,7 @@ Proof.
               = pr2 X').
   { etrans. Focus 2. apply e'.
     apply pathsinv0.
-    etrans. refine (transportf_forall _ _ _). simpl.
+    etrans. use (transportf_forall _ _ _). simpl.
     apply funextsec; intros Γ.
     apply (transportf_forall_var _
      (fun (T : functor C^op hset_precategory) => T Γ : hSet)).
@@ -222,7 +222,7 @@ Proof.
   intros Γ A; simpl in A. 
   refine (_ ;; _).
     Focus 2. eapply idtoiso.
-    refine (maponpaths pr1 (toforallpaths _ _ _
+    use (maponpaths pr1 (toforallpaths _ _ _
               (toforallpaths _ _ _ H Γ) _)).
   apply Δ. destruct e; apply idpath.
   Set Printing Notations.
@@ -256,12 +256,12 @@ Proof.
   apply obj_ext_mor_eq'.
   - intros Γ; apply toforallpaths; revert Γ; apply toforallpaths.
     apply maponpaths.
-    refine (@maponpaths _ _ pr1
+    use (@maponpaths _ _ pr1
       (functor_on_iso (obj_ext_to_preShv_functor) _)
-      (functor_on_iso _ _) _).
+      (functor_on_iso _ _)).
     etrans. apply @pathsinv0, maponpaths_idtoiso.
     etrans. apply maponpaths, base_total2_paths.
-    apply (idtoiso_isotoid _ _ _ _ _).
+    use (idtoiso_isotoid).
   - intros e_TY Γ A.
     etrans. apply maponpaths_2. apply foo2. unfold foo.
     etrans. apply maponpaths_2. apply maponpaths.
@@ -331,7 +331,7 @@ Lemma idtoiso_iso_disp_to_TM_eq
 : (idtoiso (iso_disp_to_TM_eq _ _ _ FG) : _ --> _)
   = term_fun_mor_TM (FG : _ -->[_] _).
 Proof.
-  refine (maponpaths pr1 (idtoiso_isotoid _ _ _ _ _)).
+  exact (maponpaths pr1 (idtoiso_isotoid _ _ _ _ _)).
 Qed.
 
 Definition iso_to_id__term_fun_disp_cat
@@ -357,7 +357,7 @@ Proof.
       refine (toforallpaths _ _ _ _ _).
       apply maponpaths, idtoiso_iso_disp_to_TM_eq.
     etrans. apply term_fun_mor_te.
-    refine (toforallpaths _ _ _ (functor_id (TM _) _) _).
+    exact (toforallpaths _ _ _ (functor_id (TM _) _) _).
 Qed.
 
 Theorem is_univalent_term_fun_structure


### PR DESCRIPTION
The branch is misnamed, but it started with replacing the newly introduced `refine` for `weq_iso` in #128. No effort was made to replace all `refine` if the subsequent proof had to be changed. 