### PR TITLE
first try to clean up C systems

### DIFF
--- a/TypeTheory/Bsystems/STid.v
+++ b/TypeTheory/Bsystems/STid.v
@@ -2,8 +2,11 @@
 
 By Vladimir Voevodsky, started on Jan. 10, 2015 *)
 
-Unset Automatic Introduction.
 
+
+Require Import UniMath.Foundations.All.
+
+Require Import TypeTheory.Csystems.hSet_ltowers.
 Require Export TypeTheory.Bsystems.T_Tt .
 Require Export TypeTheory.Bsystems.S_St .
 
@@ -14,7 +17,6 @@ Lemma  S_dom_STid { BB : lBsystem_carrier }
            { r : Tilde BB } { X : BB }
            ( inn : T_dom ( dd r ) X ) : S_dom r ( T ( dd r ) X inn ) . 
 Proof .
-  intros . 
   unfold S_dom . 
   exact ( Tax1b _ _ _ ) . 
 Defined.
@@ -25,7 +27,6 @@ Lemma St_dom_StTtid { BB : lBsystem_carrier }
       { r s : Tilde BB } 
       ( inn : Tt_dom ( dd r ) s ) : St_dom r ( Tt ( dd r ) s inn ) . 
 Proof .
-  intros . 
   unfold St_dom .
   rewrite Ttax1 . 
   exact (  S_dom_STid Tax1b inn ) . 

--- a/TypeTheory/Bsystems/S_St.v
+++ b/TypeTheory/Bsystems/S_St.v
@@ -2,9 +2,11 @@
 
 by Vladimir Voevodsky, file created on Jan. 6, 2015 *)
 
-Unset Automatic Introduction.
 
-Require Export UniMath.Foundations.Sets.
+Require Import UniMath.Foundations.All.
+(* Require Export UniMath.Foundations.Sets. *)
+
+Require Import TypeTheory.Csystems.hSet_ltowers.
 Require Export TypeTheory.Bsystems.lB_carriers.
 
 
@@ -37,7 +39,7 @@ Notation S_dom_gth := isabove_gth .
 Definition S_dom_gt1 { BB : lBsystem_carrier } { r : Tilde BB } { Y : BB } ( inn : S_dom r Y ) :
   ll Y > 1 .
 Proof .
-  intros . exact ( natgthgehtrans _ _ _ ( isabove_gth inn ) ( natgthtogehsn _ _ ( ll_dd _ ) ) ) . 
+  exact ( natgthgehtrans _ _ _ ( isabove_gth inn ) ( natgthtogehsn _ _ ( ll_dd _ ) ) ) . 
 
 Defined.
 
@@ -45,14 +47,14 @@ Defined.
 Definition S_dom_gt0 { BB : lBsystem_carrier } { r : Tilde BB } { Y : BB } ( inn : S_dom r Y ) :
   ll Y > 0 .
 Proof .
-  intros .  exact ( istransnatgth _ _ _ ( isabove_gth inn ) ( ll_dd _ ) )  . 
+  exact ( istransnatgth _ _ _ ( isabove_gth inn ) ( ll_dd _ ) )  . 
 
 Defined.
 
 Definition S_dom_ge1 { BB : lBsystem_carrier } { r : Tilde BB } { Y : BB } ( inn : S_dom r Y ) :
   ll Y >= 1 .
 Proof .
-  intros .  exact ( natgthtogehsn _ _ ( S_dom_gt0 inn ) ) . 
+  exact ( natgthtogehsn _ _ ( S_dom_gt0 inn ) ) . 
 
 Defined.
 
@@ -60,14 +62,14 @@ Defined.
 Lemma isaprop_S_dom { BB : lBsystem_carrier } ( r : Tilde BB ) ( Y : BB ) :
   isaprop ( S_dom r Y ) . 
 Proof.
-  intros . apply isaprop_isabove . 
+  apply isaprop_isabove . 
 Defined.
 
 
 Lemma noparts_S_dom { BB : lBsystem_carrier } { r : Tilde BB } { Y : BB }
       ( inn1 inn2 : S_dom r Y ) : inn1 = inn2 .
 Proof .
-  intros . apply ( proofirrelevance _ ( isaprop_S_dom r Y ) ) .
+  apply ( proofirrelevance _ ( isaprop_S_dom r Y ) ) .
 Defined .  
 
 
@@ -83,7 +85,7 @@ Lemma S_equals_2 { BB : lBsystem_carrier } { r : Tilde BB } { Y Y' : BB } ( S : 
       ( eq : Y = Y' ) ( inn : S_dom r Y ) ( inn' : S_dom r Y' )  :
   S r Y inn = S r Y' inn' .
 Proof.
-  intros BB r Y Y' S eq .
+  revert inn inn'.
   rewrite eq . 
   intros . rewrite ( noparts_S_dom inn inn' ) . 
   apply idpath . 
@@ -105,7 +107,6 @@ Lemma ll_S_gt0 { BB : lBsystem_carrier }
       { S : S_ops_type BB } ( ax0 :  S_ax0_type S )
       { r : Tilde BB } { X : BB } ( inn : S_dom r X ) : ll ( S r X inn ) > 0 .
 Proof.
-  intros .
   rewrite ax0 .
   exact ( minusgth0 _ _ ( S_dom_gt1 inn ) ) . 
 
@@ -141,7 +142,7 @@ Lemma ftn_S { BB : lBsystem_carrier } { S : S_ops_type BB } ( ax1a : S_ax1a_type
       ( inn : S_dom r Y ) :
   ftn n (S r Y inn ) = S r ( ftn n Y ) isab .
 Proof .
-  intros BB S ax1a n . induction n as [ | n IHn ] .
+  revert r Y isab inn. induction n as [ | n IHn ] .
   + intros .
     rewrite ( noparts_S_dom inn isab ) . 
     apply idpath . 
@@ -149,7 +150,7 @@ Proof .
   change ( ftn (Preamble.S n) (S r Y inn) ) with ( ft ( ftn n (S r Y inn) ) ) .
   assert ( isab' : isabove ( ftn n Y ) ( dd r ) ) by exact ( isabove_ft_inv isab ) . 
   rewrite ( IHn r Y isab' inn ) . 
-  refine ( ax1a _ _ _ _ ) . 
+  use ax1a. 
 Defined.
 
 (** Now get the second case in Definition 2.5.4 in arXiv:1410.5389v1 from [S_ax1b_type] 
@@ -161,7 +162,6 @@ Lemma ft_S { BB : lBsystem_carrier } { S : S_ops_type BB } { r : Tilde BB } { Y 
       ( ax0 : S_ax0_type S ) ( ax1b : S_ax1b_type S ) ( iseq : ft Y = dd r )
       ( inn : S_dom r Y ) : ft ( S r Y inn ) = ft ( dd r ) .
 Proof.
-  intros .
   assert ( isov := ax1b r Y inn : isover ( S r Y inn ) ( ft ( dd r ) ) ) .
   unfold isover in isov . 
   rewrite ll_ft in isov .  rewrite ax0 in isov . rewrite <- ll_ft  in isov .
@@ -186,7 +186,6 @@ Lemma isover_S_S_2 { BB : lBsystem_carrier }
       { r : Tilde BB } { Y Y' : BB } ( inn : S_dom r Y ) ( inn' : S_dom r Y' )
       ( is : isover Y Y' ) : isover ( S r Y inn ) ( S r Y' inn' ) .
 Proof .
-  intros . 
   unfold isover in * .
   do 2 rewrite ax0 .
   simpl .
@@ -206,10 +205,9 @@ Lemma isabove_S_S_2 { BB : lBsystem_carrier }
       { r : Tilde BB } { Y Y' : BB } ( inn : S_dom r Y ) ( inn' : S_dom r Y' )
       ( is : isabove Y Y' ) : isabove ( S r Y inn ) ( S r Y' inn' ) .
 Proof .
-  intros .
-  refine ( isabove_constr _ _ ) .
+  use isabove_constr.
   do 2 rewrite ax0 .
-  refine ( natgthandminusinvr _ _ ) .
+  use natgthandminusinvr.
   exact ( isabove_gth is ) .
 
   exact ( S_dom_ge1 inn' ) . 
@@ -240,7 +238,6 @@ Notation St_dom_gth := S_dom_gth .
 Lemma St_S_dom_comp { BB : lBsystem_carrier } { r s : Tilde BB } { Y : BB }
       ( innrs : St_dom r s ) ( inn : S_dom s Y ) : S_dom r Y .
 Proof .
-  intros .
   exact ( isabove_trans inn innrs ) .
   
 Defined.
@@ -248,7 +245,6 @@ Defined.
 Lemma St_St_dom_comp { BB : lBsystem_carrier } { r s t : Tilde BB }
       ( innrs : St_dom r s ) ( innst : St_dom s t ) : St_dom r t .
 Proof .
-  intros .
   unfold St_dom in * . 
   unfold S_dom in * . 
   exact ( isabove_trans innst innrs ) . 
@@ -296,7 +292,6 @@ Lemma St_ax1_to_St_ax0 { BB : lBsystem_carrier }
       { S : S_ops_type BB } ( ax0 : S_ax0_type S )
       { St : St_ops_type BB } ( ax1 : St_ax1_type S St ) : St_ax0_type St .
 Proof .
-  intros .
   unfold St_ax0_type . 
   intros . 
   rewrite ax1 . 
@@ -314,7 +309,6 @@ Lemma ll_dd_St { BB : lBsystem_carrier } { S : S_ops_type BB } { St : St_ops_typ
       { r s : Tilde BB } ( inn : St_dom r s ) :
   ll ( dd ( St r s inn ) ) = ll ( dd s ) - 1 . 
 Proof .
-  intros .
   rewrite ax1 . 
   exact ( ax0 _ _ inn ) . 
 
@@ -327,7 +321,6 @@ Lemma S_dom_rs_sY_to_Strs_SrY { BB : lBsystem_carrier } { S : S_ops_type BB }
            { r s : Tilde BB } { Y : BB } ( innrs : St_dom r s ) ( inn : S_dom s Y ) :
   S_dom ( St r s innrs ) ( S r Y ( St_S_dom_comp innrs inn ) ) .
 Proof .
-  intros .
   unfold S_dom . 
   rewrite ax1t . 
   exact ( isabove_S_S_2 ax0 ax1a _ _ inn ) . 
@@ -339,7 +332,6 @@ Lemma S_dom_rs_sY_to_r_SsY { BB : lBsystem_carrier } { S : S_ops_type BB }
       ( innrs : St_dom r s ) ( inn : S_dom s Y ) :
   S_dom r ( S s Y inn ) .
 Proof .
-  intros . 
   unfold S_dom . 
   refine ( isabov_trans ( ax1b _ _ _ ) _ ) . 
   exact ( isover_ft' innrs ) . 
@@ -352,12 +344,11 @@ Lemma  St_dom_rs_st_to_Strs_Strt { BB : lBsystem_carrier } { S : S_ops_type BB }
            { r s t : Tilde BB } ( innrs : St_dom r s ) ( innst : St_dom s t ) :
   St_dom ( St r s innrs ) ( St r t ( St_St_dom_comp innrs innst ) ) .
 Proof .
-  intros .
   unfold St_dom .
   rewrite ax1t . 
   exact ( S_dom_rs_sY_to_Strs_SrY ax0 ax1a ax1t innrs innst ) . 
 
-Defined. 
+Defined.
 
 Lemma St_dom_rs_st_to_r_Stst { BB : lBsystem_carrier }
       { S : S_ops_type BB } ( ax1b : S_ax1b_type S )
@@ -365,7 +356,6 @@ Lemma St_dom_rs_st_to_r_Stst { BB : lBsystem_carrier }
       { r s t : Tilde BB } ( innrs : St_dom r s ) ( innst : St_dom s t ) :
   St_dom r ( St s t innst ) .
 Proof .
-  intros . 
   unfold St_dom . 
   rewrite ax1t . 
   exact ( S_dom_rs_sY_to_r_SsY ax1b innrs innst ) . 

--- a/TypeTheory/Bsystems/S_St.v
+++ b/TypeTheory/Bsystems/S_St.v
@@ -166,7 +166,7 @@ Proof.
   unfold isover in isov . 
   rewrite ll_ft in isov .  rewrite ax0 in isov . rewrite <- ll_ft  in isov .
   rewrite iseq in isov . 
-  assert ( int : (ll (dd r) - (ll (dd r) - 1)) = 1 ) . refine ( natminusmmk _ ) .
+  assert ( int : (ll (dd r) - (ll (dd r) - 1)) = 1 ) . use natminusmmk.
   exact ( natgthtogehsn _ _ ( ll_dd _ ) ) .
 
   rewrite int in isov . 
@@ -333,7 +333,7 @@ Lemma S_dom_rs_sY_to_r_SsY { BB : lBsystem_carrier } { S : S_ops_type BB }
   S_dom r ( S s Y inn ) .
 Proof .
   unfold S_dom . 
-  refine ( isabov_trans ( ax1b _ _ _ ) _ ) . 
+  use ( isabov_trans ( ax1b _ _ _ ) ) . 
   exact ( isover_ft' innrs ) . 
 
 Defined.

--- a/TypeTheory/Bsystems/S_fun.v
+++ b/TypeTheory/Bsystems/S_fun.v
@@ -2,7 +2,10 @@
 
 by Vladimir Voevodsky, started on Feb. 1, 2015 *)
 
-Unset Automatic Introduction.
+
+Require Import UniMath.Foundations.All.
+
+Require Import TypeTheory.Csystems.hSet_ltowers.
 
 Require Export TypeTheory.Bsystems.S_St .
 
@@ -17,7 +20,6 @@ Identity Coercion S_dom_to_isabove : S_ext_dom >-> isover .
 Definition S_ext { BB : lBsystem_carrier } ( S : S_ops_type BB )
            { r : Tilde BB } { X : BB } ( inn : S_ext_dom r X ) : BB .
 Proof .
-  intros. 
   destruct ( ovab_choice inn ) as [ isab | eq ] . 
   + exact ( S _ _ isab ) . 
   + exact ( ft ( dd r ) ) .
@@ -28,7 +30,6 @@ Lemma isover_S_ext { BB : lBsystem_carrier }
       { r : Tilde BB } { X : BB } ( inn : S_ext_dom r X ) :
   isover ( S_ext S inn ) ( ft ( dd r ) ) .
 Proof .
-  intros .
   unfold S_ext . 
   destruct ( ovab_choice inn ) as [ isab | eq ] .
   + exact ( ax1b _ _ _ ) . 
@@ -40,7 +41,6 @@ Lemma ll_S_ext { BB : lBsystem_carrier }
       { S : S_ops_type BB } ( ax0 : S_ax0_type S ) ( ax1b : S_ax1b_type S )
       ( r : Tilde BB ) ( X : BB ) ( inn : S_ext_dom r X ) : ll ( S_ext S inn ) = ll X - 1.
 Proof.
-  intros .
   unfold S_ext . 
   simpl . 
   destruct ( ovab_choice inn ) as [ isab | eq ] . 
@@ -58,7 +58,7 @@ Lemma isover_S_ext_S_ext_2 { BB : lBsystem_carrier }
       { r : Tilde BB } { X2 X2' : BB } ( inn : S_ext_dom r X2 ) ( inn' : S_ext_dom r X2' )
       ( is : isover X2 X2' ) : isover ( S_ext S inn ) ( S_ext S inn' ) .
 Proof .
-  intros . unfold S_ext .
+  unfold S_ext .
   destruct ( ovab_choice inn ) as [ isab | eq ] .
   + destruct ( ovab_choice inn' ) as [ isab' | eq' ] .
     * apply ( isover_S_S_2 ax0 ax1a _ _ is ) . 
@@ -85,7 +85,6 @@ Definition S_fun { BB : lBsystem_carrier }
       { S : S_ops_type BB } ( ax1b : S_ax1b_type S )
       ( r : Tilde BB ) ( X2' : ltower_over ( dd r ) ) : ltower_over ( ft ( dd r ) ) .
 Proof .
-  intros .
   set ( X2 := pr1 X2' ) . set ( isov := pr2 X2' : isover X2 ( dd r ) ) .
   split with ( S_ext S isov )  .
   apply ( isover_S_ext S ax1b ) .
@@ -101,7 +100,6 @@ Lemma isovmonot_S_fun { BB : lBsystem_carrier }
       ( X3' X2' : ltower_over ( dd r ) ) ( isov : isover X3' X2' ) :
   isover ( S_fun ax1b r X3' ) ( S_fun ax1b r X2' ) .
 Proof .
-  intros .
   apply isinvovmonot_pocto .
   unfold S_fun . simpl .
   apply ( isover_S_ext_S_ext_2 ax0 ax1a ax1b ) .
@@ -119,7 +117,6 @@ Lemma ll_S_fun { BB : lBsystem_carrier }
       { S : S_ops_type BB } ( ax0 : S_ax0_type S ) ( ax1b : S_ax1b_type S )
       { r : Tilde BB } ( X2' : ltower_over ( dd r ) ) : ll ( S_fun ax1b r X2' ) = ll X2' .
 Proof.
-  intros .
   change ( ll ( pr1 ( S_fun ax1b r X2' ) ) - ll ( ft ( dd r ) ) = ll ( pr1 X2' ) - ll ( dd r ) ) .  
   unfold S_fun . unfold S_ext . 
   simpl . 
@@ -140,7 +137,7 @@ Lemma isllmonot_S_fun { BB : lBsystem_carrier }
       { S : S_ops_type BB } ( ax0 : S_ax0_type S ) ( ax1b : S_ax1b_type S )
       ( r : Tilde BB ) : isllmonot ( S_fun ax1b r ) .
 Proof.
-  intros. unfold isllmonot. intros X Y .
+  unfold isllmonot. intros X Y .
   repeat rewrite ll_S_fun .
   + apply idpath .
   + apply ax0.
@@ -152,7 +149,7 @@ Lemma isbased_S_fun { BB : lBsystem_carrier }
       { S : S_ops_type BB } ( ax0 : S_ax0_type S ) ( ax1b : S_ax1b_type S )
       ( r : Tilde BB ) : isbased ( S_fun ax1b r ) .
 Proof.
-  intros. unfold isbased. intros X eq0 .
+  unfold isbased. intros X eq0 .
   rewrite ll_S_fun . 
   + exact eq0.
   + exact ax0.

--- a/TypeTheory/Bsystems/TS_ST.v
+++ b/TypeTheory/Bsystems/TS_ST.v
@@ -2,7 +2,10 @@
 
 By Vladimir Voevodsky, started on Jan. 10, 2015 *)
 
-Unset Automatic Introduction.
+
+Require Import UniMath.Foundations.All.
+
+Require Import TypeTheory.Csystems.hSet_ltowers.
 
 Require Export TypeTheory.Bsystems.T_Tt .
 Require Export TypeTheory.Bsystems.S_St .
@@ -15,7 +18,6 @@ Lemma S_T_dom_comp { BB : lBsystem_carrier }
        { r : Tilde BB } { X1 X2 : BB }
        ( innr1 : S_dom r X1 ) ( inn12 : T_dom X1 X2 ) : S_dom r X2 .
 Proof .   
-  intros . 
   unfold S_dom in * . 
   exact ( isabov_trans ( T_dom_isabove inn12 ) ( isover_ft' innr1 ) ) . 
 Defined.
@@ -24,7 +26,6 @@ Definition  S_Tt_dom_comp { BB : lBsystem_carrier }
            { r s : Tilde BB } { X1 : BB }
            ( innr1 : S_dom r X1 ) ( inn1s : Tt_dom X1 s ) : St_dom r s .
 Proof .
-  intros .
   exact ( S_T_dom_comp innr1 inn1s ) .
 Defined.
 
@@ -32,8 +33,7 @@ Definition  Tt_S_dom_comp { BB : lBsystem_carrier }
            { r : Tilde BB } { X1 X2 : BB }
            ( inn1r : Tt_dom X1 r ) ( innr2 : S_dom r X2 ) : T_dom X1 X2 .
 Proof .
-  intros . 
-  refine ( T_dom_constr _ _ ) . 
+  use T_dom_constr. 
   + exact ( T_dom_gt0 inn1r ) . 
   + exact ( isabove_trans innr2 ( T_dom_isabove inn1r ) ) .
 Defined.
@@ -42,7 +42,6 @@ Definition Tt_St_dom_comp { BB : lBsystem_carrier }
            { r s : Tilde BB } { X1 : BB }
            ( inn1r : Tt_dom X1 r ) ( innrs : St_dom r s ) : Tt_dom X1 s . 
 Proof .
-  intros .
   exact ( Tt_S_dom_comp inn1r innrs ) .
 Defined.
 
@@ -63,8 +62,7 @@ Lemma T_dom_r1_12_to_Sr1_Sr2 { BB : lBsystem_carrier }
       ( innr1 : S_dom r X1 ) ( inn12 : T_dom X1 X2 ) :
   T_dom ( S r X1 innr1 ) ( S r X2 ( S_T_dom_comp innr1 inn12 ) ) .
 Proof.
-  intros .
-  refine ( T_dom_constr _ _ ) . 
+  use T_dom_constr.
   + rewrite Sax0 . 
     exact ( minusgth0 _ _ ( S_dom_gt1 innr1 ) ) .
   + destruct ( isabove_choice innr1 ) as [ isab | iseq ] .
@@ -83,7 +81,6 @@ Lemma Tt_dom_r1_1s_to_Sr1_Strs { BB : lBsystem_carrier }
       ( innr1 : S_dom r X1 ) ( inn1s : Tt_dom X1 s ) :
   Tt_dom ( S r X1 innr1 ) ( St r s ( S_Tt_dom_comp innr1 inn1s ) ) . 
 Proof.
-  intros .
   unfold Tt_dom . 
   rewrite Stax1 . 
   exact ( T_dom_r1_12_to_Sr1_Sr2 Sax0 Sax1a Sax1b _ _ ) . 
@@ -98,7 +95,6 @@ Lemma  S_dom_r1_12_to_r_T12 { BB : lBsystem_carrier }
        ( innr1 : S_dom r X1 ) ( inn : T_dom X1 X2 ) :
   S_dom r ( T X1 X2 inn ) .
 Proof .
-  intros . 
   unfold S_dom .
   exact ( isabove_trans ( Tax1b _ _ inn ) innr1 ) . 
 Defined.
@@ -111,7 +107,6 @@ Lemma St_dom_r1_1s_to_r_Tt1s { BB : lBsystem_carrier }
       ( innr1 : S_dom r X1 ) ( inn1s : Tt_dom X1 s ) :
   St_dom r ( Tt X1 s inn1s ) .
 Proof .
-  intros .
   unfold St_dom . 
   rewrite Ttax1 . 
   exact ( S_dom_r1_12_to_r_T12 Tax1b innr1 inn1s ) . 
@@ -168,7 +163,6 @@ Lemma S_dom_1r_r2_to_Tt1r_T12 { BB : lBsystem_carrier }
       ( inn1r : Tt_dom X1 r ) ( innr2 : S_dom r X2 ) :
   S_dom ( Tt X1 r inn1r ) ( T X1 X2 ( Tt_S_dom_comp inn1r innr2 ) ) .
 Proof .
-  intros .
   unfold S_dom . 
   rewrite Ttax1 . 
   exact ( isabove_T_T_2 Tax0 Tax1a _ _ innr2 ) . 
@@ -181,7 +175,6 @@ Lemma St_dom_1r_rs_to_Tt1r_Tt1s { BB : lBsystem_carrier }
       ( inn1r : Tt_dom X1 r ) ( innrs : St_dom r s ) :
   St_dom ( Tt X1 r inn1r ) ( Tt X1 s ( Tt_St_dom_comp inn1r innrs ) ) .
 Proof.
-  intros . 
   unfold St_dom . 
   rewrite Ttax1 . 
   exact ( S_dom_1r_r2_to_Tt1r_T12 Tax0 Tax1a Ttax1 _ _ ) .
@@ -194,8 +187,7 @@ Lemma  T_dom_1r_r2_to_1_Sr2 { BB : lBsystem_carrier }
        { r : Tilde BB } { X1 X2 : BB }
        ( inn1r : Tt_dom X1 r ) ( innr2 : S_dom r X2 ) : T_dom X1 ( S r X2 innr2 ) .
 Proof.
-  intros .
-  refine ( T_dom_constr _ _ ) .
+  use T_dom_constr.
   + exact ( T_dom_gt0 inn1r ) . 
   + exact ( isabov_trans ( Sax1b _ _ _ ) ( isover_ft' ( T_dom_isabove inn1r ) ) ) .  
 Defined.
@@ -206,7 +198,6 @@ Lemma  Tt_dom_1r_rs_to_1_Strs { BB : lBsystem_carrier }
        { r s : Tilde BB } { X1 : BB }
        ( inn1r : Tt_dom X1 r ) ( innrs : St_dom r s ) : Tt_dom X1 ( St r s innrs )  .
 Proof .
-  intros . 
   unfold Tt_dom .
   rewrite Stax1 . 
   exact ( T_dom_1r_r2_to_1_Sr2 Sax1b inn1r _ ) . 

--- a/TypeTheory/Bsystems/T_Tt.v
+++ b/TypeTheory/Bsystems/T_Tt.v
@@ -203,10 +203,10 @@ Proof.
   assert ( eq' : ll X2 - 1 = ll X1 - 1 ) . repeat rewrite <- ll_ft .  rewrite iseq .
   apply idpath .
 
-  assert ( eq1 : ( ll X1 - 1 ) + 1 = ll X1 ) . refine ( minusplusnmm _ _ _ ) .
+  assert ( eq1 : ( ll X1 - 1 ) + 1 = ll X1 ) . use minusplusnmm.
   exact ( natgthtogehsn _ _ (T_dom_gt0 inn ) ) .
 
-  assert ( eq2 : ( ll X2 - 1 ) + 1 = ll X2 ) . refine ( minusplusnmm _ _ _ ) .
+  assert ( eq2 : ( ll X2 - 1 ) + 1 = ll X2 ) . use minusplusnmm.
   exact ( istransnatgeh _ _ _ ( T_dom_geh inn ) ( natgthtogehsn _ _ (T_dom_gt0 inn ) ) ) .
 
   assert ( eq'' := maponpaths ( fun n => n + 1 ) eq' ) . 
@@ -343,7 +343,7 @@ Lemma T_dom_12_23_to_T12_T13 { BB : lBsystem_carrier } { T : T_ops_type BB }
 Proof . 
   assert ( is21 := T_dom_isabove inn12 ) .
   assert ( is32 := T_dom_isabove inn23 ) .
-  refine ( T_dom_constr _ _ ) .
+  use T_dom_constr.
   + apply (ll_T_gt0 ax0).
   + destruct ( isabove_choice is21 ) as [ isab | eq ] .
     * rewrite ( ax1a _ _ _ isab ) . 

--- a/TypeTheory/Bsystems/T_Tt.v
+++ b/TypeTheory/Bsystems/T_Tt.v
@@ -2,9 +2,15 @@
 
 by Vladimir Voevodsky, file created on Jan. 6, 2015 *)
 
-Unset Automatic Introduction.
 
-Require Export TypeTheory.Bsystems.lB_carriers .
+Require Import UniMath.Foundations.All.
+Require Import UniMath.Combinatorics.StandardFiniteSets.
+Require Import TypeTheory.Csystems.prelim.
+Require Import TypeTheory.Csystems.lTowers.
+Require Import TypeTheory.Csystems.ltowers_over.
+Require Import TypeTheory.Csystems.hSet_ltowers.
+
+Require Import TypeTheory.Bsystems.lB_carriers.
 
 
 (** ** Operation(s) T.
@@ -20,7 +26,7 @@ presentation is very different, but the notion is meant to be equivalent.
 (** *** Domains of definition of operations of type T *)
 
 Definition T_dom { BB : lBsystem_carrier } ( X1 X2 : BB ) :=
-  dirprod ( ll X1 > 0 ) ( isabove X2 ( ft X1 ) ) .
+  ( ll X1 > 0 ) × ( isabove X2 ( ft X1 ) ) .
 
 Definition T_dom_constr { BB : lBsystem_carrier } { X1 X2 : BB }
            ( gt0 : ll X1 > 0 ) ( isab : isabove X2 ( ft X1 ) ) : T_dom X1 X2 :=
@@ -38,9 +44,9 @@ Definition T_dom_isabove { BB : lBsystem_carrier } { X1 X2 : BB } ( inn : T_dom 
 Definition T_dom_geh { BB : lBsystem_carrier } { X1 X2 : BB } ( inn : T_dom X1 X2 ) :
   ll X2 >= ll X1 .
 Proof .
-  intros . assert ( gt := T_dom_gth inn ) . 
+  assert ( gt := T_dom_gth inn ) . 
   assert ( gte := natgthtogehsn _ _ gt ) . 
-  refine ( istransnatgeh _ _ _ gte _ ) . 
+  use ( istransnatgeh _ _ _ gte) . 
   rewrite ll_ft . 
   change ( 1 + ( ll X1 - 1 ) >= ll X1 ) . 
   rewrite natpluscomm . 
@@ -51,7 +57,6 @@ Defined.
 Lemma T_dom_gt0_2 { BB : lBsystem_carrier } { X1 X2 : BB } ( inn : T_dom X1 X2 ) :
   ll X2 > 0 .
 Proof .
-  intros .
   exact ( isabove_gt0 ( T_dom_isabove inn ) ) .
           
 Defined.
@@ -61,7 +66,6 @@ Defined.
   
 Lemma isaprop_T_dom { BB : lBsystem_carrier } ( X1 X2 : BB ) : isaprop ( T_dom X1 X2 ) . 
 Proof.
-  intros . 
   apply isapropdirprod . 
   apply ( pr2 ( _ > _ ) ) .
   
@@ -72,7 +76,7 @@ Defined.
 Lemma noparts_T_dom { BB : lBsystem_carrier } { X1 X2 : BB } ( inn1 inn2 : T_dom X1 X2 ) :
   inn1 = inn2 .
 Proof .
-  intros . apply ( proofirrelevance _ ( isaprop_T_dom X1 X2 ) ) .
+  apply ( proofirrelevance _ ( isaprop_T_dom X1 X2 ) ) .
 Defined .
 
 Definition T_dom_refl { BB : lBsystem_carrier } ( X : BB ) ( gt0 : ll X > 0 ) : T_dom X X :=
@@ -81,10 +85,9 @@ Definition T_dom_refl { BB : lBsystem_carrier } ( X : BB ) ( gt0 : ll X > 0 ) : 
 Definition T_dom_comp { BB : lBsystem_carrier } { X1 X2 X3 : BB }
            ( inn12 : T_dom X1 X2 ) ( inn23 : T_dom X2 X3 ) : T_dom X1 X3 .
 Proof.
-  intros.
   assert ( gt0 := T_dom_gt0 inn12 ) . 
   assert ( is21 := T_dom_isabove inn12 ) . assert ( is32 := T_dom_isabove inn23 ) .
-  refine ( T_dom_constr _ _ ) . 
+  use T_dom_constr. 
   exact gt0 .
 
   exact ( isabov_trans is32 ( isover_ft' is21 ) ) . 
@@ -94,7 +97,7 @@ Defined.
 Lemma T_dom_ftn { BB : lBsystem_carrier } { X1 X2 : BB } ( n : nat ) ( inn : T_dom X1 X2 )
       ( isab : isabove ( ftn n X2 ) ( ft X1 ) ) : T_dom X1 ( ftn n X2 ) .
 Proof .
-  intros. exact ( T_dom_constr ( T_dom_gt0 inn ) isab ) . 
+  exact ( T_dom_constr ( T_dom_gt0 inn ) isab ) . 
 
 Defined.
 
@@ -115,7 +118,7 @@ Lemma T_equals_T { BB : lBsystem_carrier } { X1 X2 X2' : BB } ( T : T_ops_type B
       ( eq : X2 = X2' ) ( inn : T_dom X1 X2 ) ( inn' : T_dom X1 X2' )  :
   T X1 X2 inn = T X1 X2' inn' .
 Proof.
-  intros BB X1 X2 X2' T eq .
+  revert inn inn'.
   rewrite eq . 
   intros . rewrite ( noparts_T_dom inn inn' ) . 
   apply idpath . 
@@ -138,7 +141,6 @@ Lemma ll_T_gt0 { BB : lBsystem_carrier }
       { T : T_ops_type BB } ( ax0 :  T_ax0_type T )
       { X1 X2 : BB } ( inn : T_dom X1 X2 ) : ll ( T X1 X2 inn ) > 0 .
 Proof.
-  intros .
   rewrite ax0 . 
   exact ( natgthsn0 _ ) .
 
@@ -151,7 +153,7 @@ Defined.
 Lemma T_ax1a_dom { BB : lBsystem_carrier } { X1 X2 : BB } ( inn : T_dom X1 X2 )
       ( isab : isabove ( ft X2 ) ( ft X1 ) ) : T_dom X1 ( ft X2 ) .
 Proof .
-  intros. exact ( T_dom_constr ( T_dom_gt0 inn ) isab ) . 
+  exact ( T_dom_constr ( T_dom_gt0 inn ) isab ) . 
 
 Defined.
 
@@ -181,7 +183,7 @@ Lemma ftn_T { BB : lBsystem_carrier } { T : T_ops_type BB } ( ax1a : T_ax1a_type
       ( inn : T_dom X1 X2 ) :
   ftn n ( T X1 X2 inn ) = T X1 ( ftn n X2 ) ( T_dom_ftn n inn isab ) .
 Proof .
-  intros BB T ax1a n . induction n as [ | n IHn ] .
+  revert X1 X2 isab inn. induction n as [ | n IHn ] .
   + intros .
     rewrite ( noparts_T_dom inn (T_dom_ftn 0 inn isab) ) . 
     apply idpath . 
@@ -189,7 +191,7 @@ Proof .
     change ( ftn (S n) (T X1 X2 inn) ) with ( ft ( ftn n (T X1 X2 inn) ) ) .
     assert ( isab' : isabove ( ftn n X2 ) ( ft X1 ) ) by exact ( isabove_ft_inv isab ) . 
     rewrite ( IHn X1 X2 isab' inn ) . 
-    refine ( ax1a _ _ _ _ ) . 
+    use ax1a. 
 Defined.
 
 (** Now get the second case in Definition 2.5.2 in arXiv:1410.5389v1 from [T_ax1b_type] *)
@@ -198,7 +200,6 @@ Lemma ft_T { BB : lBsystem_carrier } { T : T_ops_type BB } { X1 X2 : BB } ( ax0 
       ( ax1b : T_ax1b_type T ) ( iseq : ft X2 = ft X1 ) ( inn : T_dom X1 X2 ) :
   ft ( T X1 X2 inn ) = X1 .
 Proof.
-  intros .
   assert ( isov := ax1b X1 X2 inn : isover (T X1 X2 inn) X1  ) .
   unfold isover in isov . rewrite ax0 in isov .  rewrite ( natassocpmeq _ _ _ ( T_dom_geh inn ) )
                                                          in isov . 
@@ -235,7 +236,6 @@ Lemma isover_T_T_2 { BB : lBsystem_carrier }
       { X1 X2 X2' : BB } ( inn : T_dom X1 X2 ) ( inn' : T_dom X1 X2' )
       ( is : isover X2 X2' ) : isover ( T X1 X2 inn ) ( T X1 X2' inn' ) .
 Proof .
-  intros . 
   unfold isover in * .
   do 2 rewrite ax0 .
   simpl .
@@ -257,8 +257,7 @@ Lemma isabove_T_T_2 { BB : lBsystem_carrier }
       { X1 X2 X2' : BB } ( inn : T_dom X1 X2 ) ( inn' : T_dom X1 X2' )
       ( is : isabove X2 X2' ) : isabove ( T X1 X2 inn ) ( T X1 X2' inn' ) .
 Proof .
-  intros .
-  refine ( isabove_constr _ _ ) .
+  use isabove_constr.
   do 2 rewrite ax0 . 
   exact ( isabove_gth is ) . 
 
@@ -322,7 +321,6 @@ Lemma Tt_ax1_to_Tt_ax0 { BB : lBsystem_carrier }
       { T : T_ops_type BB } ( ax0 : T_ax0_type T )
       { Tt : Tt_ops_type BB } ( ax1 : Tt_ax1_type T Tt ) : Tt_ax0_type Tt .
 Proof .
-  intros . 
   unfold Tt_ax0_type . 
   intros . 
   rewrite ax1 . 
@@ -347,7 +345,6 @@ Lemma T_dom_12_23_to_T12_T13 { BB : lBsystem_carrier } { T : T_ops_type BB }
            { X1 X2 X3 : BB } ( inn12 : T_dom X1 X2 ) ( inn23 : T_dom X2 X3 ) :
   T_dom ( T X1 X2 inn12 ) ( T X1 X3 ( T_dom_comp inn12 inn23 ) ) .
 Proof . 
-  intros . 
   assert ( is21 := T_dom_isabove inn12 ) .
   assert ( is32 := T_dom_isabove inn23 ) .
   refine ( T_dom_constr _ _ ) .
@@ -366,10 +363,9 @@ Lemma T_dom_12_23_to_T1T23 { BB : lBsystem_carrier }
            { X1 X2 X3 : BB } ( inn12 : T_dom X1 X2 ) ( inn23 : T_dom X2 X3 ) :
   T_dom X1 ( T X2 X3 inn23 ) .
 Proof .
-  intros .
-  refine ( T_dom_constr _ _ ) . 
+  use T_dom_constr. 
   + exact ( T_dom_gt0 inn12 ) . 
-  + refine ( isabov_trans ( ax1b _ _ _ ) _ ) . 
+  + use ( isabov_trans ( ax1b _ _ _ ) ) . 
     exact ( T_dom_isabove inn12 ) .
 Defined.
 
@@ -404,7 +400,6 @@ Lemma Tt_dom_12_2r_to_T12_Tt1r { BB : lBsystem_carrier } { T : T_ops_type BB }
            { X1 X2 : BB } { r : Tilde BB } ( inn12 : T_dom X1 X2 ) ( inn2r : Tt_dom X2 r ) :
   Tt_dom ( T X1 X2 inn12 ) ( Tt X1 r ( T_dom_comp inn12 inn2r ) ) .
 Proof.
-  intros . 
   unfold Tt_dom .
   rewrite ax1at . 
   apply ( T_dom_12_23_to_T12_T13 ax0 ax1a ax1b inn12 inn2r ) . 
@@ -417,7 +412,6 @@ Lemma Tt_dom_12_2r_to_Tt1Tt2r { BB : lBsystem_carrier } { T : T_ops_type BB }
       { X1 X2 : BB } { r : Tilde BB } ( inn12 : T_dom X1 X2 ) ( inn2r : Tt_dom X2 r ) :
   Tt_dom X1 ( Tt X2 r inn2r ) .
 Proof.
-  intros.
   unfold Tt_dom.
   rewrite ax1at . 
   apply ( T_dom_12_23_to_T1T23 ax1b inn12 inn2r ) .

--- a/TypeTheory/Bsystems/T_Tt.v
+++ b/TypeTheory/Bsystems/T_Tt.v
@@ -4,13 +4,9 @@ by Vladimir Voevodsky, file created on Jan. 6, 2015 *)
 
 
 Require Import UniMath.Foundations.All.
-Require Import UniMath.Combinatorics.StandardFiniteSets.
-Require Import TypeTheory.Csystems.prelim.
-Require Import TypeTheory.Csystems.lTowers.
-Require Import TypeTheory.Csystems.ltowers_over.
-Require Import TypeTheory.Csystems.hSet_ltowers.
 
-Require Import TypeTheory.Bsystems.lB_carriers.
+Require Import TypeTheory.Csystems.hSet_ltowers.
+Require Export TypeTheory.Bsystems.lB_carriers.
 
 
 (** ** Operation(s) T.

--- a/TypeTheory/Bsystems/T_fun.v
+++ b/TypeTheory/Bsystems/T_fun.v
@@ -2,21 +2,24 @@
 
 by Vladimir Voevodsky, started on Jan. 22, 2015 *)
 
-Unset Automatic Introduction.
 
+
+Require Import UniMath.Foundations.All.
+
+Require Import TypeTheory.Csystems.hSet_ltowers.
 Require Export TypeTheory.Bsystems.T_Tt .
 
 
 (** ** The definition of an extended operation T and its elementary properties. *)
 
 Definition T_ext_dom { BB : lBsystem_carrier } ( X1 X2 : BB ) :=
-  dirprod ( ll X1 > 0 ) ( isover X2 ( ft X1 ) ) .
+  ( ll X1 > 0 ) × ( isover X2 ( ft X1 ) ) .
 
 (** The only difference with [T_dom] is the possibility that X2 is ft X1. *)
 
 Definition T_ext_dom_constr { BB : lBsystem_carrier } { X1 X2 : BB }
            ( gt0 : ll X1 > 0 ) ( isov : isover X2 ( ft X1 ) ) : T_ext_dom X1 X2 :=
-  dirprodpair gt0 isov . 
+  gt0 ,, isov . 
 
 Definition T_ext_dom_gt0 { BB : lBsystem_carrier } { X1 X2 : BB } ( inn : T_ext_dom X1 X2 ) :
   ll X1 > 0:= pr1 inn .
@@ -35,9 +38,9 @@ Definition T_dom_to_T_ext_dom_ft { BB : lBsystem_carrier } { X1 X2 : BB } ( inn 
 Definition T_ext { BB : lBsystem_carrier } ( T : T_ops_type BB )
            { X1 X2 : BB } ( inn : T_ext_dom X1 X2 ) : BB .
 Proof .
-  intros. set ( gt0 := pr1 inn ) . set ( isov := pr2 inn ) . 
+  set ( gt0 := pr1 inn ) . set ( isov := pr2 inn ) . 
   destruct ( ovab_choice isov ) as [ isab | eq ] . 
-  + exact ( T _ _ ( dirprodpair gt0 isab ) ) . 
+  + exact ( T _ _ ( gt0 ,, isab ) ) . 
   + exact X1 .
 Defined.
 
@@ -48,7 +51,6 @@ Lemma isover_T_ext { BB : lBsystem_carrier }
       { X1 X2 : BB } ( inn : T_ext_dom X1 X2 ) :
   isover ( T_ext T inn ) X1 .
 Proof .
-  intros .
   unfold T_ext . 
   destruct ( ovab_choice (pr2 inn) ) as [ isab | eq ] .
   + exact ( ax1b _ _ _ ) . 
@@ -63,18 +65,17 @@ Lemma isover_T_ext_T_ext_2 { BB : lBsystem_carrier }
       { X1 X2 X2' : BB } ( inn : T_ext_dom X1 X2 ) ( inn' : T_ext_dom X1 X2' )
       ( is : isover X2 X2' ) : isover ( T_ext T inn ) ( T_ext T inn' ) .
 Proof .
-  intros . unfold T_ext .
+  unfold T_ext .
   destruct ( ovab_choice (pr2 inn) ) as [ isab | eq ] .
   + destruct ( ovab_choice (pr2 inn') ) as [ isab' | eq' ] .
     * apply ( isover_T_T_2 ax0 ax1a _ _ is ) . 
     * exact ( ax1b _ _ _ ) . 
   + destruct ( ovab_choice (pr2 inn') ) as [ isab' | eq' ] .
-    * assert ( absd : empty ) .
+    * apply fromempty. 
       rewrite eq in is . 
       assert ( ge := isover_geh is ) .  
       assert ( gt := isabove_gth isab' ) . 
       exact ( natgthnegleh gt ge ) . 
-      destruct absd . 
     * exact ( isover_XX _ ) . 
 Defined.
 
@@ -91,9 +92,8 @@ Definition T_fun_int { BB : lBsystem_carrier }
       { T : T_ops_type BB } ( ax1b : T_ax1b_type T )
       { X1 : BB } ( gt0 : ll X1 > 0 ) ( X2' : ltower_over ( ft X1 ) ) : ltower_over X1 .
 Proof .
-  intros .
   set ( X2 := pr1 X2' ) . set ( isov := pr2 X2' : isover X2 ( ft X1 ) ) .
-  split with ( T_ext T ( dirprodpair gt0 isov ) )  .
+  split with ( T_ext T ( gt0 ,, isov ) )  .
 
   apply ( isover_T_ext T ax1b ) .
 
@@ -107,7 +107,6 @@ Lemma isovmonot_T_fun { BB : lBsystem_carrier }
       ( X3' X2' : ltower_over ( ft X1 ) ) ( isov : isover X3' X2' ) :
   isover ( T_fun_int ax1b gt0 X3' ) ( T_fun_int ax1b gt0 X2' ) .
 Proof .
-  intros .
   apply isinvovmonot_pocto .
   unfold T_fun_int. simpl .
   apply ( isover_T_ext_T_ext_2 ax0 ax1a ax1b ) .
@@ -123,7 +122,6 @@ Lemma ll_T_fun { BB : lBsystem_carrier }
       { X1 : BB } ( gt0 : ll X1 > 0 ) ( X2' : ltower_over ( ft X1 ) ) :
   ll ( T_fun_int ax1b gt0 X2' ) = ll X2' .
 Proof.
-  intros. 
   change ( ll ( T_ext T ( dirprodpair gt0 ( pr2 X2' ) ) ) - ll X1 = ll X2' ) .
   change ( ll X2' ) with ( ll ( pr1 X2' ) - ll ( ft X1 ) ) . 
   unfold T_ext . 
@@ -154,7 +152,7 @@ Lemma isllmonot_T_fun { BB : lBsystem_carrier }
       { T : T_ops_type BB } ( ax0 : T_ax0_type T ) ( ax1b : T_ax1b_type T )
       { X1 : BB } ( gt0 : ll X1 > 0 ) : isllmonot ( T_fun_int ax1b gt0 ) .
 Proof.
-  intros. unfold isllmonot . 
+  unfold isllmonot . 
   intros X Y .
   do 2 rewrite ( ll_T_fun ax0 ) . 
   apply idpath . 
@@ -167,7 +165,7 @@ Lemma isbased_T_fun { BB : lBsystem_carrier }
       { T : T_ops_type BB } ( ax0 : T_ax0_type T ) ( ax1b : T_ax1b_type T )
       { X1 : BB } ( gt0 : ll X1 > 0 ) : isbased ( T_fun_int ax1b gt0 ) .
 Proof.
-  intros. red.  intros X eq0 . 
+  red.  intros X eq0 . 
   rewrite ll_T_fun . 
   + exact eq0.
   + exact ax0.
@@ -215,7 +213,6 @@ Lemma Tj_fun_compt { BB : lBsystem_carrier }
   ltower_funcomp ( Tj_fun ax0 ax1a ax1b ( isover_ft' isab ) )
                  ( T_fun ax0 ax1a ax1b ( isabove_gt0 isab ) ) . 
 Proof.
-  intros.
   unfold Tj_fun .
   rewrite (@isover_ind_isab BB _ _ _ _ _ _ ). 
   apply idpath .
@@ -509,7 +506,6 @@ Lemma Tprod_compt { BB : lBsystem_carrier }
       ( X Y : BB ) ( gt0 : ll X > 0 ) :
   Tprod_fun ax0 ax1a ax1b X Y = T_fun ax0 ax1a ax1b gt0 ( Tprod_fun ax0 ax1a ax1b ( ft X ) Y ) .
 Proof.
-  intros.
   simpl .
   unfold funcomp . 
   simpl .

--- a/TypeTheory/Bsystems/dlt.v
+++ b/TypeTheory/Bsystems/dlt.v
@@ -62,7 +62,7 @@ Lemma Tt_dom_12_to_1_dlt2 { BB : lBsystem_carrier }
       { X1 X2 : BB } ( inn12 : T_dom X1 X2 ) : Tt_dom  X1 ( dlt X2 ( T_dom_gt0_2 inn12 ) ) .
 Proof .
   unfold Tt_dom . 
-  refine (T_dom_constr _ _ ) .
+  use T_dom_constr.
   + exact ( T_dom_gt0 inn12 ) .
   + rewrite dltax1 . 
     exact ( isabove_trans ( tax1b _ _ _ ) ( T_dom_isabove inn12 ) ) .  
@@ -224,7 +224,7 @@ Proof .
   unfold St_dom. unfold S_dom.
   rewrite dltax1 .
   rewrite ttax1 .
-  refine ( isabove_T_T_2 tax0 tax1a _ _ isab ) .
+  use ( isabove_T_T_2 tax0 tax1a _ _ isab ) .
 Defined.
 
   

--- a/TypeTheory/Bsystems/dlt.v
+++ b/TypeTheory/Bsystems/dlt.v
@@ -4,8 +4,10 @@ Properties deltaT, deltaS, deltaSid and SdeltaT and StdeltaTt.
 
 By Vladimir Voevodsky, started Jan. 14, 2015 *)
 
-Unset Automatic Introduction.
 
+Require Import UniMath.Foundations.All.
+
+Require Import TypeTheory.Csystems.hSet_ltowers.
 Require Export TypeTheory.Bsystems.T_Tt.
 Require Export TypeTheory.Bsystems.S_St.
 
@@ -47,7 +49,6 @@ Lemma ll_dd_dlt { BB : lBsystem_carrier }
            { dlt : dlt_ops_type BB } ( ax1 : dlt_ax1_type T dlt )
            { X : BB } ( gt0 : ll X > 0 ) : ll ( dd ( dlt X gt0 ) ) = 1 + ll X .
 Proof .
-  intros .
   rewrite ax1 .
   rewrite ax0 . 
   exact ( idpath _ ) .
@@ -60,7 +61,6 @@ Lemma Tt_dom_12_to_1_dlt2 { BB : lBsystem_carrier }
       { dlt : dlt_ops_type BB } ( dltax1 : dlt_ax1_type T dlt )  
       { X1 X2 : BB } ( inn12 : T_dom X1 X2 ) : Tt_dom  X1 ( dlt X2 ( T_dom_gt0_2 inn12 ) ) .
 Proof .
-  intros . 
   unfold Tt_dom . 
   refine (T_dom_constr _ _ ) .
   + exact ( T_dom_gt0 inn12 ) .
@@ -95,7 +95,6 @@ Lemma St_dom_r1_to_r_dlt1 { BB : lBsystem_carrier }
       { r : Tilde BB } { X : BB } ( innr1 : S_dom r X ) :
   St_dom  r ( dlt X ( S_dom_gt0 innr1 ) ) .
 Proof .
-  intros . 
   unfold St_dom .
   unfold S_dom .
   rewrite dltax1 . 
@@ -130,7 +129,6 @@ Lemma St_dom_r_dltddr { BB : lBsystem_carrier }
       { dlt : dlt_ops_type BB } ( dltax1 : dlt_ax1_type T dlt )
       ( r : Tilde BB ) : St_dom r ( dlt ( dd r ) ( ll_dd r ) ) . 
 Proof.
-  intros .
   unfold St_dom. 
   unfold S_dom .
   rewrite dltax1 .
@@ -166,8 +164,7 @@ Identity Coercion dltSid_to_Fun: dltSid_type >-> Funclass .
 Lemma T_dom_SdltT_l1 { BB : lBsystem_carrier }
       { X1 X2 : BB } ( gt0 : ll X1 > 0 ) ( isov : isover X2 X1 ) : T_dom X1 X2 .
 Proof.
-  intros .
-  refine ( T_dom_constr gt0 _ ) . 
+  use ( T_dom_constr gt0 ) . 
   exact ( isabove_X_ftA' isov gt0 ) . 
 Defined.
   
@@ -177,10 +174,9 @@ Lemma S_dom_gt0_isab_to_dlt1_T12 { BB : lBsystem_carrier }
       { X1 X2 : BB } ( gt0 : ll X1 > 0 ) ( isab : isabove X2 X1 ) :
   S_dom ( dlt X1 gt0 ) ( T X1 X2 ( T_dom_SdltT_l1 gt0 isab ) ) .
 Proof.
-  intros .
   unfold S_dom . 
   rewrite dltax1 . 
-  refine ( isabove_T_T_2 tax0 tax1a _ _ isab ) .
+  use ( isabove_T_T_2 tax0 tax1a _ _ isab ) .
 Defined.
 
   
@@ -211,8 +207,7 @@ Lemma Tt_dom_StdltTt_l1 { BB : lBsystem_carrier }
       { X : BB } { r : Tilde BB } ( gt0 : ll X > 0 ) ( isab : isabove ( dd r ) X ) :
   Tt_dom X r .
 Proof.
-  intros .
-  refine ( T_dom_constr _ _ ) . 
+  use T_dom_constr.
   + exact gt0 . 
   + exact ( isabove_X_ftA isab ) . 
 Defined.
@@ -226,7 +221,6 @@ Lemma St_dom_gt0_isab_to_dlt1_Tt1r { BB : lBsystem_carrier }
            { X : BB } { r : Tilde BB } ( gt0 : ll X > 0 ) ( isab : isabove ( dd r ) X ) :
   St_dom ( dlt X gt0 ) ( Tt X r ( Tt_dom_StdltTt_l1 gt0 isab ) ) .
 Proof .
-  intros .
   unfold St_dom. unfold S_dom.
   rewrite dltax1 .
   rewrite ttax1 .

--- a/TypeTheory/Bsystems/lB.v
+++ b/TypeTheory/Bsystems/lB.v
@@ -2,8 +2,10 @@
 
 By Vladimir Voevodsky, started on Jan. 18, 2015 *)
 
-Unset Automatic Introduction.
 
+Require Import UniMath.Foundations.All.
+
+Require Import TypeTheory.Csystems.hSet_ltowers.
 Require Export TypeTheory.Bsystems.lB_non_unital.
 Require Export TypeTheory.Bsystems.lB0.
 
@@ -38,13 +40,10 @@ Definition dltSid_type { BB : lB_nu } ( dlt : dlt_layer ( @T_op BB ) ) :=
 (** *** Unital lB-system *)
 
 Definition lB :=
-  total2 ( fun BB : lB_nu =>
-             total2 ( fun dlt : dlt_layer ( @T_op BB ) =>
-             dirprod
-               ( dirprod
-                   ( dirprod ( dltT_type dlt ) ( dltS_type dlt ) )
-                   ( dirprod ( SdltT_type dlt ) ( StdltTt_type dlt ) ) )
-               ( dltSid_type dlt ) ) ) .
+  ∑ (BB : lB_nu) (dlt : dlt_layer ( @T_op BB )),
+               ( ( ( dltT_type dlt ) × ( dltS_type dlt ) ) ×
+                 ( ( SdltT_type dlt ) × ( StdltTt_type dlt ) ) )
+               × ( dltSid_type dlt ).
 
 (** This definition corresponds to the addition of Definition 3.2 in arXiv:1410.5389v1
     of the axioms, only the packaging order is different in irrelevant ways

--- a/TypeTheory/Bsystems/lB0.v
+++ b/TypeTheory/Bsystems/lB0.v
@@ -2,8 +2,10 @@
 
 By Vladimir Voevodsky, split off lB0systems.v on March 3, 2015 *)
 
-Unset Automatic Introduction.
 
+Require Import UniMath.Foundations.All.
+
+Require Import TypeTheory.Csystems.hSet_ltowers.
 Require Export TypeTheory.Bsystems.lB0_non_unital.
 
 
@@ -11,7 +13,7 @@ Require Export TypeTheory.Bsystems.lB0_non_unital.
 (** *** The layer associated with operations dlt *)
 
 Definition dlt_layer { BB : lBsystem_carrier } ( T : T_ops_type BB ) :=
-  total2 ( fun dlt : dlt_layer_0 BB => dlt_ax1_type T dlt ) .
+  ∑ dlt : dlt_layer_0 BB, dlt_ax1_type T dlt.
 
 Definition dlt_layer_pr1 { BB : lBsystem_carrier }
            ( T : T_ops_type BB )
@@ -27,7 +29,7 @@ Definition dlt_ax1 { BB : lBsystem_carrier } { T : T_ops_type BB } ( dlt : dlt_l
 
 
 Definition lB0system :=
-  total2 ( fun BB : lB0system_non_unital => dlt_layer ( @T_op BB ) ) .
+  ∑ BB : lB0system_non_unital, dlt_layer ( @T_op BB ).
 
 (** This definition corresponds to the addition of Definition 2.6 in arXiv:1410.5389v1
     of the axiom [dlt_ax1_type], only the packaging order is different in irrelevant ways

--- a/TypeTheory/Bsystems/lB0_non_unital.v
+++ b/TypeTheory/Bsystems/lB0_non_unital.v
@@ -2,7 +2,10 @@
 
 By Vladimir Voevodsky, started on Jan. 24, 2015 *)
 
-Unset Automatic Introduction.
+
+Require Import UniMath.Foundations.All.
+
+Require Import TypeTheory.Csystems.hSet_ltowers.
 
 Require Export TypeTheory.Bsystems.prelB. 
 Require Export TypeTheory.Bsystems.TS_ST.
@@ -16,7 +19,7 @@ Require Export TypeTheory.Bsystems.dlt .
 (** *** The layer associated with operations T *)
 
 Definition T_layer ( BB : lBsystem_carrier ) :=
-  total2 ( fun T : T_layer_0 BB => dirprod ( T_ax1a_type T ) ( T_ax1b_type T ) ) .
+  ∑ T : T_layer_0 BB, ( T_ax1a_type T ) × ( T_ax1b_type T ).
 
 (** Warning: [T_layer_0] refers to a pre-lB-system, [T_layer] refers to a lB0-system. *)
 
@@ -30,7 +33,7 @@ Coercion T_layer_to_T_layer_0 : T_layer >-> T_layer_0 .
 
 
 Definition Tt_layer { BB : lBsystem_carrier } ( T : T_ops_type BB ) :=
-  total2 ( fun Tt : Tt_ops_type BB => Tt_ax1_type T Tt ) .
+  ∑ Tt : Tt_ops_type BB, Tt_ax1_type T Tt.
 
 Definition Tt_layer_to_Tt_ops_type ( BB : lBsystem_carrier ) ( T : T_ops_type BB )
   ( Tt : Tt_layer T ) : Tt_ops_type BB := pr1 Tt .
@@ -40,7 +43,7 @@ Coercion Tt_layer_to_Tt_ops_type : Tt_layer >-> Tt_ops_type .
 (** *** The structure formed by operations T and Tt *)
 
 Definition T_Tt_layer ( BB : lBsystem_carrier ) :=
-  total2 ( fun T : T_layer BB => Tt_layer T ) .
+  ∑ T : T_layer BB, Tt_layer T.
 
 Definition T_Tt_layer_to_T_layer { BB : lBsystem_carrier } ( T_Tt : T_Tt_layer BB ) :
   T_layer BB := pr1 T_Tt .
@@ -55,7 +58,7 @@ Coercion T_Tt_layer_to_Tt_layer : T_Tt_layer >-> Tt_layer .
 
 
 Definition S_layer ( BB : lBsystem_carrier ) :=
-  total2 ( fun S : S_layer_0 BB =>  dirprod ( S_ax1a_type S ) ( S_ax1b_type S ) ) .
+  ∑ S : S_layer_0 BB, ( S_ax1a_type S ) × ( S_ax1b_type S ).
 
 Definition S_layer_to_S_layer_0 ( BB : lBsystem_carrier ) :
   S_layer BB -> S_layer_0 BB := pr1 .
@@ -66,7 +69,7 @@ Coercion S_layer_to_S_layer_0 : S_layer >-> S_layer_0 .
 
 
 Definition St_layer { BB : lBsystem_carrier } ( S : S_ops_type BB ) :=
-  total2 ( fun St : St_ops_type BB => St_ax1_type S St ) .
+  ∑ St : St_ops_type BB, St_ax1_type S St.
 
 Definition St_layer_to_St_ops_type ( BB : lBsystem_carrier ) ( S : S_ops_type BB )
   ( St : St_layer S ) : St_ops_type BB := pr1 St.
@@ -76,7 +79,7 @@ Coercion St_layer_to_St_ops_type : St_layer >-> St_ops_type .
 (** *** The structure formed by operations S and St *)
 
 Definition S_St_layer ( BB : lBsystem_carrier ) :=
-  total2 ( fun S : S_layer BB => St_layer S ) .
+  ∑ S : S_layer BB, St_layer S.
 
 Definition S_St_layer_to_S_layer { BB : lBsystem_carrier } ( S_St : S_St_layer BB ) :
   S_layer BB := pr1 S_St .
@@ -90,22 +93,21 @@ Coercion S_St_layer_to_St_layer : S_St_layer >-> St_layer .
 (** ** Complete definition of a non-unital lB0-system *)
 
 Definition T_ax1_type ( BB : prelBsystem_non_unital ) :=
-  dirprod ( T_ax1a_type ( @T_op BB ) ) ( T_ax1b_type ( @T_op BB ) ) .
+  ( T_ax1a_type ( @T_op BB ) ) × ( T_ax1b_type ( @T_op BB ) ) .
 
 Definition Tt_ax1_type' ( BB : prelBsystem_non_unital ) :=
   Tt_ax1_type ( @T_op BB ) ( @Tt_op BB ) .
 
 Definition S_ax1_type ( BB : prelBsystem_non_unital ) :=
-  dirprod ( S_ax1a_type ( @S_op BB ) ) ( S_ax1b_type ( @S_op BB ) ) .
+  ( S_ax1a_type ( @S_op BB ) ) × ( S_ax1b_type ( @S_op BB ) ) .
 
 Definition St_ax1_type' ( BB : prelBsystem_non_unital ) :=
   St_ax1_type ( @S_op BB ) ( @St_op BB ) .
 
 Definition lB0system_non_unital :=
-  total2 ( fun BB : prelBsystem_non_unital =>
-             dirprod
-               ( dirprod ( T_ax1_type BB ) ( Tt_ax1_type' BB ) )
-               ( dirprod ( S_ax1_type BB ) ( St_ax1_type' BB ) ) ) .
+  ∑ BB : prelBsystem_non_unital,
+               ( ( T_ax1_type BB ) × ( Tt_ax1_type' BB ) ) ×
+               ( ( S_ax1_type BB ) × ( St_ax1_type' BB ) ).
 
 (** This definition corresponds to Definition 2.5 in arXiv:1410.5389v1 modulo
     the details on the treatment of the second cases of 2.5.2 and 2.5.4, discussed
@@ -178,7 +180,6 @@ Definition Tj_compt { BB : lB0system_non_unital } { X A Y : BB }
   Tj isab isov2 =
   T_ext X ( Tj ( isover_ft' isab ) isov2 ) ( isabove_gt0 isab ) ( isover_Tj ( isover_ft' isab ) isov2 ) . 
 Proof.
-  intros.
   unfold Tj .  
   rewrite Tj_fun_compt . 
   apply idpath . 
@@ -197,7 +198,6 @@ Definition isover_Tprod { BB : lB0system_non_unital } ( X Y : BB ) :
 
 Lemma ll_Tprod { BB : lB0system_non_unital } ( X Y : BB ) : ll ( Tprod X Y ) = ll X + ll Y .
 Proof.
-  intros.
   unfold Tprod .
   rewrite ll_pocto .
   rewrite natpluscomm . 
@@ -210,8 +210,7 @@ Defined.
 Definition Tprod_compt { BB : lB0system_non_unital } ( X Y : BB ) ( gt0 : ll X > 0 ) :
   Tprod X Y = T_ext X ( Tprod ( ft X ) Y ) gt0 ( isover_Tprod _ _ ) .
 Proof.
-  intros.
-  assert ( int :=
+  set ( int :=
              T_fun.Tprod_compt
                ( @T_ax0 BB ) ( @T_ax1a BB ) ( @T_ax1b BB ) X Y gt0 ).
   exact ( maponpaths pocto int ) . 
@@ -225,7 +224,6 @@ Defined.
 Lemma ll_S_ext { BB : lB0system_non_unital }
       ( r : Tilde BB ) ( X : BB ) ( inn : isover X ( dd r )  ) : ll ( S_ext r X inn ) = ll X - 1.
 Proof.
-  intros.
   apply S_fun.ll_S_ext .
   + apply ( @S_ax0 BB ) .
   + apply ( @S_ax1b BB ) . 

--- a/TypeTheory/Bsystems/lB_carriers.v
+++ b/TypeTheory/Bsystems/lB_carriers.v
@@ -3,10 +3,6 @@
 by Vladimir Voevodsky, file created on Jan. 6, 2015 *)
 
 Require Import UniMath.Foundations.All.
-Require Import UniMath.Combinatorics.StandardFiniteSets.
-Require Import TypeTheory.Csystems.prelim.
-Require Import TypeTheory.Csystems.lTowers.
-Require Import TypeTheory.Csystems.ltowers_over.
 Require Import TypeTheory.Csystems.hSet_ltowers.
 
 

--- a/TypeTheory/Bsystems/lB_carriers.v
+++ b/TypeTheory/Bsystems/lB_carriers.v
@@ -2,12 +2,11 @@
 
 by Vladimir Voevodsky, file created on Jan. 6, 2015 *)
 
-
+Require Import UniMath.Foundations.All.
 Require Import UniMath.Combinatorics.StandardFiniteSets.
 Require Import TypeTheory.Csystems.prelim.
 Require Import TypeTheory.Csystems.lTowers.
-Require Import TypeTheory.Csystems.ltowers_over .
-
+Require Import TypeTheory.Csystems.ltowers_over.
 Require Import TypeTheory.Csystems.hSet_ltowers.
 
 

--- a/TypeTheory/Bsystems/lB_carriers.v
+++ b/TypeTheory/Bsystems/lB_carriers.v
@@ -2,19 +2,21 @@
 
 by Vladimir Voevodsky, file created on Jan. 6, 2015 *)
 
-Unset Automatic Introduction.
 
-Require Export TypeTheory.Csystems.hSet_ltowers.
+Require Import UniMath.Combinatorics.StandardFiniteSets.
+Require Import TypeTheory.Csystems.prelim.
+Require Import TypeTheory.Csystems.lTowers.
+Require Import TypeTheory.Csystems.ltowers_over .
+
+Require Import TypeTheory.Csystems.hSet_ltowers.
 
 
 
 (** **** lB-system carriers *)
 
 Definition lBsystem_carrier :=
-  total2 ( fun B :  hSet_pltower =>
-             total2 ( fun TildeB : hSet =>
-                        total2 ( fun dd : TildeB -> B =>
-                                   forall r : TildeB , ll ( dd r ) > 0 ) ) ) .
+  ∑ (B :  hSet_pltower)(TildeB : hSet)( dd : TildeB -> B ),
+                                   forall r : TildeB , ll ( dd r ) > 0.
 
 
 (** Note: the condition that the carrier of an lB-system is based on an h-set is used for the first
@@ -29,7 +31,6 @@ hold. *)
 Definition lBsystem_carrier_constr { B : hSet_pltower } { TildeB : hSet }
            ( dd : TildeB -> B ) ( is : forall r : TildeB, ll ( dd r ) > 0 ) : lBsystem_carrier .
 Proof .
-  intros . 
   split with B . 
 
   split with TildeB . 
@@ -50,7 +51,7 @@ Definition Tilde : lBsystem_carrier -> UU := fun BB => pr1 ( pr2 BB ) .
 Definition dd { BB : lBsystem_carrier } : Tilde BB -> BB := pr1 ( pr2 ( pr2 BB ) ) .
 
 Definition Tilde_dd { BB : lBsystem_carrier } ( X : BB ) :=
-  total2 ( fun r : Tilde BB => dd r = X ) .
+  ∑ r : Tilde BB, dd r = X.
 
 Definition Tilde_dd_pr1 { BB : lBsystem_carrier } { X : BB } : Tilde_dd X -> Tilde BB := pr1 .
 Coercion Tilde_dd_pr1 : Tilde_dd >-> Tilde . 

--- a/TypeTheory/Bsystems/lB_non_unital.v
+++ b/TypeTheory/Bsystems/lB_non_unital.v
@@ -2,8 +2,11 @@
 
 By Vladimir Voevodsky, started on Jan. 16, 2015 *)
 
-Unset Automatic Introduction.
 
+
+Require Import UniMath.Foundations.All.
+
+Require Import TypeTheory.Csystems.hSet_ltowers.
 Require Export TypeTheory.Bsystems.TS_ST.
 Require Export TypeTheory.Bsystems.STid .
 Require Export TypeTheory.Bsystems.lB0. 
@@ -19,7 +22,7 @@ Definition TT_type { BB : lB0system_non_unital } :=
 Definition TTt_type { BB : lB0system_non_unital } :=
   T_Tt.TTt_type ( @T_ax0 BB ) ( @T_ax1a BB ) ( @T_ax1b BB ) ( @Tt_ax1 BB ) .
 
-Definition TT_TTt_layer ( BB : lB0system_non_unital ) := dirprod ( @TT_type BB ) ( @TTt_type BB ) . 
+Definition TT_TTt_layer ( BB : lB0system_non_unital ) := ( @TT_type BB ) × ( @TTt_type BB ) . 
                    
 
 
@@ -31,7 +34,7 @@ Definition SSt_type { BB : lB0system_non_unital } :=
 Definition StSt_type { BB : lB0system_non_unital } :=
   S_St.StSt_type ( @S_ax0 BB ) ( @S_ax1a BB ) ( @S_ax1b BB ) ( @St_ax1 BB ) .
 
-Definition SSt_StSt_layer ( BB : lB0system_non_unital ) := dirprod ( @SSt_type BB ) ( @StSt_type BB ) . 
+Definition SSt_StSt_layer ( BB : lB0system_non_unital ) := ( @SSt_type BB ) × ( @StSt_type BB ) . 
 
 
 
@@ -44,7 +47,7 @@ Definition TtS_type { BB : lB0system_non_unital } :=
   TS_ST.TtS_type ( @T_ax1b BB ) ( @Tt_ax1 BB )
                            ( @S_ax0 BB ) ( @S_ax1a BB ) ( @S_ax1b BB ) ( @St_ax1 BB ) .
 
-Definition TS_TtS_layer ( BB : lB0system_non_unital ) := dirprod ( @TS_type BB ) ( @TtS_type BB ) .
+Definition TS_TtS_layer ( BB : lB0system_non_unital ) := ( @TS_type BB ) × ( @TtS_type BB ) .
 
 
 
@@ -56,7 +59,7 @@ Definition STt_type { BB : lB0system_non_unital } :=
 Definition StTt_type { BB : lB0system_non_unital } :=
   TS_ST.StTt_type ( @T_ax0 BB ) ( @T_ax1a BB ) ( @Tt_ax1 BB )  ( @S_ax1b BB ) ( @St_ax1 BB ) .
 
-Definition ST_StTt_layer ( BB : lB0system_non_unital ) := dirprod ( @STt_type BB ) ( @StTt_type BB ) .
+Definition ST_StTt_layer ( BB : lB0system_non_unital ) := ( @STt_type BB ) × ( @StTt_type BB ) .
 
 
 
@@ -68,7 +71,7 @@ Definition STid_type { BB : lB0system_non_unital } :=
 Definition StTtid_type { BB : lB0system_non_unital } :=
   STid.StTtid_type ( @T_ax1b BB ) ( @Tt_ax1 BB ) ( @St_op BB ) .
 
-Definition STid_layer ( BB : lB0system_non_unital ) := dirprod ( @STid_type BB ) ( @StTtid_type BB ) .
+Definition STid_layer ( BB : lB0system_non_unital ) := ( @STid_type BB ) × ( @StTtid_type BB ) .
 
 
 
@@ -78,12 +81,10 @@ Definition STid_layer ( BB : lB0system_non_unital ) := dirprod ( @STid_type BB )
 
 
 Definition lB_nu :=
-  total2 ( fun BB : lB0system_non_unital =>
-             dirprod
-               ( dirprod
-                   ( dirprod ( TT_TTt_layer BB ) ( SSt_StSt_layer BB ) )
-                   ( dirprod ( TS_TtS_layer BB ) ( ST_StTt_layer BB ) ) )
-               ( STid_layer BB ) ) .
+  ∑ BB : lB0system_non_unital,
+               ( ( ( TT_TTt_layer BB ) × ( SSt_StSt_layer BB ) ) ×
+                 ( ( TS_TtS_layer BB ) × ( ST_StTt_layer BB ) ) )
+                 × ( STid_layer BB ).
 
 (** This definition corresponds to Definition 3.1 in arXiv:1410.5389v1. *)
                                                              

--- a/TypeTheory/Bsystems/lB_to_precat.v
+++ b/TypeTheory/Bsystems/lB_to_precat.v
@@ -49,8 +49,8 @@ Fixpoint Tilden_dd { BB : prelBsystem_non_unital } ( n : nat )  ( X : BB )  : UU
     | 0 => unit
     | S n' => match n' with
                 | 0 => Tilde_dd X
-                | S n'' => total2 ( fun s1 : Tilde_dd ( ftn ( S n'' ) X ) =>
-                                      Tilden_dd n' ( S_op s1 X ( Tilden_dd_inn s1 ) ) )
+                | S n'' => ∑ s1 : Tilde_dd ( ftn ( S n'' ) X ),
+                                      Tilden_dd n' ( S_op s1 X ( Tilden_dd_inn s1 ) )
               end
   end .
 
@@ -143,8 +143,8 @@ Proof .
         (rewrite ll_ft ; rewrite eq ; simpl ; rewrite natminuseqn ; apply idpath).
     set ( Mor_X1_ftA := pr1 ( IHn ( ft A ) eqft ) ) .
     set ( Mor_X1_A :=
-          total2 ( fun ftf : Mor_X1_ftA =>
-                     Tilde_dd ( pocto ( ( pr2 ( IHn ( ft A ) eqft ) ftf ) ( X_over_ftX A ) ) ) ) ) .
+          ∑ ftf : Mor_X1_ftA,
+                     Tilde_dd ( pocto ( ( pr2 ( IHn ( ft A ) eqft ) ftf ) ( X_over_ftX A ) ) ) ).
     split with Mor_X1_A . 
     intro f . 
     set ( ftf := pr1 f : Mor_X1_ftA ) .

--- a/TypeTheory/Bsystems/lB_to_precat.v
+++ b/TypeTheory/Bsystems/lB_to_precat.v
@@ -2,8 +2,10 @@
 
 by Vladimir Voevodsky, started on Jan. 22, 2015 *)
 
-Unset Automatic Introduction.
 
+Require Import UniMath.Foundations.All.
+
+Require Import TypeTheory.Csystems.hSet_ltowers.
 Require Export TypeTheory.Bsystems.T_fun.
 Require Export TypeTheory.Bsystems.S_fun.
 
@@ -24,7 +26,6 @@ axiom ax0. *)
 Lemma Tilden_dd_inn { BB : prelBsystem_non_unital }
       { n' : nat } { X : BB } ( s : Tilde_dd ( ftn ( S n' ) X ) ) : S_dom s X .
 Proof.
-  intros.
   unfold S_dom .
   destruct s as [ s' eq ].
   assert ( gt0 : ll ( ftn ( S n' ) X ) > 0 ) by (rewrite <- eq; apply ll_dd).
@@ -126,13 +127,13 @@ operation f_star *)
 
 Definition Mor_and_fstar { BB : lB0system_non_unital }
            ( X1 : BB ) ( n : nat ) ( A : BB ) ( eq : ll A = n ) : 
-  total2 ( fun Mor_X1_A : UU =>
+  ∑ Mor_X1_A : UU,
              forall f : Mor_X1_A ,
-               ltower_fun ( ltower_over A ) ( ltower_over X1 ) ) .
+               ltower_fun ( ltower_over A ) ( ltower_over X1 ) .
 
 (** Notice that [f] is vacuously bound. *)
 Proof .
-  intros until n . induction n as [ | n IHn ] . 
+  revert A eq. induction n as [ | n IHn ] . 
   + intros . 
     split with unit .
     intro .

--- a/TypeTheory/Bsystems/prelB.v
+++ b/TypeTheory/Bsystems/prelB.v
@@ -2,8 +2,11 @@
 
 By Vladimir Voevodsky, split off the file prelBsystems.v on March 3, 2015 *)
 
-Unset Automatic Introduction.
 
+
+Require Import UniMath.Foundations.All.
+
+Require Import TypeTheory.Csystems.hSet_ltowers.
 Require Export TypeTheory.Bsystems.prelB_non_unital.
 Require Export TypeTheory.Bsystems.dlt.
 
@@ -14,7 +17,7 @@ Require Export TypeTheory.Bsystems.dlt.
 
 
 Definition dlt_layer_0 ( BB : lBsystem_carrier ) :=
-  total2 ( fun dlt : dlt_ops_type BB => dlt_ax0_type dlt ) .
+  ∑ dlt : dlt_ops_type BB, dlt_ax0_type dlt.
 
 Definition dlt_layer_0_to_dlt_ops_type ( BB : lBsystem_carrier ) :
   dlt_layer_0 BB -> dlt_ops_type BB := pr1 .
@@ -25,7 +28,7 @@ Coercion dlt_layer_0_to_dlt_ops_type : dlt_layer_0 >-> dlt_ops_type .
 
 
 Definition prelBsystem :=
-  total2 ( fun BB : prelBsystem_non_unital => dlt_layer_0 BB ) .
+  ∑ BB : prelBsystem_non_unital, dlt_layer_0 BB.
 
 (** This definition adds exactly what Definition 2.2 adds in arXiv:1410.5389v1
     to a non-unital pre-B-system. *)

--- a/TypeTheory/Bsystems/prelB_non_unital.v
+++ b/TypeTheory/Bsystems/prelB_non_unital.v
@@ -2,8 +2,11 @@
 
 By Vladimir Voevodsky, started on Jan. 24, 2015 *)
 
-Unset Automatic Introduction.
 
+
+Require Import UniMath.Foundations.All.
+
+Require Import TypeTheory.Csystems.hSet_ltowers.
 Require Export TypeTheory.Bsystems.T_fun.
 Require Export TypeTheory.Bsystems.S_fun .
 
@@ -14,7 +17,7 @@ Require Export TypeTheory.Bsystems.S_fun .
 (** *** The structure formed by operations T *)
 
 Definition T_layer_0 ( BB : lBsystem_carrier ) :=
-  total2 ( fun T : T_ops_type BB =>  T_ax0_type T ) .
+  ∑ T : T_ops_type BB, T_ax0_type T.
 
 Definition T_layer_0_to_T_ops_type ( BB : lBsystem_carrier ) ( T : T_layer_0 BB ) :
   T_ops_type BB := pr1 T .
@@ -24,7 +27,7 @@ Coercion T_layer_0_to_T_ops_type : T_layer_0 >-> T_ops_type .
 (** *** The structure formed by operations Tt *)
 
 Definition Tt_layer_0 ( BB : lBsystem_carrier ) :=
-  total2 ( fun Tt : Tt_ops_type BB => Tt_ax0_type Tt ) .
+  ∑ Tt : Tt_ops_type BB, Tt_ax0_type Tt.
 
 Definition Tt_layer_0_to_Tt_ops_type ( BB : lBsystem_carrier ) :
   Tt_layer_0 BB -> Tt_ops_type BB := pr1 .
@@ -35,7 +38,7 @@ Coercion Tt_layer_0_to_Tt_ops_type : Tt_layer_0 >-> Tt_ops_type .
 
 
 Definition S_layer_0 ( BB : lBsystem_carrier ) :=
-  total2 ( fun S : S_ops_type BB => S_ax0_type S ) .
+  ∑ S : S_ops_type BB, S_ax0_type S.
 
 Definition S_layer_0_to_S_ops_type { BB : lBsystem_carrier } ( S : S_layer_0 BB ) :
   S_ops_type BB := pr1 S .
@@ -47,7 +50,7 @@ Coercion S_layer_0_to_S_ops_type : S_layer_0 >-> S_ops_type .
 
 
 Definition St_layer_0 ( BB : lBsystem_carrier ) :=
-  total2 ( fun St : St_ops_type BB => St_ax0_type St ) .
+  ∑ St : St_ops_type BB, St_ax0_type St.
 
 Definition St_layer_0_to_St_ops_type ( BB : lBsystem_carrier ) :
   St_layer_0 BB -> St_ops_type BB := pr1 .
@@ -58,10 +61,9 @@ Coercion St_layer_0_to_St_ops_type : St_layer_0 >-> St_ops_type .
 (** ** Complete definition of a non-unital pre-lB-system *)
 
 Definition prelBsystem_non_unital :=
-  total2 ( fun BB : lBsystem_carrier =>
-             dirprod
-               ( dirprod ( T_layer_0 BB ) ( Tt_layer_0 BB ) )
-               ( dirprod ( S_layer_0 BB ) ( St_layer_0 BB ) ) ) .
+  ∑ BB : lBsystem_carrier,
+               (( T_layer_0 BB ) × ( Tt_layer_0 BB ) ) ×
+               (( S_layer_0 BB ) × ( St_layer_0 BB ) ).
 
 (** This definition closely corresponds to Definition 2.1 in arXiv:1410.5389v1. What is different
     is the underlying notion of [lBsystem_carrier] that is less specific on [TildeB] and already

--- a/TypeTheory/Csystems/hSet_ltowers.v
+++ b/TypeTheory/Csystems/hSet_ltowers.v
@@ -6,86 +6,77 @@ Require Import UniMath.Foundations.All.
 Require Export TypeTheory.Csystems.ltowers_over.
 
 
+Definition hSet_ltower := ∑ T : ltower, isaset T.
 
-Definition hSet_ltower := ∑ T : ltower, isaset T .
+Definition hSet_ltower_constr ( T : ltower ) ( is : isaset T ):
+  hSet_ltower := T ,, is. 
 
-Definition hSet_ltower_constr ( T : ltower ) ( is : isaset T ) : hSet_ltower :=
-  T ,, is. 
+Definition hSet_ltower_pr1: hSet_ltower -> ltower := pr1. 
+Coercion hSet_ltower_pr1: hSet_ltower >-> ltower.
 
-Definition hSet_ltower_pr1 : hSet_ltower -> ltower := pr1 . 
-Coercion hSet_ltower_pr1 : hSet_ltower >-> ltower .
+Definition isasetB ( T : hSet_ltower ): isaset T := pr2 T.
 
-Definition isasetB ( T : hSet_ltower ) : isaset T := pr2 T .
-
-Lemma isaprop_isover { T : hSet_ltower } ( X A : T ) : isaprop ( isover X A ) .
-Proof .
-  exact ( isasetB _ _ _ ) . 
-
+Lemma isaprop_isover { T : hSet_ltower } ( X A : T ): isaprop ( isover X A ).
+Proof.
+  use isasetB.
 Defined.
 
-Lemma isaprop_isabove { T : hSet_ltower } ( X A : T ) : isaprop ( isabove X A ) . 
+Lemma isaprop_isabove { T : hSet_ltower } ( X A : T ): isaprop ( isabove X A ). 
 Proof. 
-  apply isapropdirprod . 
-  exact ( pr2 ( _ > _ ) ) .
-
-  exact ( isaprop_isover _ _ ) . 
-
-Defined .
+  apply isapropdirprod. 
+  - exact ( pr2 ( _ > _ ) ).
+  - use isaprop_isover. 
+Defined.
 
 Definition hSet_pltower := ∑ T : hSet_ltower, ispointed_type T.
 
-Definition hSet_pltower_constr ( T : hSet_ltower ) ( is : ispointed_type T ) : hSet_pltower :=
-  T ,, is. 
+Definition hSet_pltower_constr ( T : hSet_ltower ) ( is : ispointed_type T ):
+  hSet_pltower := T ,, is. 
 
 
-Definition hSet_pltowers_to_pltowers : hSet_pltower -> pltower :=
-  fun T => pltower_constr ( pr2 T ) . 
-Coercion hSet_pltowers_to_pltowers : hSet_pltower >-> pltower . 
+Definition hSet_pltowers_to_pltowers: hSet_pltower -> pltower :=
+  fun T => pltower_constr ( pr2 T ). 
+Coercion hSet_pltowers_to_pltowers : hSet_pltower >-> pltower. 
 
-Definition hSet_pltowers_pr1 : hSet_pltower -> hSet_ltower := pr1 . 
-Coercion hSet_pltowers_pr1 : hSet_pltower >-> hSet_ltower . 
+Definition hSet_pltowers_pr1: hSet_pltower -> hSet_ltower := pr1. 
+Coercion hSet_pltowers_pr1: hSet_pltower >-> hSet_ltower. 
 
 
 
 Lemma isinvovmonot_pocto { T : hSet_ltower } { A : T } { X Y : ltower_over A }
-      ( isov : isover ( pocto X ) ( pocto Y ) ) : isover X Y .  
-Proof .
-  use ( invmaponpathsincl pr1 ) . 
-  apply isinclpr1 . 
-  intro x . 
-  apply isaprop_isover .
-
-  rewrite ll_over_minus_ll_over . 
-  rewrite ltower_over_ftn . 
-  exact isov . 
-
-  change ( ll X ) with ( ll ( pr1 X ) - ll A ) . 
-  apply natgehandminusl . 
-  exact ( isover_geh ( isov_isov Y ) ) . 
-
+      ( isov : isover ( pocto X ) ( pocto Y ) ): isover X Y.  
+Proof.
+  use ( invmaponpathsincl pr1 ). 
+  - apply isinclpr1. 
+    intro x. 
+    apply isaprop_isover.
+  - rewrite ll_over_minus_ll_over. 
+    rewrite ltower_over_ftn. 
+    + exact isov. 
+    + change ( ll X ) with ( ll ( pr1 X ) - ll A ). 
+      apply natgehandminusl. 
+      exact ( isover_geh ( isov_isov Y ) ). 
 Defined.
 
 
 
-Lemma isaset_ltower_over { T : hSet_ltower } ( X : T ) : isaset ( ltower_over X ) .
-Proof .
-  apply ( isofhleveltotal2 2 ) . 
-  exact ( pr2 T ) . 
-
-  intro x .
-  apply isasetaprop . 
-  apply isaprop_isover . 
-
+Lemma isaset_ltower_over { T : hSet_ltower } ( X : T ): isaset ( ltower_over X ).
+Proof.
+  apply ( isofhleveltotal2 2 ). 
+  - exact ( pr2 T ). 
+  - intro x.
+    apply isasetaprop. 
+    apply isaprop_isover. 
 Defined.
 
 
 
-Definition hSet_ltower_over { T : hSet_ltower } ( X : T ) : hSet_ltower :=
-  tpair ( fun T : ltower => isaset T ) ( ltower_over X ) ( isaset_ltower_over X ) . 
+Definition hSet_ltower_over { T : hSet_ltower } ( X : T ): hSet_ltower :=
+  tpair ( fun T : ltower => isaset T ) ( ltower_over X ) ( isaset_ltower_over X ). 
 
 
-Definition hSet_pltower_over { T : hSet_ltower } ( X : T ) : hSet_pltower :=
-  tpair _ ( hSet_ltower_over X ) ( pr2 ( pltower_over X ) ) . 
+Definition hSet_pltower_over { T : hSet_ltower } ( X : T ): hSet_pltower :=
+  hSet_ltower_over X  ,, pr2 ( pltower_over X ). 
 
 
 
@@ -93,19 +84,16 @@ Definition hSet_pltower_over { T : hSet_ltower } ( X : T ) : hSet_pltower :=
 
   
 Lemma isovmonot_to_ltower_over { T : hSet_pltower }
-      { X Y : T } ( isov : isover X Y ) : isover ( to_ltower_over X ) ( to_ltower_over Y ) .
-Proof .
-  use ( @isinvovmonot_pocto T ( cntr T ) (to_ltower_over X) (to_ltower_over Y) isov ) . 
-
+      { X Y : T } ( isov : isover X Y ) : isover ( to_ltower_over X ) ( to_ltower_over Y ).
+Proof.
+  use ( @isinvovmonot_pocto T ( cntr T ) (to_ltower_over X) (to_ltower_over Y) isov ). 
 Defined.
 
 
-Definition ltower_fun_to_ltower_over { T : hSet_pltower }  :
+Definition ltower_fun_to_ltower_over { T : hSet_pltower }:
   ltower_fun T ( hSet_ltower_over ( cntr T ) ) :=
   ltower_fun_constr ( @isovmonot_to_ltower_over T )
-                     ( @isllmonot_to_ltower_over T ) ( @isbased_to_ltower_over T ) . 
-
-
+                     ( @isllmonot_to_ltower_over T ) ( @isbased_to_ltower_over T ). 
 
 
 
@@ -113,75 +101,73 @@ Definition ltower_fun_to_ltower_over { T : hSet_pltower }  :
 
 
 Definition lft { T : hSet_ltower }
-           { X : T } { X' : ltower_over X } ( X'' : ltower_over ( pocto X' ) ) : ltower_over X' .
-Proof .
+           { X : T } { X' : ltower_over X } ( X'' : ltower_over ( pocto X' ) ): ltower_over X'.
+Proof.
   use obj_over_constr.
-  split with ( pocto X'' ) . 
-  apply ( isover_trans ( isov_isov X'' ) ( isov_isov X' ) ) .
-  apply isinvovmonot_pocto . 
-  simpl .
-  exact ( isov_isov X'' ) . 
-
+  - split with ( pocto X'' ). 
+    apply ( isover_trans ( isov_isov X'' ) ( isov_isov X' ) ).
+  - apply isinvovmonot_pocto. 
+    simpl.
+    exact ( isov_isov X'' ). 
 Defined.
 
-Lemma ll_lft { T : hSet_ltower }
-      { X : T } { X' : ltower_over X } ( X'' : ltower_over ( pocto X' ) ) :
-  ll ( lft X'' ) = ll X'' .
-Proof.
-  change _ with
-  ( ll ( pr1 X'' ) - ll X - ( ll ( pr1 X' ) - ll X ) = ll ( pr1 X'' ) - ll ( pr1 X' ) ) .
-  rewrite natminusassoc . 
-  rewrite natpluscomm . 
-  rewrite ( minusplusnmm _ _ ( isover_geh ( isov_isov X' ) ) ) . 
-  apply idpath . 
 
+Lemma ll_lft { T : hSet_ltower }
+      { X : T } { X' : ltower_over X } ( X'' : ltower_over ( pocto X' ) ):
+  ll ( lft X'' ) = ll X''.
+Proof.
+  change
+  ( ll ( pr1 X'' ) - ll X - ( ll ( pr1 X' ) - ll X ) = ll ( pr1 X'' ) - ll ( pr1 X' ) ).
+  rewrite natminusassoc. 
+  rewrite natpluscomm. 
+  rewrite ( minusplusnmm _ _ ( isover_geh ( isov_isov X' ) ) ). 
+  apply idpath.
 Defined.
 
   
 
 Lemma isovmonot_lft { T : hSet_ltower }
-      { X : T } ( X' : ltower_over X ) : isovmonot ( @lft _ _ X' ) .
+      { X : T } ( X' : ltower_over X ): isovmonot ( @lft _ _ X' ).
 Proof .
-  unfold isovmonot . 
-  intros X0 Y isov . 
-  apply ( @isinvovmonot_pocto ( hSet_ltower_over X ) ) .
-  simpl . 
+  unfold isovmonot. 
+  intros X0 Y isov. 
+  apply ( @isinvovmonot_pocto ( hSet_ltower_over X ) ).
+  simpl. 
   apply isinvovmonot_pocto. 
-  simpl . 
-  apply ( isovmonot_pocto _ isov ) . 
-
+  simpl. 
+  apply ( isovmonot_pocto _ isov ). 
 Defined.
-
 
 
 Lemma isllmonot_lft { T : hSet_ltower }
-      { X : T } ( X' : ltower_over X ) : isllmonot ( @lft _ _ X' ) .
-Proof .
-  unfold isllmonot . intros .
-  repeat rewrite ll_lft . 
-  apply idpath . 
-
+      { X : T } ( X' : ltower_over X ): isllmonot ( @lft _ _ X' ).
+Proof.
+  unfold isllmonot.
+  intros.
+  do 2 rewrite ll_lft. 
+  apply idpath. 
 Defined.
+
 
 Lemma isbased_lft { T : hSet_ltower }
-      { X : T } ( X' : ltower_over X ) : isbased ( @lft _ _ X' ) .
+      { X : T } ( X' : ltower_over X ): isbased ( @lft _ _ X' ).
 Proof.
-  unfold isbased. intros X0 eq0. rewrite ll_lft. exact eq0 .
-
+  unfold isbased.
+  intros X0 eq0.
+  rewrite ll_lft.
+  exact eq0.
 Defined.
 
 
 
-
-
-Definition ovmonot_lft { T : hSet_ltower } { X : T } ( X' : ltower_over X ) :
+Definition ovmonot_lft { T : hSet_ltower } { X : T } ( X' : ltower_over X ):
   ovmonot_fun ( ltower_over ( pocto X' ) ) ( ltower_over X' ) :=
-  ovmonot_fun_constr _ ( isovmonot_lft X' ) .
+  ovmonot_fun_constr _ ( isovmonot_lft X' ).
 
 
-Definition ltower_fun_lft { T : hSet_ltower } { X : T } ( X' : ltower_over X ) :
+Definition ltower_fun_lft { T : hSet_ltower } { X : T } ( X' : ltower_over X ):
   ltower_fun ( ltower_over ( pocto X' ) ) ( ltower_over X' ) :=
-  ltower_fun_constr ( isovmonot_lft X' ) ( isllmonot_lft X' ) ( isbased_lft X' ) . 
+  ltower_fun_constr ( isovmonot_lft X' ) ( isllmonot_lft X' ) ( isbased_lft X' ). 
 
 
 
@@ -189,200 +175,173 @@ Definition ltower_fun_lft { T : hSet_ltower } { X : T } ( X' : ltower_over X ) :
 
 
 Definition ovmonot_over { T1 T2 : hSet_ltower } ( f : ovmonot_fun T1 T2 )
-           ( X : T1 ) : ovmonot_fun ( ltower_over X ) ( ltower_over ( f X ) ) .
-Proof .
+           ( X : T1 ): ovmonot_fun ( ltower_over X ) ( ltower_over ( f X ) ).
+Proof.
   use ovmonot_fun_constr.
-  intro X' . 
-  split with ( f ( pocto X' ) ) . 
-  apply ( pr2 f ) . 
-  apply ( isov_isov X' ) . 
-
-  intros X0 Y isov . simpl .
-  apply isinvovmonot_pocto . 
-  simpl .
-  apply ( pr2 f ) . 
-  apply ( isovmonot_pocto _ isov ) . 
-
+ -  intro X'. 
+    split with ( f ( pocto X' ) ). 
+    apply ( pr2 f ) . 
+    apply ( isov_isov X' ) . 
+ - intros X0 Y isov.
+   simpl.
+   apply isinvovmonot_pocto. 
+   simpl.
+   apply ( pr2 f ). 
+   apply ( isovmonot_pocto _ isov ). 
 Defined.
 
 
 Lemma isllmonot_ovmonot_over { T1 T2 : hSet_ltower } { f : ovmonot_fun T1 T2 } ( isf : isllmonot f )
-      ( X : T1 ) : isllmonot ( ovmonot_over f X ) .
+      ( X : T1 ): isllmonot ( ovmonot_over f X ).
 Proof.
-  unfold isllmonot .
-  intros X0 Y . 
-  change _ with ( ll ( f ( pr1 X0 ) ) - ll ( f X ) - ( ll ( f ( pr1 Y ) ) - ll ( f X ) ) =
-                  ll X0 - ll Y ) . 
-  repeat rewrite isf . 
-  apply idpath .
-
+  unfold isllmonot.
+  intros X0 Y. 
+  change ( ll ( f ( pr1 X0 ) ) - ll ( f X ) - ( ll ( f ( pr1 Y ) ) - ll ( f X ) ) =
+           ll X0 - ll Y ). 
+  do 2 rewrite isf. 
+  apply idpath.
 Defined.
+
 
 Lemma isbased_ovmonot_over { T1 T2 : hSet_ltower }
       { f : ovmonot_fun T1 T2 } ( isf : isllmonot f ) 
-      ( X : T1 ) : isbased ( ovmonot_over f X ) .
+      ( X : T1 ): isbased ( ovmonot_over f X ).
 Proof.
-  unfold isbased. intros X0 eq0 . 
-  change _ with ( ll ( pr1 X0 ) - ll X = 0 ) in eq0 . 
-  change _ with ( ll ( f ( pr1 X0 ) ) - ll ( f X ) = 0 ) .
-  rewrite isf . 
-  exact eq0 .
-
+  unfold isbased.
+  intros X0 eq0. 
+  change ( ll ( pr1 X0 ) - ll X = 0 ) in eq0. 
+  change ( ll ( f ( pr1 X0 ) ) - ll ( f X ) = 0 ).
+  rewrite isf. 
+  exact eq0.
 Defined.
 
 
-
-Definition ltower_fun_over { T1 T2 : hSet_ltower } ( f : ovmonot_fun T1 T2 ) ( isf : isllmonot f )
-           ( X : T1 ) : ltower_fun ( ltower_over X ) ( ltower_over ( f X ) ) :=
+Definition ltower_fun_over { T1 T2 : hSet_ltower } ( f : ovmonot_fun T1 T2 )
+  ( isf : isllmonot f ) ( X : T1 ): ltower_fun ( ltower_over X ) ( ltower_over ( f X ) ) :=
   ltower_fun_constr ( pr2 ( ovmonot_over f X )  )
-                    ( isllmonot_ovmonot_over isf X ) ( isbased_ovmonot_over isf X ) . 
-
-
-
+                    ( isllmonot_ovmonot_over isf X ) ( isbased_ovmonot_over isf X ). 
 
   
 
 (** **** The function to_over_pocto *)
 
-
-
-
-
 Definition to_over_pocto  { T : hSet_ltower } { X : T } ( X' : ltower_over X )
-           ( X'' : ltower_over X' ) : ltower_over ( pocto X' ) .
-Proof .
-  split with ( pocto ( pocto X'' ) ) . 
-  apply isovmonot_pocto . 
-  apply ( isov_isov X'' ) .
-
+           ( X'' : ltower_over X' ): ltower_over ( pocto X' ).
+Proof.
+  split with ( pocto ( pocto X'' ) ). 
+  apply isovmonot_pocto. 
+  apply ( isov_isov X'' ).
 Defined.
 
 
-
-Lemma isovmonot_to_over_pocto { T : hSet_ltower } { X : T } ( X' : ltower_over X ) :
-  isovmonot ( to_over_pocto X' ) . 
-Proof .
+Lemma isovmonot_to_over_pocto { T : hSet_ltower } { X : T } ( X' : ltower_over X ):
+  isovmonot ( to_over_pocto X' ). 
+Proof.
   unfold isovmonot. 
-  intros X0 Y isov .
-  simpl .
-  apply isinvovmonot_pocto . 
-  simpl .
-  apply isovmonot_pocto .  apply isovmonot_pocto . 
-  apply isov . 
-
+  intros X0 Y isov.
+  simpl.
+  apply isinvovmonot_pocto. 
+  simpl.
+  apply isovmonot_pocto.
+  apply isovmonot_pocto. 
+  exact isov. 
 Defined.
 
 
-Definition ovmonot_to_over_pocto  { T : hSet_ltower } { X : T } ( X' : ltower_over X ) :
+Definition ovmonot_to_over_pocto  { T : hSet_ltower } { X : T } ( X' : ltower_over X ):
   ovmonot_fun ( ltower_over X' ) ( ltower_over ( pocto X' ) ) :=
-  ovmonot_fun_constr _ ( isovmonot_to_over_pocto X' ) .
+  ovmonot_fun_constr _ ( isovmonot_to_over_pocto X' ).
 
 
 Lemma ll_to_over_pocto { T : hSet_ltower } { X : T } ( X' : ltower_over X )
-      ( X'' : ltower_over X' ) : ll ( to_over_pocto X' X'' ) = ll X'' .
+      ( X'' : ltower_over X' ): ll ( to_over_pocto X' X'' ) = ll X''.
 Proof .
-  change _ with ( ll ( pr1 ( pr1 X'' ) ) - ll ( pr1 X' ) =
-                ll ( pr1 ( pr1 X'' ) ) - ll X - ( ll ( pr1 X' ) - ll X ) ) . 
-  rewrite natminusassoc . 
-  rewrite natpluscomm . 
-  rewrite ( minusplusnmm _ _ ( isover_geh ( isov_isov X' ) ) ) . 
-  apply idpath . 
-
+  change ( ll ( pr1 ( pr1 X'' ) ) - ll ( pr1 X' ) =
+           ll ( pr1 ( pr1 X'' ) ) - ll X - ( ll ( pr1 X' ) - ll X ) ). 
+  rewrite natminusassoc. 
+  rewrite natpluscomm. 
+  rewrite ( minusplusnmm _ _ ( isover_geh ( isov_isov X' ) ) ). 
+  apply idpath.
 Defined.
 
 
-Lemma isllmonot_to_over_pocto { T : hSet_ltower } { X : T } ( X' : ltower_over X ) :
-  isllmonot ( to_over_pocto X' ) .
-Proof .
-  unfold isllmonot . intros X0 Y .
-  repeat rewrite ll_to_over_pocto . 
-  apply idpath . 
-
-Defined.
-
-
-Lemma isbased_to_over_pocto { T : hSet_ltower } { X : T } ( X' : ltower_over X ) :
-  isbased ( to_over_pocto X' ) .
+Lemma isllmonot_to_over_pocto { T : hSet_ltower } { X : T } ( X' : ltower_over X ):
+  isllmonot ( to_over_pocto X' ).
 Proof.
-  unfold isbased .  intros X0 eq0 . 
-  rewrite ll_to_over_pocto . 
-  exact eq0 .
-
+  unfold isllmonot.
+  intros X0 Y.
+  do 2 rewrite ll_to_over_pocto. 
+  apply idpath. 
 Defined.
 
 
+Lemma isbased_to_over_pocto { T : hSet_ltower } { X : T } ( X' : ltower_over X ):
+  isbased ( to_over_pocto X' ).
+Proof.
+  unfold isbased.
+  intros X0 eq0. 
+  rewrite ll_to_over_pocto. 
+  exact eq0.
+Defined.
 
-Definition ltower_fun_to_over_pocto { T : hSet_ltower } { X : T } ( X' : ltower_over X ) :
+
+Definition ltower_fun_to_over_pocto { T : hSet_ltower } { X : T } ( X' : ltower_over X ):
   ltower_fun ( ltower_over X' ) ( ltower_over ( pocto X' ) ) :=
   ltower_fun_constr ( isovmonot_to_over_pocto X' )
-                    ( isllmonot_to_over_pocto X' ) ( isbased_to_over_pocto X' ) . 
-
+                    ( isllmonot_to_over_pocto X' ) ( isbased_to_over_pocto X' ). 
 
 
 (** **** The function ltower_fun_second *)
-
-
   
 
-Definition ovmonot_second { T : hSet_ltower }
-           { X Y : T } ( f : ovmonot_fun ( ltower_over X ) ( ltower_over Y ) )
-           ( X' : ltower_over X ) :
-  ovmonot_fun ( ltower_over ( pocto X' ) ) ( ltower_over ( pocto ( f X' ) ) ) .
-Proof .
+Definition ovmonot_second { T : hSet_ltower } { X Y : T }
+  ( f : ovmonot_fun ( ltower_over X ) ( ltower_over Y ) ) ( X' : ltower_over X ):
+  ovmonot_fun ( ltower_over ( pocto X' ) ) ( ltower_over ( pocto ( f X' ) ) ).
+Proof.
   set ( int1 :=
           ovmonot_funcomp ( ovmonot_lft X' )
-                          ( @ovmonot_over ( hSet_ltower_over X ) ( hSet_ltower_over Y ) f X' ) ) .  
-  apply ( ovmonot_funcomp int1 ( ovmonot_to_over_pocto _ ) ) .
-
+                          ( @ovmonot_over ( hSet_ltower_over X ) ( hSet_ltower_over Y ) f X' ) ).  
+  apply ( ovmonot_funcomp int1 ( ovmonot_to_over_pocto _ ) ).
 Defined.
 
 
-Lemma isllmonot_ovmonot_second { T : hSet_ltower }
-      { X Y : T }
-      ( f : ovmonot_fun ( ltower_over X ) ( ltower_over Y ) ) ( isf : isllmonot f ) 
-      ( X' : ltower_over X ) : isllmonot ( ovmonot_second f X' ) .
-Proof .
-  use isllmonot_funcomp. use isllmonot_funcomp.
-  apply isllmonot_lft . 
-
-  use ( @isllmonot_ovmonot_over ( hSet_ltower_over _ ) ( hSet_ltower_over _ ) _ isf X' ) . 
-
-  apply isllmonot_to_over_pocto . 
-
-Defined.
-
-
-Lemma isbased_second { T : hSet_ltower }
-           { X Y : T } ( f : ltower_fun ( ltower_over X ) ( ltower_over Y ) )
-           ( X' : ltower_over X ) :
-  isbased ( ovmonot_second f X' ) .
+Lemma isllmonot_ovmonot_second { T : hSet_ltower } { X Y : T }
+  ( f : ovmonot_fun ( ltower_over X ) ( ltower_over Y ) ) ( isf : isllmonot f ) 
+  ( X' : ltower_over X ) : isllmonot ( ovmonot_second f X' ).
 Proof.
-  unfold isbased. intros X0 eq0 .
-  unfold ovmonot_second .
-  apply isbased_funcomp. 
-  apply isbased_funcomp.
-  apply isbased_lft . 
-
-  apply ( @isbased_ovmonot_over ( hSet_ltower_over X ) ( hSet_ltower_over Y ) ) .
-
-  apply ( isllmonot_pr f ) . 
-
-  apply ( isbased_to_over_pocto ) .
-
-  exact eq0 . 
-
+  use isllmonot_funcomp.
+  - use isllmonot_funcomp.
+    + apply isllmonot_lft. 
+    + use ( @isllmonot_ovmonot_over ( hSet_ltower_over _ )
+                                    ( hSet_ltower_over _ ) _ isf X' ). 
+  - apply isllmonot_to_over_pocto. 
 Defined.
 
 
-Definition ltower_fun_second { T : hSet_ltower }
-           { X Y : T } ( f : ltower_fun ( ltower_over X ) ( ltower_over Y ) )
-           ( X' : ltower_over X ) :
+Lemma isbased_second { T : hSet_ltower } { X Y : T }
+  ( f : ltower_fun ( ltower_over X ) ( ltower_over Y ) ) ( X' : ltower_over X ):
+  isbased ( ovmonot_second f X' ).
+Proof.
+  unfold isbased.
+  intros X0 eq0.
+  unfold ovmonot_second.
+  apply isbased_funcomp. 
+  - apply isbased_funcomp.
+    + apply isbased_lft. 
+    + apply ( @isbased_ovmonot_over ( hSet_ltower_over X )
+                                    ( hSet_ltower_over Y ) ).
+      apply ( isllmonot_pr f ). 
+  - apply ( isbased_to_over_pocto ).
+  - exact eq0. 
+Defined.
+
+
+Definition ltower_fun_second { T : hSet_ltower } { X Y : T }
+  ( f : ltower_fun ( ltower_over X ) ( ltower_over Y ) ) ( X' : ltower_over X ):
   ltower_fun ( ltower_over ( pocto X' ) ) ( ltower_over ( pocto ( f X' ) ) ) :=
   ltower_fun_constr ( pr2 ( ovmonot_second f X' ) )
                     ( isllmonot_ovmonot_second f ( isllmonot_pr f ) X' )
-                    ( isbased_second f X' ) .
-
-
+                    ( isbased_second f X' ).
 
 
 (** **** The induction principle for isover *)

--- a/TypeTheory/Csystems/hSet_ltowers.v
+++ b/TypeTheory/Csystems/hSet_ltowers.v
@@ -346,284 +346,280 @@ Definition ltower_fun_second { T : hSet_ltower } { X Y : T }
 
 (** **** The induction principle for isover *)
 
-
 Definition isover_ind_int { BB : ltower }
-           ( P : forall ( X Y : BB ) , UU )
-           ( P0 : forall ( X : BB ) , P X X )
-           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ) , P X ( ft X ) )
-           ( Pcomp : forall ( X Y : BB ) , P X ( ft X ) -> P ( ft X ) Y -> P X Y ) :
-  forall ( n : nat ) ( X Y : BB ) ( eq : Y = ftn n X ) , P X Y .
+           ( P : forall ( X Y : BB ), UU )
+           ( P0 : forall ( X : BB ), P X X )
+           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ), P X ( ft X ) )
+           ( Pcomp : forall ( X Y : BB ), P X ( ft X ) -> P ( ft X ) Y -> P X Y ):
+  forall ( n : nat ) ( X Y : BB ) ( eq : Y = ftn n X ), P X Y.
 Proof.
-  induction n as [ | n IHn ] .
-  intros . change _ with ( Y = X ) in eq . 
-  rewrite eq . 
-  apply P0 .
-
-  intros .
-  destruct ( natgehchoice _ _ ( natgehn0 ( ll X ) ) ) as [ gt0 | eq0 ] .
-  
-  apply Pcomp . 
-  apply Pft . 
-  apply gt0 . 
-  assert ( eq' : Y = ftn n ( ft X ) ) . 
-  rewrite ftn_ft . 
-  apply eq .
-
-  apply ( IHn _ _ eq' ) .
-  rewrite ftnX_eq_X in eq . 
-  rewrite eq . 
-  apply P0 .
-
-  apply eq0.
-
+  induction n as [ | n IHn ].
+  - intros X Y eq.
+    change ( Y = X ) in eq. 
+    rewrite eq. 
+    apply P0.
+  - intros X Y eq.
+    destruct ( natgehchoice _ _ ( natgehn0 ( ll X ) ) ) as [ gt0 | eq0 ].
+    + apply Pcomp. 
+      apply Pft. 
+      apply gt0. 
+      assert ( eq' : Y = ftn n ( ft X ) ). 
+      { rewrite ftn_ft. 
+        apply eq.
+      }
+      apply ( IHn _ _ eq' ).
+    + rewrite ftnX_eq_X in eq. 
+      rewrite eq. 
+      apply P0.
+      apply eq0.
 Defined.
 
 Lemma isover_ind_int_XX { BB : hSet_ltower }
-           ( P : forall ( X Y : BB ) , UU )
-           ( P0 : forall ( X : BB ) , P X X )
-           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ) , P X ( ft X ) )
-           ( Pcomp : forall ( X Y : BB ) , P X ( ft X ) -> P ( ft X ) Y -> P X Y )
-           ( n : nat ) ( eq0 : n = 0 ) ( X : BB ) ( eq : X = ftn n X ) :
-  isover_ind_int P P0 Pft Pcomp n X X eq = P0 X .
+           ( P : forall ( X Y : BB ), UU )
+           ( P0 : forall ( X : BB ), P X X )
+           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ), P X ( ft X ) )
+           ( Pcomp : forall ( X Y : BB ), P X ( ft X ) -> P ( ft X ) Y -> P X Y )
+           ( n : nat ) ( eq0 : n = 0 ) ( X : BB ) ( eq : X = ftn n X ):
+  isover_ind_int P P0 Pft Pcomp n X X eq = P0 X.
 Proof. 
-  set ( Y := X ) . 
-  change _ with ( Y = ftn n X ) in eq . 
-  change _ with (isover_ind_int P P0 Pft Pcomp n X Y eq = P0 X).
-  generalize eq . 
-  rewrite eq0 . 
-  intro eq1. assert ( eqq : eq1 = idpath X ) .  apply isasetB .
-  simpl . rewrite eqq .
-  apply idpath . 
-
+  set ( Y := X ). 
+  change ( Y = ftn n X ) in eq. 
+  change (isover_ind_int P P0 Pft Pcomp n X Y eq = P0 X).
+  generalize eq. 
+  rewrite eq0. 
+  intro eq1.
+  assert ( eqq : eq1 = idpath X ) by apply isasetB.
+  simpl.
+  rewrite eqq.
+  apply idpath. 
 Defined.
 
 
-
 Lemma isover_ind_int_isab_eq_in_BB { BB : hSet_ltower }
-      { n m : nat } ( eqn : n = S m ) { X Y : BB } ( eq : Y = ftn n X ) :
-  Y = ftn m ( ft X ) .
-Proof .
-  rewrite ftn_ft . 
-  change ( 1 + m ) with ( S m ) . 
-  rewrite <- eqn . 
-  exact eq .
-
+      { n m : nat } ( eqn : n = S m ) { X Y : BB } ( eq : Y = ftn n X ):
+  Y = ftn m ( ft X ).
+Proof.
+  rewrite ftn_ft. 
+  change ( 1 + m ) with ( S m ). 
+  rewrite <- eqn. 
+  exact eq.
 Defined.
 
 
 Lemma isover_ind_int_isab { BB : hSet_ltower }
-           ( P : forall ( X Y : BB ) , UU )
-           ( P0 : forall ( X : BB ) , P X X )
-           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ) , P X ( ft X ) )
-           ( Pcomp : forall ( X Y : BB ) , P X ( ft X ) -> P ( ft X ) Y -> P X Y )
+           ( P : forall ( X Y : BB ), UU )
+           ( P0 : forall ( X : BB ), P X X )
+           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ), P X ( ft X ) )
+           ( Pcomp : forall ( X Y : BB ), P X ( ft X ) -> P ( ft X ) Y -> P X Y )
            ( n m : nat ) ( eqn : n = S m ) ( X Y : BB ) ( gt0 : ll X > 0 )
-           ( eq : Y = ftn n X ) ( eq' : Y = ftn m ( ft X ) ) :
+           ( eq : Y = ftn n X ) ( eq' : Y = ftn m ( ft X ) ):
   isover_ind_int P P0 Pft Pcomp n X Y eq =
-  Pcomp _ _ ( Pft X gt0 ) ( isover_ind_int P P0 Pft Pcomp m ( ft X ) Y eq' ) .
+  Pcomp _ _ ( Pft X gt0 ) ( isover_ind_int P P0 Pft Pcomp m ( ft X ) Y eq' ).
 Proof. 
-  revert X Y gt0 eq eq'. rewrite eqn .
-  intros .
-  simpl .
-  destruct (natgehchoice (ll X) 0 (natgehn0 (ll X))) as [ gt0' | eq0 ] . 
-  assert ( int : gt0 = gt0' ) . apply proofirrelevance . apply ( pr2 ( _ > _ ) ) . 
-  rewrite int .
+  revert X Y gt0 eq eq'.
+  rewrite eqn.
+  intros.
+  simpl.
+  destruct (natgehchoice (ll X) 0 (natgehn0 (ll X))) as [ gt0' | eq0 ]. 
+  - assert ( int : gt0 = gt0' ).
+    { apply proofirrelevance.
+      apply ( pr2 ( _ > _ ) ). 
+    }
+    rewrite int.
 (*
   assert ( int' : (uu0a.internal_identity_rew_r BB (ftn m (ft X)) 
            ((ft circ ftn m) X) (fun l : BB => Y = l) eq 
            (ftn_ft m X)) = eq' ) .
-*)
+ *)
   assert ( int' : (internal_paths_rew_r BB (ftn m (ft X)) 
            ((ft ∘ ftn m) X) (fun l : BB => Y = l) eq 
-           (ftn_ft m X)) = eq' ) .
-  { apply isasetB . }
-  rewrite int' .
-  apply idpath .
-
-  assert ( gt0' : ll X > 0 ) . apply gt0 .
-
-  rewrite eq0 in gt0' . destruct ( negnatgthnn _ gt0' ) . 
-
+           (ftn_ft m X)) = eq' ) by apply isasetB.
+  rewrite int'.
+  apply idpath.
+  - assert ( gt0' : ll X > 0 ) by apply gt0 .
+    rewrite eq0 in gt0'.
+    destruct ( negnatgthnn _ gt0' ). 
 Defined.
 
 
-
-
 Lemma isover_ind_int_X_ftX { BB : hSet_ltower }
-           ( P : forall ( X Y : BB ) , UU )
-           ( P0 : forall ( X : BB ) , P X X )
-           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ) , P X ( ft X ) )
-           ( Pcomp : forall ( X Y : BB ) , P X ( ft X ) -> P ( ft X ) Y -> P X Y )
-           ( Pcomp_eq : forall ( X : BB ) ( gt0 : ll X > 0 ) ,
+           ( P : forall ( X Y : BB ), UU )
+           ( P0 : forall ( X : BB ), P X X )
+           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ), P X ( ft X ) )
+           ( Pcomp : forall ( X Y : BB ), P X ( ft X ) -> P ( ft X ) Y -> P X Y )
+           ( Pcomp_eq : forall ( X : BB ) ( gt0 : ll X > 0 ),
                           Pcomp _ _ ( Pft _ gt0 ) ( P0 ( ft X ) ) = ( Pft _ gt0 ) )
-           ( n : nat ) ( eq1 : n = 1 ) ( X : BB ) ( eq : ft X = ftn n X ) ( gt0 : ll X > 0 ) :
-  isover_ind_int P P0 Pft Pcomp n X ( ft X ) eq = Pft X gt0 .
+           ( n : nat ) ( eq1 : n = 1 ) ( X : BB ) ( eq : ft X = ftn n X ) ( gt0 : ll X > 0 ):
+  isover_ind_int P P0 Pft Pcomp n X ( ft X ) eq = Pft X gt0.
 Proof.
-  revert X eq gt0. rewrite eq1 . 
-  intros X eq . assert ( eqq : eq = idpath _ ) . apply isasetB . 
-  rewrite eqq . intro . 
-  simpl .
-  destruct (natgehchoice (ll X) 0 (natgehn0 (ll X))) as [ gt0' | eq0 ] .
-  assert ( eq' : gt0 = gt0' ) . apply proofirrelevance .  apply ( pr2 ( _ > _ ) ) . 
-  rewrite eq' . apply Pcomp_eq . 
-
-  apply fromempty.
-  rewrite eq0 in gt0 . 
-  apply ( negnatgthnn _ gt0 ) . 
-
+  revert X eq gt0.
+  rewrite eq1. 
+  intros X eq.
+  assert ( eqq : eq = idpath _ ) by apply isasetB. 
+  rewrite eqq.
+  intro. 
+  simpl.
+  destruct (natgehchoice (ll X) 0 (natgehn0 (ll X))) as [ gt0' | eq0 ].
+  - assert ( eq' : gt0 = gt0' ).
+    { apply proofirrelevance.
+      apply ( pr2 ( _ > _ ) ).
+    }
+    rewrite eq'.
+    apply Pcomp_eq. 
+  - apply fromempty.
+    rewrite eq0 in gt0. 
+    apply ( negnatgthnn _ gt0 ). 
 Defined.
 
   
 Definition isover_ind { BB : ltower }
-           ( P : forall ( X Y : BB ) , UU )
-           ( P0 : forall ( X : BB ) , P X X )
-           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ) , P X ( ft X ) )
-           ( Pcomp : forall ( X Y : BB ) , P X ( ft X ) -> P ( ft X ) Y -> P X Y ) :
-  forall ( X Y : BB ) ( isov : isover X Y ) , P X Y :=
-  fun X Y isov => isover_ind_int P P0 Pft Pcomp ( ll X - ll Y ) X Y isov .
+           ( P : forall ( X Y : BB ), UU )
+           ( P0 : forall ( X : BB ), P X X )
+           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ), P X ( ft X ) )
+           ( Pcomp : forall ( X Y : BB ), P X ( ft X ) -> P ( ft X ) Y -> P X Y ):
+  forall ( X Y : BB ) ( isov : isover X Y ), P X Y :=
+  fun X Y isov => isover_ind_int P P0 Pft Pcomp ( ll X - ll Y ) X Y isov.
 
 
 Lemma isover_ind_XX { BB : hSet_ltower }
-           ( P : forall ( X Y : BB ) , UU )
-           ( P0 : forall ( X : BB ) , P X X )
-           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ) , P X ( ft X ) )
-           ( Pcomp : forall ( X Y : BB ) , P X ( ft X ) -> P ( ft X ) Y -> P X Y )
-           ( X : BB ) ( isov : isover X X ) : isover_ind P P0 Pft Pcomp X X isov = P0 X .
+           ( P : forall ( X Y : BB ), UU )
+           ( P0 : forall ( X : BB ), P X X )
+           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ), P X ( ft X ) )
+           ( Pcomp : forall ( X Y : BB ), P X ( ft X ) -> P ( ft X ) Y -> P X Y )
+           ( X : BB ) ( isov : isover X X ):
+  isover_ind P P0 Pft Pcomp X X isov = P0 X.
 Proof.
-  apply isover_ind_int_XX . 
-  apply natminusnn . 
-
+  apply isover_ind_int_XX. 
+  apply natminusnn. 
 Defined.
 
-Opaque isover_ind_XX .
+Opaque isover_ind_XX.
 
 
 Lemma isover_ind_isab { BB : hSet_ltower }
-           ( P : forall ( X Y : BB ) , UU )
-           ( P0 : forall ( X : BB ) , P X X )
-           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ) , P X ( ft X ) )
-           ( Pcomp : forall ( X Y : BB ) , P X ( ft X ) -> P ( ft X ) Y -> P X Y )
-           ( X Y : BB ) ( isab : isabove X Y ) :
+           ( P : forall ( X Y : BB ), UU )
+           ( P0 : forall ( X : BB ), P X X )
+           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ), P X ( ft X ) )
+           ( Pcomp : forall ( X Y : BB ), P X ( ft X ) -> P ( ft X ) Y -> P X Y )
+           ( X Y : BB ) ( isab : isabove X Y ):
   isover_ind P P0 Pft Pcomp X Y isab =
-  Pcomp _ _ ( Pft X ( isabove_gt0 isab ) ) ( isover_ind P P0 Pft Pcomp ( ft X ) Y ( isover_ft' isab ) ) .
+  Pcomp _ _ ( Pft X ( isabove_gt0 isab ) ) ( isover_ind P P0 Pft Pcomp ( ft X ) Y ( isover_ft' isab ) ).
 Proof.
-  apply isover_ind_int_isab .
-  rewrite ll_ft . 
-  apply lB_2014_12_07_l1 . 
-  apply ( isabove_gth isab ) . 
-
+  apply isover_ind_int_isab.
+  rewrite ll_ft. 
+  apply lB_2014_12_07_l1. 
+  apply ( isabove_gth isab ). 
 Defined.
 
-Opaque isover_ind_isab .
+Opaque isover_ind_isab.
 
 
 Lemma isover_ind_X_ftX { BB : hSet_ltower }
-           ( P : forall ( X Y : BB ) , UU )
-           ( P0 : forall ( X : BB ) , P X X )
-           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ) , P X ( ft X ) )
-           ( Pcomp : forall ( X Y : BB ) , P X ( ft X ) -> P ( ft X ) Y -> P X Y )
-           ( Pcomp_eq : forall ( X : BB ) ( gt0 : ll X > 0 ) ,
+           ( P : forall ( X Y : BB ), UU )
+           ( P0 : forall ( X : BB ), P X X )
+           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ), P X ( ft X ) )
+           ( Pcomp : forall ( X Y : BB ), P X ( ft X ) -> P ( ft X ) Y -> P X Y )
+           ( Pcomp_eq : forall ( X : BB ) ( gt0 : ll X > 0 ),
                           Pcomp _ _ ( Pft _ gt0 ) ( P0 ( ft X ) ) = ( Pft _ gt0 ) )
-           ( X : BB ) ( gt0 : ll X > 0 ) :
-  isover_ind P P0 Pft Pcomp X ( ft X ) ( isover_X_ftX X ) = Pft X gt0 .
+           ( X : BB ) ( gt0 : ll X > 0 ):
+  isover_ind P P0 Pft Pcomp X ( ft X ) ( isover_X_ftX X ) = Pft X gt0.
 Proof.
-  apply isover_ind_int_X_ftX .
-  intros . apply Pcomp_eq . 
-
-  rewrite ll_ft .
-  apply natminusmmk . 
-  apply ( gth0_to_geh1 gt0 ) . 
-
+  apply isover_ind_int_X_ftX.
+  - intros.
+    apply Pcomp_eq. 
+  - rewrite ll_ft.
+    apply natminusmmk. 
+    apply ( gth0_to_geh1 gt0 ). 
 Defined.
-
-
   
 
 (** **** Stronger induction principle for isover *)
 
 
 Definition isover_strong_ind_int { BB : hSet_ltower }
-           ( P : forall ( X Y : BB ) ( isov : isover X Y ) , UU )
-           ( P0 : forall ( X : BB ) , P X X ( isover_XX X ) )
-           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ) , P X ( ft X ) ( isover_X_ftX X ) )
-           ( Pcomp : forall ( X Y : BB ) ,
-                       ( forall isov1 , P X ( ft X ) isov1 ) ->
-                       ( forall isov2 , P ( ft X ) Y isov2 ) ->
-                       forall ( isab : isabove X Y ) , P X Y isab )  :
-  forall ( n : nat ) ( X Y : BB ) ( eq : Y = ftn n X ) ( isov : isover X Y ) , P X Y isov .
+           ( P : forall ( X Y : BB ) ( isov : isover X Y ), UU )
+           ( P0 : forall ( X : BB ), P X X ( isover_XX X ) )
+           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ), P X ( ft X ) ( isover_X_ftX X ) )
+           ( Pcomp : forall ( X Y : BB ),
+                       ( forall isov1, P X ( ft X ) isov1 ) ->
+                       ( forall isov2, P ( ft X ) Y isov2 ) ->
+                       forall ( isab : isabove X Y ), P X Y isab ):
+  forall ( n : nat ) ( X Y : BB ) ( eq : Y = ftn n X ) ( isov : isover X Y ), P X Y isov.
 Proof.
-  induction n as [ | n IHn ] .
-  intros . change _ with ( Y = X ) in eq .
-  generalize isov . clear isov . 
-  rewrite eq .
-  intro isov .
-  assert ( eq1: isov = isover_XX X ) . 
-  apply proofirrelevance .  apply isaprop_isover . rewrite eq1 . apply P0 .
-  
-  intros .
-  destruct ( natgehchoice _ _ ( natgehn0 ( ll X ) ) ) as [ gt0 | eq0 ] . 
-  assert ( int1 : forall isov1 : isover X (ft X), P X (ft X) isov1).
-  intros. 
-  assert ( int11 := Pft X gt0 ) .
-  assert ( eq1: isov1 = isover_X_ftX X ) . 
-  apply proofirrelevance .  apply isaprop_isover . rewrite eq1 . apply int11 .
-
-  assert ( int2 : forall isov2 : isover (ft X) Y, P (ft X) Y isov2).
-  intros.
-  use ( IHn ( ft X ) Y ) . 
-  rewrite ftn_ft . 
-  apply eq .
-
-  assert ( gt : ll X > ll Y ) . 
-  rewrite eq . 
-  rewrite ll_ftn . apply ( natgthgehtrans _ ( ll X - 1 ) _ ) .
-  apply natminuslthn . 
-  apply gt0 . 
-
-  apply idpath .
-
-  change ( ll X - S n ) with ( ll X - ( 1 + n ) ) . 
-  rewrite <- natminusassoc . 
-  apply natminuslehn . 
-
-  exact ( Pcomp _ _ int1 int2 ( isabove_constr gt isov ) ) . 
+  induction n as [ | n IHn ].
+  - intros X Y eq isov.
+    change ( Y = X ) in eq.
+    revert isov.
+    rewrite eq.
+    intro isov.
+    assert ( eq1: isov = isover_XX X ). 
+    { apply proofirrelevance.
+      apply isaprop_isover.
+    }
+    rewrite eq1.
+    apply P0.
+  - intros X Y eq isov.
+    destruct ( natgehchoice _ _ ( natgehn0 ( ll X ) ) ) as [ gt0 | eq0 ]. 
+    + assert ( int1 : forall isov1 : isover X (ft X), P X (ft X) isov1).
+      { intros.
+        set ( int11 := Pft X gt0 ).
+        assert ( eq1: isov1 = isover_X_ftX X ). 
+        { apply proofirrelevance.
+          apply isaprop_isover.
+        }
+        rewrite eq1.
+        apply int11.
+      }
+      assert ( int2 : forall isov2 : isover (ft X) Y, P (ft X) Y isov2).
+      { intros.
+        use ( IHn ( ft X ) Y ). 
+        rewrite ftn_ft. 
+        apply eq.
+      }
+      assert ( gt : ll X > ll Y ). 
+      { rewrite eq. 
+        rewrite ll_ftn.
+        apply ( natgthgehtrans _ ( ll X - 1 ) _ ).
+        * apply natminuslthn. 
+          -- apply gt0. 
+          -- apply idpath.
+        * change ( ll X - S n ) with ( ll X - ( 1 + n ) ). 
+          rewrite <- natminusassoc. 
+          apply natminuslehn. 
+      }
+      exact ( Pcomp _ _ int1 int2 ( isabove_constr gt isov ) ). 
   (* assert ( int3 := Pcomp _ _ int1 int2 ) . 
   set ( int31 := pr1 int3 ) . assert ( int32 := pr2 int3 ) .
   assert ( eq1: isov = int31 ) . 
   apply proofirrelevance .  apply isaprop_isover . rewrite eq1 . 
   exact int32.*)
-
-  rewrite ftnX_eq_X in eq . 
-  generalize isov .
-  rewrite eq . 
-  clear isov . intro isov .
-  assert ( eq1: isov = isover_XX X ) . 
-  apply proofirrelevance .  apply isaprop_isover . rewrite eq1 . apply P0 .
-  exact eq0 . 
-
+  + rewrite ftnX_eq_X in eq. 
+    * revert isov.
+      rewrite eq. 
+      intro isov.
+      assert ( eq1: isov = isover_XX X ). 
+      { apply proofirrelevance.
+        apply isaprop_isover.
+      }
+      rewrite eq1.
+      apply P0.
+    * exact eq0. 
 Defined.
 
 
 
-
-
-
-
-
-
-
 Definition isover_strong_ind { BB : hSet_ltower }
-           ( P : forall ( X Y : BB ) ( isov : isover X Y ) , UU )
-           ( P0 : forall ( X : BB ) , P X X ( isover_XX X ) )
-           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ) , P X ( ft X ) ( isover_X_ftX X ) )
-           ( Pcomp : forall ( X Y : BB ) ,
-                       ( forall isov1 , P X ( ft X ) isov1 ) ->
-                       ( forall isov2 , P ( ft X ) Y isov2 ) ->
-                       forall isov3 , P X Y isov3 )  :
-  forall ( X Y : BB ) ( isov : isover X Y ) , P X Y isov .
+           ( P : forall ( X Y : BB ) ( isov : isover X Y ), UU )
+           ( P0 : forall ( X : BB ), P X X ( isover_XX X ) )
+           ( Pft : forall ( X : BB ) ( gt0 : ll X > 0 ), P X ( ft X ) ( isover_X_ftX X ) )
+           ( Pcomp : forall ( X Y : BB ),
+                       ( forall isov1, P X ( ft X ) isov1 ) ->
+                       ( forall isov2, P ( ft X ) Y isov2 ) ->
+                       forall isov3, P X Y isov3 ):
+  forall ( X Y : BB ) ( isov : isover X Y ), P X Y isov.
 Proof.
   intros.
-  apply ( isover_strong_ind_int P P0 Pft Pcomp ( ll X - ll Y ) X Y isov isov ) .  
-
+  apply ( isover_strong_ind_int P P0 Pft Pcomp ( ll X - ll Y ) X Y isov isov ).  
 Defined.
 
 
@@ -653,16 +649,18 @@ Defined.*)
 
 Definition isover_ind_one_sided_int { BB : ltower }
            ( Γ : BB )
-           ( P : forall {X : BB} (n : nat) , Γ = ftn n X  -> UU )
+           ( P : forall {X : BB} (n : nat), Γ = ftn n X  -> UU )
            ( P0 : P 0 (@paths_refl _ _))
-           ( Pft : forall ( X : BB ) (n : nat) ( eq : Γ = ftn (S n) X ) , P n (eq @ ! (ftn_ft _ _)) -> P (S n) eq)
-  : forall ( X : BB )  (n : nat) ( eq: Γ = ftn n X ) , P n eq.
+           ( Pft : forall ( X : BB ) (n : nat) ( eq : Γ = ftn (S n) X ), P n (eq @ ! (ftn_ft _ _)) -> P (S n) eq)
+  : forall ( X : BB )  (n : nat) ( eq: Γ = ftn n X ), P n eq.
 Proof.
-  intros X n . revert X.  induction n as [ | n IHn ]; intros.
-  + change _ with ( Γ = X ) in eq . 
-    rewrite <- eq . 
-    apply P0 .
-  + apply Pft.
+  intros X n.
+  revert X.
+  induction n as [ | n IHn ]; intros.
+  - change ( Γ = X ) in eq. 
+    rewrite <- eq. 
+    apply P0.
+  - apply Pft.
     apply IHn.
 Defined.
 
@@ -671,54 +669,68 @@ Defined.
 
 Definition isover_ind_one_sided { BB : hSet_ltower }
            ( Γ : BB )
-           ( P : forall {X : BB} , isover X Γ -> UU )
+           ( P : forall {X : BB}, isover X Γ -> UU )
            ( P0 : P (isover_XX Γ) )
-           ( Pft : forall ( X : BB ) ( isab : isabove X Γ ) , P ( isover_ft' isab) -> P isab)
-  : forall ( X : BB ) ( isov : isover X Γ ) , P isov.
+           ( Pft : forall ( X : BB ) ( isab : isabove X Γ ), P ( isover_ft' isab) -> P isab)
+  : forall ( X : BB ) ( isov : isover X Γ ), P isov.
 Proof.
   set (P' := fun {X:BB} {n: nat} (eq: Γ = ftn n X) => P _ (transportf _ (!eq) (isover_X_ftnX X n))).
   assert (P'ok : forall ( X : BB )  (n : nat) ( eq: Γ = ftn n X ) , P' X n eq).
   { apply isover_ind_one_sided_int.
-    + red. exact P0.
+    + red.
+      exact P0.
     + intros X n eq IHn.
-      red. red in IHn.
+      red.
+      red in IHn.
       set (H := transportf (isover (ft X)) (! (eq @ ! ftn_ft n X)) (isover_X_ftnX (ft X) n)).
-      destruct ( natgehchoice _ _ ( natgehn0 ( ll X ) ) ) as [ gt0 | eq0 ] .
+      destruct ( natgehchoice _ _ ( natgehn0 ( ll X ) ) ) as [ gt0 | eq0 ].
       * assert (isab : isabove X Γ).
-        { rewrite eq. apply isabove_X_ftnX; try assumption.
-           (* Search ( _ > _). *) apply natgthsn0. }
+        { rewrite eq.
+          apply isabove_X_ftnX; try assumption.
+          (* Search ( _ > _). *)
+          apply natgthsn0.
+        }
         specialize Pft with X isab.
         assert (eq' : isover_ft' isab = H).
         { apply proofirrelevance.
-          apply isaprop_isover. } 
+          apply isaprop_isover.
+        } 
         assert (H' : P X isab).
-        { apply Pft. rewrite eq'. exact IHn. }
+        { apply Pft.
+          rewrite eq'.
+          exact IHn.
+        }
         red in isab.
         assert (eq'' : pr2 isab = transportf (isover X) (! eq) (isover_X_ftnX X (S n))).
         { apply proofirrelevance.
-          apply isaprop_isover. }
+          apply isaprop_isover.
+        }
         rewrite <- eq''.
         exact H'.
       * clear IHn H Pft P'.
         assert (eq' : Γ = X).
-        { rewrite <- (ftnX_eq_X (S n) eq0) .
-           exact eq. }
-        clear eq0. remember (transportf (isover X) (! eq) (isover_X_ftnX X (S n))) as H''.
+        { rewrite <- (ftnX_eq_X (S n) eq0).
+          exact eq.
+        }
+        clear eq0.
+        remember (transportf (isover X) (! eq) (isover_X_ftnX X (S n))) as H''.
         set (H3 := transportf (isover X) (! eq') (isover_XX X)).
         assert (eq'' : H'' = H3) by (apply proofirrelevance, isaprop_isover).
         rewrite eq''.
         clear HeqH'' H'' eq'' eq.
         induction eq'.
         cbn in H3.
-        unfold H3. apply P0.         
+        unfold H3.
+        apply P0.         
   }
   intros.
   red in isov.
   specialize P'ok with X (ll X - ll Γ) isov.
   red in P'ok.
-  assert ( eq' : isov = (transportf (isover X) (! isov) (isover_X_ftnX X (ll X - ll Γ))) ) .
+  assert ( eq' : isov = (transportf (isover X) (! isov) (isover_X_ftnX X (ll X - ll Γ))) ).
   { apply proofirrelevance.
-    apply isasetB. }
+    apply isasetB.
+  }
   induction eq'.
   apply P'ok.
 Defined.

--- a/TypeTheory/Csystems/hSet_ltowers.v
+++ b/TypeTheory/Csystems/hSet_ltowers.v
@@ -50,7 +50,7 @@ Coercion hSet_pltowers_pr1 : hSet_pltower >-> hSet_ltower .
 Lemma isinvovmonot_pocto { T : hSet_ltower } { A : T } { X Y : ltower_over A }
       ( isov : isover ( pocto X ) ( pocto Y ) ) : isover X Y .  
 Proof .
-  refine ( invmaponpathsincl pr1 _ _ _ _ ) . 
+  use ( invmaponpathsincl pr1 ) . 
   apply isinclpr1 . 
   intro x . 
   apply isaprop_isover .
@@ -345,7 +345,7 @@ Proof .
   use isllmonot_funcomp. use isllmonot_funcomp.
   apply isllmonot_lft . 
 
-  refine ( @isllmonot_ovmonot_over ( hSet_ltower_over _ ) ( hSet_ltower_over _ ) _ isf X' ) . 
+  use ( @isllmonot_ovmonot_over ( hSet_ltower_over _ ) ( hSet_ltower_over _ ) _ isf X' ) . 
 
   apply isllmonot_to_over_pocto . 
 
@@ -610,7 +610,7 @@ Proof.
 
   assert ( int2 : forall isov2 : isover (ft X) Y, P (ft X) Y isov2).
   intros.
-  refine ( IHn ( ft X ) Y _ _ ) . 
+  use ( IHn ( ft X ) Y ) . 
   rewrite ftn_ft . 
   apply eq .
 

--- a/TypeTheory/Csystems/hSet_ltowers.v
+++ b/TypeTheory/Csystems/hSet_ltowers.v
@@ -3,10 +3,7 @@
 by Vladimir Voevodsky. File created on January 30, 2015. *)
 
 Require Import UniMath.Foundations.All.
-Require Import UniMath.Combinatorics.StandardFiniteSets.
-Require Import TypeTheory.Csystems.prelim.
-Require Import TypeTheory.Csystems.lTowers.
-Require Import TypeTheory.Csystems.ltowers_over.
+Require Export TypeTheory.Csystems.ltowers_over.
 
 
 

--- a/TypeTheory/Csystems/hSet_ltowers.v
+++ b/TypeTheory/Csystems/hSet_ltowers.v
@@ -2,12 +2,11 @@
 
 by Vladimir Voevodsky. File created on January 30, 2015. *)
 
-
+Require Import UniMath.Foundations.All.
 Require Import UniMath.Combinatorics.StandardFiniteSets.
 Require Import TypeTheory.Csystems.prelim.
 Require Import TypeTheory.Csystems.lTowers.
-
-Require Import TypeTheory.Csystems.ltowers_over .
+Require Import TypeTheory.Csystems.ltowers_over.
 
 
 

--- a/TypeTheory/Csystems/hSet_ltowers.v
+++ b/TypeTheory/Csystems/hSet_ltowers.v
@@ -2,16 +2,19 @@
 
 by Vladimir Voevodsky. File created on January 30, 2015. *)
 
-Unset Automatic Introduction.
 
-Require Export TypeTheory.Csystems.ltowers_over .
+Require Import UniMath.Combinatorics.StandardFiniteSets.
+Require Import TypeTheory.Csystems.prelim.
+Require Import TypeTheory.Csystems.lTowers.
+
+Require Import TypeTheory.Csystems.ltowers_over .
 
 
 
-Definition hSet_ltower := total2 ( fun T : ltower => isaset T ) .
+Definition hSet_ltower := ∑ T : ltower, isaset T .
 
 Definition hSet_ltower_constr ( T : ltower ) ( is : isaset T ) : hSet_ltower :=
-  tpair _ T is . 
+  T ,, is. 
 
 Definition hSet_ltower_pr1 : hSet_ltower -> ltower := pr1 . 
 Coercion hSet_ltower_pr1 : hSet_ltower >-> ltower .
@@ -20,13 +23,12 @@ Definition isasetB ( T : hSet_ltower ) : isaset T := pr2 T .
 
 Lemma isaprop_isover { T : hSet_ltower } ( X A : T ) : isaprop ( isover X A ) .
 Proof .
-  intros . exact ( isasetB _ _ _ ) . 
+  exact ( isasetB _ _ _ ) . 
 
 Defined.
 
 Lemma isaprop_isabove { T : hSet_ltower } ( X A : T ) : isaprop ( isabove X A ) . 
 Proof. 
-  intros . 
   apply isapropdirprod . 
   exact ( pr2 ( _ > _ ) ) .
 
@@ -34,10 +36,10 @@ Proof.
 
 Defined .
 
-Definition hSet_pltower := total2 ( fun T : hSet_ltower => ispointed_type T ) .
+Definition hSet_pltower := ∑ T : hSet_ltower, ispointed_type T.
 
 Definition hSet_pltower_constr ( T : hSet_ltower ) ( is : ispointed_type T ) : hSet_pltower :=
-  tpair _ T is . 
+  T ,, is. 
 
 
 Definition hSet_pltowers_to_pltowers : hSet_pltower -> pltower :=
@@ -52,7 +54,6 @@ Coercion hSet_pltowers_pr1 : hSet_pltower >-> hSet_ltower .
 Lemma isinvovmonot_pocto { T : hSet_ltower } { A : T } { X Y : ltower_over A }
       ( isov : isover ( pocto X ) ( pocto Y ) ) : isover X Y .  
 Proof .
-  intros . 
   refine ( invmaponpathsincl pr1 _ _ _ _ ) . 
   apply isinclpr1 . 
   intro x . 
@@ -72,7 +73,6 @@ Defined.
 
 Lemma isaset_ltower_over { T : hSet_ltower } ( X : T ) : isaset ( ltower_over X ) .
 Proof .
-  intros . 
   apply ( isofhleveltotal2 2 ) . 
   exact ( pr2 T ) . 
 
@@ -99,8 +99,7 @@ Definition hSet_pltower_over { T : hSet_ltower } ( X : T ) : hSet_pltower :=
 Lemma isovmonot_to_ltower_over { T : hSet_pltower }
       { X Y : T } ( isov : isover X Y ) : isover ( to_ltower_over X ) ( to_ltower_over Y ) .
 Proof .
-  intros .
-  refine ( @isinvovmonot_pocto T ( cntr T ) (to_ltower_over X) (to_ltower_over Y) isov ) . 
+  use ( @isinvovmonot_pocto T ( cntr T ) (to_ltower_over X) (to_ltower_over Y) isov ) . 
 
 Defined.
 
@@ -120,8 +119,7 @@ Definition ltower_fun_to_ltower_over { T : hSet_pltower }  :
 Definition lft { T : hSet_ltower }
            { X : T } { X' : ltower_over X } ( X'' : ltower_over ( pocto X' ) ) : ltower_over X' .
 Proof .
-  intros .
-  simple refine (obj_over_constr _ ) .
+  use obj_over_constr.
   split with ( pocto X'' ) . 
   apply ( isover_trans ( isov_isov X'' ) ( isov_isov X' ) ) .
   apply isinvovmonot_pocto . 
@@ -134,7 +132,6 @@ Lemma ll_lft { T : hSet_ltower }
       { X : T } { X' : ltower_over X } ( X'' : ltower_over ( pocto X' ) ) :
   ll ( lft X'' ) = ll X'' .
 Proof.
-  intros .
   change _ with
   ( ll ( pr1 X'' ) - ll X - ( ll ( pr1 X' ) - ll X ) = ll ( pr1 X'' ) - ll ( pr1 X' ) ) .
   rewrite natminusassoc . 
@@ -149,7 +146,7 @@ Defined.
 Lemma isovmonot_lft { T : hSet_ltower }
       { X : T } ( X' : ltower_over X ) : isovmonot ( @lft _ _ X' ) .
 Proof .
-  intros . unfold isovmonot . 
+  unfold isovmonot . 
   intros X0 Y isov . 
   apply ( @isinvovmonot_pocto ( hSet_ltower_over X ) ) .
   simpl . 
@@ -164,7 +161,6 @@ Defined.
 Lemma isllmonot_lft { T : hSet_ltower }
       { X : T } ( X' : ltower_over X ) : isllmonot ( @lft _ _ X' ) .
 Proof .
-  intros .
   unfold isllmonot . intros .
   repeat rewrite ll_lft . 
   apply idpath . 
@@ -174,7 +170,7 @@ Defined.
 Lemma isbased_lft { T : hSet_ltower }
       { X : T } ( X' : ltower_over X ) : isbased ( @lft _ _ X' ) .
 Proof.
-  intros. unfold isbased. intros X0 eq0. rewrite ll_lft. exact eq0 .
+  unfold isbased. intros X0 eq0. rewrite ll_lft. exact eq0 .
 
 Defined.
 
@@ -199,8 +195,7 @@ Definition ltower_fun_lft { T : hSet_ltower } { X : T } ( X' : ltower_over X ) :
 Definition ovmonot_over { T1 T2 : hSet_ltower } ( f : ovmonot_fun T1 T2 )
            ( X : T1 ) : ovmonot_fun ( ltower_over X ) ( ltower_over ( f X ) ) .
 Proof .
-  intros . 
-  simple refine ( ovmonot_fun_constr _ _ ) .
+  use ovmonot_fun_constr.
   intro X' . 
   split with ( f ( pocto X' ) ) . 
   apply ( pr2 f ) . 
@@ -218,7 +213,6 @@ Defined.
 Lemma isllmonot_ovmonot_over { T1 T2 : hSet_ltower } { f : ovmonot_fun T1 T2 } ( isf : isllmonot f )
       ( X : T1 ) : isllmonot ( ovmonot_over f X ) .
 Proof.
-  intros.
   unfold isllmonot .
   intros X0 Y . 
   change _ with ( ll ( f ( pr1 X0 ) ) - ll ( f X ) - ( ll ( f ( pr1 Y ) ) - ll ( f X ) ) =
@@ -232,7 +226,7 @@ Lemma isbased_ovmonot_over { T1 T2 : hSet_ltower }
       { f : ovmonot_fun T1 T2 } ( isf : isllmonot f ) 
       ( X : T1 ) : isbased ( ovmonot_over f X ) .
 Proof.
-  intros. unfold isbased. intros X0 eq0 . 
+  unfold isbased. intros X0 eq0 . 
   change _ with ( ll ( pr1 X0 ) - ll X = 0 ) in eq0 . 
   change _ with ( ll ( f ( pr1 X0 ) ) - ll ( f X ) = 0 ) .
   rewrite isf . 
@@ -261,7 +255,6 @@ Definition ltower_fun_over { T1 T2 : hSet_ltower } ( f : ovmonot_fun T1 T2 ) ( i
 Definition to_over_pocto  { T : hSet_ltower } { X : T } ( X' : ltower_over X )
            ( X'' : ltower_over X' ) : ltower_over ( pocto X' ) .
 Proof .
-  intros .
   split with ( pocto ( pocto X'' ) ) . 
   apply isovmonot_pocto . 
   apply ( isov_isov X'' ) .
@@ -273,7 +266,6 @@ Defined.
 Lemma isovmonot_to_over_pocto { T : hSet_ltower } { X : T } ( X' : ltower_over X ) :
   isovmonot ( to_over_pocto X' ) . 
 Proof .
-  intros.
   unfold isovmonot. 
   intros X0 Y isov .
   simpl .
@@ -293,7 +285,6 @@ Definition ovmonot_to_over_pocto  { T : hSet_ltower } { X : T } ( X' : ltower_ov
 Lemma ll_to_over_pocto { T : hSet_ltower } { X : T } ( X' : ltower_over X )
       ( X'' : ltower_over X' ) : ll ( to_over_pocto X' X'' ) = ll X'' .
 Proof .
-  intros .
   change _ with ( ll ( pr1 ( pr1 X'' ) ) - ll ( pr1 X' ) =
                 ll ( pr1 ( pr1 X'' ) ) - ll X - ( ll ( pr1 X' ) - ll X ) ) . 
   rewrite natminusassoc . 
@@ -307,7 +298,6 @@ Defined.
 Lemma isllmonot_to_over_pocto { T : hSet_ltower } { X : T } ( X' : ltower_over X ) :
   isllmonot ( to_over_pocto X' ) .
 Proof .
-  intros .
   unfold isllmonot . intros X0 Y .
   repeat rewrite ll_to_over_pocto . 
   apply idpath . 
@@ -318,7 +308,7 @@ Defined.
 Lemma isbased_to_over_pocto { T : hSet_ltower } { X : T } ( X' : ltower_over X ) :
   isbased ( to_over_pocto X' ) .
 Proof.
-  intros. unfold isbased .  intros X0 eq0 . 
+  unfold isbased .  intros X0 eq0 . 
   rewrite ll_to_over_pocto . 
   exact eq0 .
 
@@ -343,7 +333,6 @@ Definition ovmonot_second { T : hSet_ltower }
            ( X' : ltower_over X ) :
   ovmonot_fun ( ltower_over ( pocto X' ) ) ( ltower_over ( pocto ( f X' ) ) ) .
 Proof .
-  intros .
   set ( int1 :=
           ovmonot_funcomp ( ovmonot_lft X' )
                           ( @ovmonot_over ( hSet_ltower_over X ) ( hSet_ltower_over Y ) f X' ) ) .  
@@ -357,8 +346,7 @@ Lemma isllmonot_ovmonot_second { T : hSet_ltower }
       ( f : ovmonot_fun ( ltower_over X ) ( ltower_over Y ) ) ( isf : isllmonot f ) 
       ( X' : ltower_over X ) : isllmonot ( ovmonot_second f X' ) .
 Proof .
-  intros .
-  refine ( isllmonot_funcomp _ _ ) . refine ( isllmonot_funcomp _ _ ) . 
+  use isllmonot_funcomp. use isllmonot_funcomp.
   apply isllmonot_lft . 
 
   refine ( @isllmonot_ovmonot_over ( hSet_ltower_over _ ) ( hSet_ltower_over _ ) _ isf X' ) . 
@@ -373,7 +361,7 @@ Lemma isbased_second { T : hSet_ltower }
            ( X' : ltower_over X ) :
   isbased ( ovmonot_second f X' ) .
 Proof.
-  intros. unfold isbased. intros X0 eq0 .
+  unfold isbased. intros X0 eq0 .
   unfold ovmonot_second .
   apply isbased_funcomp. 
   apply isbased_funcomp.
@@ -411,7 +399,7 @@ Definition isover_ind_int { BB : ltower }
            ( Pcomp : forall ( X Y : BB ) , P X ( ft X ) -> P ( ft X ) Y -> P X Y ) :
   forall ( n : nat ) ( X Y : BB ) ( eq : Y = ftn n X ) , P X Y .
 Proof.
-  intros until n .  induction n as [ | n IHn ] .
+  induction n as [ | n IHn ] .
   intros . change _ with ( Y = X ) in eq . 
   rewrite eq . 
   apply P0 .
@@ -443,7 +431,6 @@ Lemma isover_ind_int_XX { BB : hSet_ltower }
            ( n : nat ) ( eq0 : n = 0 ) ( X : BB ) ( eq : X = ftn n X ) :
   isover_ind_int P P0 Pft Pcomp n X X eq = P0 X .
 Proof. 
-  intros .
   set ( Y := X ) . 
   change _ with ( Y = ftn n X ) in eq . 
   change _ with (isover_ind_int P P0 Pft Pcomp n X Y eq = P0 X).
@@ -461,7 +448,6 @@ Lemma isover_ind_int_isab_eq_in_BB { BB : hSet_ltower }
       { n m : nat } ( eqn : n = S m ) { X Y : BB } ( eq : Y = ftn n X ) :
   Y = ftn m ( ft X ) .
 Proof .
-  intros .
   rewrite ftn_ft . 
   change ( 1 + m ) with ( S m ) . 
   rewrite <- eqn . 
@@ -480,7 +466,7 @@ Lemma isover_ind_int_isab { BB : hSet_ltower }
   isover_ind_int P P0 Pft Pcomp n X Y eq =
   Pcomp _ _ ( Pft X gt0 ) ( isover_ind_int P P0 Pft Pcomp m ( ft X ) Y eq' ) .
 Proof. 
-  intros until m .  intro eqn . rewrite eqn .
+  revert X Y gt0 eq eq'. rewrite eqn .
   intros .
   simpl .
   destruct (natgehchoice (ll X) 0 (natgehn0 (ll X))) as [ gt0' | eq0 ] . 
@@ -517,7 +503,7 @@ Lemma isover_ind_int_X_ftX { BB : hSet_ltower }
            ( n : nat ) ( eq1 : n = 1 ) ( X : BB ) ( eq : ft X = ftn n X ) ( gt0 : ll X > 0 ) :
   isover_ind_int P P0 Pft Pcomp n X ( ft X ) eq = Pft X gt0 .
 Proof.
-  intros until n. intro eq1 . rewrite eq1 . 
+  revert X eq gt0. rewrite eq1 . 
   intros X eq . assert ( eqq : eq = idpath _ ) . apply isasetB . 
   rewrite eqq . intro . 
   simpl .
@@ -525,10 +511,9 @@ Proof.
   assert ( eq' : gt0 = gt0' ) . apply proofirrelevance .  apply ( pr2 ( _ > _ ) ) . 
   rewrite eq' . apply Pcomp_eq . 
 
-  assert ( absd : empty ) . rewrite eq0 in gt0 . 
+  apply fromempty.
+  rewrite eq0 in gt0 . 
   apply ( negnatgthnn _ gt0 ) . 
-
-  destruct absd .
 
 Defined.
 
@@ -549,7 +534,6 @@ Lemma isover_ind_XX { BB : hSet_ltower }
            ( Pcomp : forall ( X Y : BB ) , P X ( ft X ) -> P ( ft X ) Y -> P X Y )
            ( X : BB ) ( isov : isover X X ) : isover_ind P P0 Pft Pcomp X X isov = P0 X .
 Proof.
-  intros.
   apply isover_ind_int_XX . 
   apply natminusnn . 
 
@@ -567,7 +551,6 @@ Lemma isover_ind_isab { BB : hSet_ltower }
   isover_ind P P0 Pft Pcomp X Y isab =
   Pcomp _ _ ( Pft X ( isabove_gt0 isab ) ) ( isover_ind P P0 Pft Pcomp ( ft X ) Y ( isover_ft' isab ) ) .
 Proof.
-  intros .
   apply isover_ind_int_isab .
   rewrite ll_ft . 
   apply lB_2014_12_07_l1 . 
@@ -588,7 +571,7 @@ Lemma isover_ind_X_ftX { BB : hSet_ltower }
            ( X : BB ) ( gt0 : ll X > 0 ) :
   isover_ind P P0 Pft Pcomp X ( ft X ) ( isover_X_ftX X ) = Pft X gt0 .
 Proof.
-  intros. apply isover_ind_int_X_ftX .
+  apply isover_ind_int_X_ftX .
   intros . apply Pcomp_eq . 
 
   rewrite ll_ft .
@@ -613,7 +596,7 @@ Definition isover_strong_ind_int { BB : hSet_ltower }
                        forall ( isab : isabove X Y ) , P X Y isab )  :
   forall ( n : nat ) ( X Y : BB ) ( eq : Y = ftn n X ) ( isov : isover X Y ) , P X Y isov .
 Proof.
-  intros until n .  induction n as [ | n IHn ] .
+  induction n as [ | n IHn ] .
   intros . change _ with ( Y = X ) in eq .
   generalize isov . clear isov . 
   rewrite eq .
@@ -720,7 +703,7 @@ Definition isover_ind_one_sided_int { BB : ltower }
            ( Pft : forall ( X : BB ) (n : nat) ( eq : Γ = ftn (S n) X ) , P n (eq @ ! (ftn_ft _ _)) -> P (S n) eq)
   : forall ( X : BB )  (n : nat) ( eq: Γ = ftn n X ) , P n eq.
 Proof.
-  intros until n . revert X.  induction n as [ | n IHn ]; intros.
+  intros X n . revert X.  induction n as [ | n IHn ]; intros.
   + change _ with ( Γ = X ) in eq . 
     rewrite <- eq . 
     apply P0 .
@@ -738,7 +721,6 @@ Definition isover_ind_one_sided { BB : hSet_ltower }
            ( Pft : forall ( X : BB ) ( isab : isabove X Γ ) , P ( isover_ft' isab) -> P isab)
   : forall ( X : BB ) ( isov : isover X Γ ) , P isov.
 Proof.
-  intros BB Γ P P0 Pft.
   set (P' := fun {X:BB} {n: nat} (eq: Γ = ftn n X) => P _ (transportf _ (!eq) (isover_X_ftnX X n))).
   assert (P'ok : forall ( X : BB )  (n : nat) ( eq: Γ = ftn n X ) , P' X n eq).
   { apply isover_ind_one_sided_int.

--- a/TypeTheory/Csystems/lC0systems.v
+++ b/TypeTheory/Csystems/lC0systems.v
@@ -8,6 +8,7 @@ by V. Voevodsky as "Csubsystems".
 
  *)
 
+Require Import UniMath.Foundations.All.
 Require Import UniMath.Combinatorics.StandardFiniteSets.
 Require Import TypeTheory.Csystems.prelim.
 Require Import TypeTheory.Csystems.lTowers.

--- a/TypeTheory/Csystems/lC0systems.v
+++ b/TypeTheory/Csystems/lC0systems.v
@@ -426,7 +426,7 @@ Lemma q_X_ftX { CC : lC0system_data } { X : CC } ( f : mor_to ( ft X ) ) ( gt0 :
 Proof.
   unfold qn . 
   apply ( maponpaths ( fun g => g f ) ) .
-  refine ( isover_ind_X_ftX _ _ _ _ _ _ _ ) . 
+  use isover_ind_X_ftX.
   intros X0 gt1 . 
   apply idpath . 
 
@@ -597,7 +597,7 @@ Proof.
   unfold P . 
   intro f0 . 
   rewrite f_star_isab .
-  simple refine ( isover_trans _ _ ) .  
+  use isover_trans.
   apply ( dom (qn f0 (isover_ft' isab))). 
   apply isover_f_star .
   apply G0 . 

--- a/TypeTheory/Csystems/lC0systems.v
+++ b/TypeTheory/Csystems/lC0systems.v
@@ -8,20 +8,25 @@ by V. Voevodsky as "Csubsystems".
 
  *)
 
-Require Export UniMath.Foundations.NaturalNumbers.
-Require Export UniMath.CategoryTheory.Categories.
+Require Import UniMath.Combinatorics.StandardFiniteSets.
+Require Import TypeTheory.Csystems.prelim.
+Require Import TypeTheory.Csystems.lTowers.
+
+Require Import TypeTheory.Csystems.ltowers_over.
+
+
+(* Require Import UniMath.CategoryTheory.Categories. *)
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
-Require Export TypeTheory.Csystems.hSet_ltowers.
+Require Import TypeTheory.Csystems.hSet_ltowers.
 
 
-(* Unset Automatic Introduction. *)
 
 (* Notation "a --> b" := (precategory_morphisms a b)(at level 50). *)
 
 (* Notation "f ;; g" := (compose f g)(at level 50). *)
 
 Definition mor_from { C : precategory_ob_mor } ( X : C ) :=
-  total2 ( fun A : C => X --> A ) .
+  ∑ A : C, X --> A .
 
 Definition mor_from_pr2 { C : precategory_ob_mor } ( X : C ) :
   forall f : mor_from X , precategory_morphisms X ( pr1 f ) := pr2 .  
@@ -31,7 +36,7 @@ Definition mor_from_constr { C : precategory_ob_mor } { X A : C } ( f : X --> A 
   mor_from X := tpair _ _ f . 
 
 Definition mor_to { C : precategory_ob_mor } ( X : C ) :=
-  total2 ( fun A : C => A --> X ) .
+  ∑ A : C, A --> X .
 
 Definition mor_to_pr2 { C : precategory_ob_mor } ( X : C ) :
   forall f : mor_to X , precategory_morphisms ( pr1 f ) X := pr2 .  
@@ -65,7 +70,7 @@ the canonical projections pX : X --> ft X . *)
 (** **** l-tower precategories *)
 
 
-Definition ltower_precat := total2 ( fun C : setcategory => ltower_str C ) . 
+Definition ltower_precat := ∑ C : setcategory, ltower_str C . 
 
 Definition ltower_precat_to_ltower ( CC : ltower_precat ) : hSet_ltower :=
   hSet_ltower_constr
@@ -77,7 +82,7 @@ Definition ltower_precat_pr1 : ltower_precat -> setcategory := pr1 .
 Coercion ltower_precat_pr1 : ltower_precat >-> setcategory .
 
 Definition ltower_precat_and_p :=
-  total2 ( fun CC : ltower_precat  => forall X : CC , X --> ft X ) .
+  ∑ CC : ltower_precat, forall X : CC , X --> ft X .
 
 Definition ltower_precat_and_p_pr1 : ltower_precat_and_p -> ltower_precat := pr1 . 
 Coercion ltower_precat_and_p_pr1 : ltower_precat_and_p >-> ltower_precat . 
@@ -91,7 +96,6 @@ Definition pX { CC : ltower_precat_and_p } ( X : CC ) : X --> ft X := pr2 CC X .
 
 Definition pnX { CC : ltower_precat_and_p } ( n : nat ) ( X : CC ) : X --> ftn n X . 
 Proof.
-  intros.
   induction n as [ | n IHn ]. 
   exact ( identity X ). 
 
@@ -104,7 +108,7 @@ Defined.
 
 
 Definition sec_pnX { CC : ltower_precat_and_p } ( n : nat ) ( X : CC ) :=
-  total2 ( fun s : ftn n X --> X => s ;; pnX n X = identity ( ftn n X ) ) . 
+  ∑ s : ftn n X --> X, s ;; pnX n X = identity ( ftn n X ) . 
 
 Definition sec_pnX_to_mor { CC : ltower_precat_and_p } ( n : nat ) ( X : CC ) :
   sec_pnX n X -> ftn n X --> X := pr1.
@@ -123,7 +127,7 @@ Definition ftf { CC : ltower_precat_and_p } { X Y : CC } ( f : X --> Y ) : X -->
 
 
 Definition Ob_tilde_over { CC : ltower_precat_and_p  } ( X : CC ) :=
-  total2 ( fun r : ft X --> X => r ;; ( pX X ) = identity ( ft X ) ) .
+  ∑ r : ft X --> X, r ;; ( pX X ) = identity ( ft X ) .
 
 Definition Ob_tilde_over_to_mor_to { CC : ltower_precat_and_p } ( X : CC ) ( r : Ob_tilde_over X ) :
   mor_to X := mor_to_constr ( pr1 r ) .
@@ -142,7 +146,7 @@ Definition Ob_tilde_over_eq { CC : ltower_precat_and_p  } { X : CC } ( r : Ob_ti
 
 
 Definition pltower_precat_and_p :=
-  total2 ( fun CC : ltower_precat_and_p => ispointed_type CC ) .
+  ∑ CC : ltower_precat_and_p, ispointed_type CC.
 
 Definition pltower_precat_and_p_pr1 : pltower_precat_and_p ->
                                              ltower_precat_and_p := pr1 .
@@ -238,13 +242,12 @@ Definition C0ax7_type { CC : lC0system_data }
 
 
 Definition lC0system :=
-  total2 ( fun CC : lC0system_data =>
-                     dirprod ( C0ax4_type CC )
-                     ( total2 ( fun axs : dirprod ( C0ax5a_type CC )
-                                                  ( total2 ( fun ax5b : C0ax5b_type CC =>
-                                                               C0ax5c_type ax5b ) ) => 
-                                  dirprod ( C0ax6_type CC )
-                                          ( C0ax7_type ( pr1 axs ) ( pr1 ( pr2 axs ) ) ) ) ) ) .
+  ∑ CC : lC0system_data,
+                     ( C0ax4_type CC ) ×
+                     ( ∑ axs : ( C0ax5a_type CC ) ×
+                               ( ∑ ax5b : C0ax5b_type CC, C0ax5c_type ax5b ), 
+                          ( C0ax6_type CC ) ×
+                          ( C0ax7_type ( pr1 axs ) ( pr1 ( pr2 axs ) ) ) ).
 
 Definition lC0system_pr1 : lC0system -> lC0system_data := pr1 .
 Coercion lC0system_pr1 : lC0system >-> lC0system_data .
@@ -298,7 +301,6 @@ Definition C0ax7a { CC : lC0system }
 Lemma ll_f_star { CC : lC0system } { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ) :
   ll ( f_star gt0 f ) = 1 + ll Y .
 Proof .
-  intros . 
   assert ( gt0' : ll ( f_star gt0 f ) > 0 ) . apply C0ax5a .
   rewrite <- ( S_ll_ft gt0' ) . 
   rewrite C0ax5b . 
@@ -309,7 +311,7 @@ Defined.
 Lemma isover_f_star { CC : lC0system } { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ) :
   isover ( f_star gt0 f ) Y .
 Proof.
-  intros. set ( eq := C0ax5b gt0 f ) . unfold isover . 
+  set ( eq := C0ax5b gt0 f ) . unfold isover . 
   assert ( eq1 : ll ( f_star gt0 f ) - ll Y = 1 ) .
   rewrite ll_f_star . 
   apply plusminusnmm . 
@@ -398,7 +400,7 @@ Defined. *)
 Lemma q_XX { CC : lC0system_data } { X : CC } ( f : mor_to X ) ( isov : isover X X ) :
   qn f isov = f .
 Proof .
-  intros .  unfold qn .
+  unfold qn .
   assert ( int := @isover_ind_XX CC ( fun X Y : CC => mor_to Y -> mor_to X )
                             ( fun X => idfun _ )
                             ( fun X gt0 => q_of_mor_to gt0 )
@@ -413,7 +415,6 @@ Opaque q_XX.
 Lemma q_isab { CC : lC0system_data } { X A : CC } ( f : mor_to A ) ( isab : isabove X A ) :
   qn f isab = q_of_mor_to ( isabove_gt0 isab ) ( qn f ( isover_ft' isab ) ) . 
 Proof.
-  intros.
   assert ( int := isover_ind_isab ( fun X Y : CC => mor_to Y -> mor_to X )
                             ( fun X => idfun _ )
                             ( fun X gt0 => q_of_mor_to gt0 )
@@ -428,7 +429,6 @@ Opaque q_isab .
 Lemma q_X_ftX { CC : lC0system_data } { X : CC } ( f : mor_to ( ft X ) ) ( gt0 : ll X > 0 ) :
   qn f ( isover_X_ftX X ) = q_of_mor_to gt0 f .
 Proof.
-  intros.
   unfold qn . 
   apply ( maponpaths ( fun g => g f ) ) .
   refine ( isover_ind_X_ftX _ _ _ _ _ _ _ ) . 
@@ -444,7 +444,7 @@ Opaque q_X_ftX .
 Lemma f_star_XX { CC : lC0system_data } { X : CC } ( f : mor_to X ) ( isov : isover X X ) :
   fn_star f isov =  dom f .
 Proof .
-  intros . apply ( maponpaths dom ) . apply q_XX . 
+  apply ( maponpaths dom ) . apply q_XX . 
   
 Defined.
 
@@ -455,7 +455,7 @@ Lemma f_star_isab { CC : lC0system_data } { X A : CC }
       ( f : mor_to A ) ( isab : isabove X A ) :
   fn_star f isab = f_star ( isabove_gt0 isab ) ( qn f ( isover_ft' isab ) ) . 
 Proof.
-  intros. apply ( maponpaths dom ) . apply q_isab. 
+  apply ( maponpaths dom ) . apply q_isab. 
   
 Defined.
 
@@ -465,7 +465,6 @@ Opaque f_star_isab.
 Lemma f_star_X_ftX { CC : lC0system_data } { X : CC } ( f : mor_to ( ft X ) ) ( gt0 : ll X > 0 ) :
   fn_star f ( isover_X_ftX X ) = f_star gt0 f .
 Proof.
-  intros . 
   apply ( maponpaths dom ) . 
   apply q_X_ftX .
 
@@ -544,7 +543,6 @@ Definition fn_star_to_fsm_star { CC : lC0system } { Y A : CC } ( f : Y --> A ) {
 Lemma ll_fn_star { CC : lC0system } { A X : CC } ( f : mor_to A ) ( isov : isover X A ) :
   ll ( fn_star f isov ) + ll A  = ll ( dom f ) + ll X . 
 Proof.
-  intros.
   set ( P := fun ( X0 Y0 : CC ) ( isov0 : isover X0 Y0 ) =>
                forall ( f0 : mor_to Y0 ) , ll ( fn_star f0 isov0 ) + ll Y0  = ll ( dom f0 ) + ll X0 ) .
   assert ( P0 : forall X0 , P X0 X0 ( isover_XX X0 ) ) . intro . unfold P . intro. 
@@ -587,7 +585,6 @@ Defined.
 Lemma isover_fn_star { CC : lC0system } { X A : CC } ( f : mor_to A ) ( isov : isover X A ) :
   isover ( fn_star f isov ) ( dom f ) .
 Proof.
-  intros.
   set ( P := fun ( X0 Y0 : CC ) ( isov0 : isover X0 Y0 ) =>
                forall ( f0 : mor_to Y0 ) , isover ( fn_star f0 isov0 ) ( dom f0 ) ) .
   assert ( P0 : forall X0 , P X0 X0 ( isover_XX X0 ) ) . intro . unfold P . intro. 

--- a/TypeTheory/Csystems/lC0systems.v
+++ b/TypeTheory/Csystems/lC0systems.v
@@ -9,16 +9,10 @@ by V. Voevodsky as "Csubsystems".
  *)
 
 Require Import UniMath.Foundations.All.
-Require Import UniMath.Combinatorics.StandardFiniteSets.
-Require Import TypeTheory.Csystems.prelim.
-Require Import TypeTheory.Csystems.lTowers.
-
-Require Import TypeTheory.Csystems.ltowers_over.
-
 
 (* Require Import UniMath.CategoryTheory.Categories. *)
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
-Require Import TypeTheory.Csystems.hSet_ltowers.
+Require Export TypeTheory.Csystems.hSet_ltowers.
 
 
 

--- a/TypeTheory/Csystems/lC0systems.v
+++ b/TypeTheory/Csystems/lC0systems.v
@@ -5,8 +5,7 @@ by Vladimir Voevodsky, started Dec. 4, 2014, continued Jan. 22, 2015, Feb. 11, 2
 We refer below to the paper "Subsystems and regular quotients of C-systems"
 by V. Voevodsky as "Csubsystems".
 
-
- *)
+*)
 
 Require Import UniMath.Foundations.All.
 
@@ -20,25 +19,23 @@ Require Export TypeTheory.Csystems.hSet_ltowers.
 
 (* Notation "f ;; g" := (compose f g)(at level 50). *)
 
-Definition mor_from { C : precategory_ob_mor } ( X : C ) :=
-  ∑ A : C, X --> A .
+Definition mor_from { C : precategory_ob_mor } ( X : C ) := ∑ A : C, X --> A.
 
-Definition mor_from_pr2 { C : precategory_ob_mor } ( X : C ) :
-  forall f : mor_from X , precategory_morphisms X ( pr1 f ) := pr2 .  
-Coercion mor_from_pr2 : mor_from >-> precategory_morphisms  . 
+Definition mor_from_pr2 { C : precategory_ob_mor } ( X : C ):
+  forall f : mor_from X, precategory_morphisms X ( pr1 f ) := pr2.  
+Coercion mor_from_pr2 : mor_from >-> precategory_morphisms. 
 
-Definition mor_from_constr { C : precategory_ob_mor } { X A : C } ( f : X --> A ) :
-  mor_from X := tpair _ _ f . 
+Definition mor_from_constr { C : precategory_ob_mor } { X A : C } ( f : X --> A ):
+  mor_from X := tpair _ _ f. 
 
-Definition mor_to { C : precategory_ob_mor } ( X : C ) :=
-  ∑ A : C, A --> X .
+Definition mor_to { C : precategory_ob_mor } ( X : C ) := ∑ A : C, A --> X.
 
-Definition mor_to_pr2 { C : precategory_ob_mor } ( X : C ) :
-  forall f : mor_to X , precategory_morphisms ( pr1 f ) X := pr2 .  
-Coercion mor_to_pr2 : mor_to >-> precategory_morphisms  . 
+Definition mor_to_pr2 { C : precategory_ob_mor } ( X : C ):
+  forall f : mor_to X , precategory_morphisms ( pr1 f ) X := pr2.  
+Coercion mor_to_pr2 : mor_to >-> precategory_morphisms. 
 
-Definition mor_to_constr { C : precategory_ob_mor } { X A : C } ( f : A --> X ) :
-  mor_to X := tpair ( fun A : C => A --> X ) _ f .
+Definition mor_to_constr { C : precategory_ob_mor } { X A : C } ( f : A --> X ):
+  mor_to X := tpair ( fun A : C => A --> X ) _ f.
 
  
 
@@ -46,9 +43,9 @@ Definition mor_to_constr { C : precategory_ob_mor } { X A : C } ( f : A --> X ) 
 
 (** To precategories *)
 
-Definition isaset_ob ( C : setcategory ) : isaset C := pr1 ( pr2 C ) .
+Definition isaset_ob ( C : setcategory ): isaset C := pr1 ( pr2 C ).
 
-Definition isaset_mor ( C : setcategory ) : has_homsets C := pr2 ( pr2 C ) . 
+Definition isaset_mor ( C : setcategory ): has_homsets C := pr2 ( pr2 C ). 
 
 
 (** *** The C0-systems
@@ -65,75 +62,72 @@ the canonical projections pX : X --> ft X . *)
 (** **** l-tower precategories *)
 
 
-Definition ltower_precat := ∑ C : setcategory, ltower_str C . 
+Definition ltower_precat := ∑ C : setcategory, ltower_str C. 
 
-Definition ltower_precat_to_ltower ( CC : ltower_precat ) : hSet_ltower :=
+Definition ltower_precat_to_ltower ( CC : ltower_precat ): hSet_ltower :=
   hSet_ltower_constr
     ( tpair ( fun C : UU => ltower_str C ) ( pr1 CC ) ( pr2 CC ) )
-    ( pr1 ( pr2 ( pr1  CC ) ) ) .
-Coercion ltower_precat_to_ltower : ltower_precat >-> hSet_ltower .
+    ( pr1 ( pr2 ( pr1  CC ) ) ).
+Coercion ltower_precat_to_ltower: ltower_precat >-> hSet_ltower.
 
-Definition ltower_precat_pr1 : ltower_precat -> setcategory := pr1 .
-Coercion ltower_precat_pr1 : ltower_precat >-> setcategory .
+Definition ltower_precat_pr1: ltower_precat -> setcategory := pr1.
+Coercion ltower_precat_pr1: ltower_precat >-> setcategory.
 
 Definition ltower_precat_and_p :=
-  ∑ CC : ltower_precat, forall X : CC , X --> ft X .
+  ∑ CC : ltower_precat, forall X : CC, X --> ft X.
 
-Definition ltower_precat_and_p_pr1 : ltower_precat_and_p -> ltower_precat := pr1 . 
-Coercion ltower_precat_and_p_pr1 : ltower_precat_and_p >-> ltower_precat . 
+Definition ltower_precat_and_p_pr1: ltower_precat_and_p -> ltower_precat := pr1. 
+Coercion ltower_precat_and_p_pr1: ltower_precat_and_p >-> ltower_precat. 
                                                           
-Definition pX { CC : ltower_precat_and_p } ( X : CC ) : X --> ft X := pr2 CC X .
+Definition pX { CC : ltower_precat_and_p } ( X : CC ): X --> ft X := pr2 CC X.
 
 
 
 
 (** **** Some constructions *)
 
-Definition pnX { CC : ltower_precat_and_p } ( n : nat ) ( X : CC ) : X --> ftn n X . 
+Definition pnX { CC : ltower_precat_and_p } ( n : nat ) ( X : CC ): X --> ftn n X. 
 Proof.
-  induction n as [ | n IHn ]. 
-  exact ( identity X ). 
-
-  destruct n as [ | n ].
-  exact ( pX X ). 
-
-  exact ( IHn ;; pX ( ftn ( S n ) X ) ).
-
+  induction n as [ | n IHn ].
+  - exact ( identity X ). 
+  - destruct n as [ | n ].
+    + exact ( pX X ). 
+    + exact ( IHn ;; pX ( ftn ( S n ) X ) ).
 Defined.
 
 
 Definition sec_pnX { CC : ltower_precat_and_p } ( n : nat ) ( X : CC ) :=
-  ∑ s : ftn n X --> X, s ;; pnX n X = identity ( ftn n X ) . 
+  ∑ s : ftn n X --> X, s ;; pnX n X = identity ( ftn n X ). 
 
-Definition sec_pnX_to_mor { CC : ltower_precat_and_p } ( n : nat ) ( X : CC ) :
+Definition sec_pnX_to_mor { CC : ltower_precat_and_p } ( n : nat ) ( X : CC ):
   sec_pnX n X -> ftn n X --> X := pr1.
 Coercion sec_pnX_to_mor : sec_pnX >-> precategory_morphisms.
 
-Definition sec_pnX_eq { CC : ltower_precat_and_p } { n : nat } { X : CC } ( s : sec_pnX n X ) :
-  s ;; pnX n X = identity ( ftn n X ) := pr2 s . 
+Definition sec_pnX_eq { CC : ltower_precat_and_p } { n : nat } { X : CC } ( s : sec_pnX n X ):
+  s ;; pnX n X = identity ( ftn n X ) := pr2 s. 
   
-Notation sec_pX := (sec_pnX 1) .
+Notation sec_pX := (sec_pnX 1).
 
-Notation sec_pX_eq := (@sec_pnX_eq _ 1 _ ) .
+Notation sec_pX_eq := (@sec_pnX_eq _ 1 _ ).
 
 
-Definition ftf { CC : ltower_precat_and_p } { X Y : CC } ( f : X --> Y ) : X --> ft Y :=
-  f ;; pX Y . 
+Definition ftf { CC : ltower_precat_and_p } { X Y : CC } ( f : X --> Y ): X --> ft Y :=
+  f ;; pX Y. 
 
 
 Definition Ob_tilde_over { CC : ltower_precat_and_p  } ( X : CC ) :=
-  ∑ r : ft X --> X, r ;; ( pX X ) = identity ( ft X ) .
+  ∑ r : ft X --> X, r ;; ( pX X ) = identity ( ft X ).
 
-Definition Ob_tilde_over_to_mor_to { CC : ltower_precat_and_p } ( X : CC ) ( r : Ob_tilde_over X ) :
-  mor_to X := mor_to_constr ( pr1 r ) .
-Coercion Ob_tilde_over_to_mor_to : Ob_tilde_over >-> mor_to . 
+Definition Ob_tilde_over_to_mor_to { CC : ltower_precat_and_p } ( X : CC ) ( r : Ob_tilde_over X ):
+  mor_to X := mor_to_constr ( pr1 r ).
+Coercion Ob_tilde_over_to_mor_to: Ob_tilde_over >-> mor_to. 
 
-Definition Ob_tilde_over_to_mor_from { CC : ltower_precat_and_p  } ( X : CC ) ( r : Ob_tilde_over X ) :
-  mor_from ( ft X ) := mor_from_constr ( pr1 r ) .
-Coercion Ob_tilde_over_to_mor_from : Ob_tilde_over >-> mor_from .
+Definition Ob_tilde_over_to_mor_from { CC : ltower_precat_and_p  } ( X : CC ) ( r : Ob_tilde_over X ):
+  mor_from ( ft X ) := mor_from_constr ( pr1 r ).
+Coercion Ob_tilde_over_to_mor_from: Ob_tilde_over >-> mor_from.
 
-Definition Ob_tilde_over_eq { CC : ltower_precat_and_p  } { X : CC } ( r : Ob_tilde_over X ) :
-  r ;; ( pX X ) = identity ( ft X ) := pr2 r . 
+Definition Ob_tilde_over_eq { CC : ltower_precat_and_p  } { X : CC } ( r : Ob_tilde_over X ):
+  r ;; ( pX X ) = identity ( ft X ) := pr2 r. 
 
 
 
@@ -143,31 +137,31 @@ Definition Ob_tilde_over_eq { CC : ltower_precat_and_p  } { X : CC } ( r : Ob_ti
 Definition pltower_precat_and_p :=
   ∑ CC : ltower_precat_and_p, ispointed_type CC.
 
-Definition pltower_precat_and_p_pr1 : pltower_precat_and_p ->
-                                             ltower_precat_and_p := pr1 .
-Coercion pltower_precat_and_p_pr1 : pltower_precat_and_p >->
-                                             ltower_precat_and_p.
+Definition pltower_precat_and_p_pr1 :
+  pltower_precat_and_p -> ltower_precat_and_p := pr1.
+Coercion pltower_precat_and_p_pr1 :
+  pltower_precat_and_p >-> ltower_precat_and_p.
 
-Definition pltower_precat_and_p_to_pltower : pltower_precat_and_p -> pltower :=
-  fun X => pltower_constr ( pr2 X ) . 
-Coercion pltower_precat_and_p_to_pltower : pltower_precat_and_p >-> pltower .
+Definition pltower_precat_and_p_to_pltower: pltower_precat_and_p -> pltower :=
+  fun X => pltower_constr ( pr2 X ). 
+Coercion pltower_precat_and_p_to_pltower: pltower_precat_and_p >-> pltower.
 
 
 (** **** l-C0-system data *)
 
 
 Definition q_data_type ( CC : ltower_precat_and_p ) := 
-  forall ( X Y : CC ) ( gt0 : ll X > 0 ) ( f : Y --> ft X ) , mor_to X . 
-Identity Coercion from_q_data_type : q_data_type >-> Funclass .  
+  forall ( X Y : CC ) ( gt0 : ll X > 0 ) ( f : Y --> ft X ), mor_to X. 
+Identity Coercion from_q_data_type: q_data_type >-> Funclass.  
 
 Definition lC0system_data := ∑ CC : pltower_precat_and_p, q_data_type CC.
 
-Definition lC0system_data_pr1 : lC0system_data -> pltower_precat_and_p  := pr1 .
-Coercion lC0system_data_pr1 : lC0system_data >-> pltower_precat_and_p .
+Definition lC0system_data_pr1: lC0system_data -> pltower_precat_and_p := pr1.
+Coercion lC0system_data_pr1: lC0system_data >-> pltower_precat_and_p.
 
-Definition codom { CC : lC0system_data } { X : CC } ( f : mor_from X ) : CC := pr1 f .
+Definition codom { CC : lC0system_data } { X : CC } ( f : mor_from X ): CC := pr1 f.
 
-Definition dom { CC : lC0system_data } { X : CC } ( f : mor_to X ) : CC := pr1 f .
+Definition dom { CC : lC0system_data } { X : CC } ( f : mor_to X ): CC := pr1 f.
 
 
 Definition q_of_f { CC : lC0system_data }  
@@ -175,18 +169,16 @@ Definition q_of_f { CC : lC0system_data }
   pr2 CC _ _ gt0 f . 
 
 Definition f_star { CC : lC0system_data }  
-           { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ) : CC := 
-  pr1 ( q_of_f gt0 f ) .
+           { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ): CC := 
+  pr1 ( q_of_f gt0 f ).
 
 (** Formulation of q_of_f as a function from mor_to to mor_to *)
 
 Definition q_of_mor_to { CC : lC0system_data } { X : CC } ( gt0 : ll X > 0 )
-           ( f : mor_to ( ft X ) ) : mor_to X :=
-  q_of_f gt0 f .
+  ( f : mor_to ( ft X ) ): mor_to X := q_of_f gt0 f .
 
 Definition mor_to_star { CC : lC0system_data } { X : CC } ( gt0 : ll X > 0 )
-           ( f : mor_to ( ft X ) ) : CC :=
-  f_star gt0 f .
+  ( f : mor_to ( ft X ) ): CC := f_star gt0 f.
 
 
 
@@ -199,37 +191,36 @@ The conditions 1-3 are consequences of the definition of a pointed l-tower (plto
            
 
 Definition C0ax4_type ( CC : pltower_precat_and_p ) :=
-  forall X : CC , iscontr ( X --> cntr CC ) . 
+  forall X : CC, iscontr ( X --> cntr CC ). 
 
 Definition C0ax5a_type ( CC : lC0system_data ) :=
-  forall ( X Y : CC ) ( gt0 : ll X > 0 ) ( f : Y --> ft X ) , ll ( f_star gt0 f ) > 0  .
+  forall ( X Y : CC ) ( gt0 : ll X > 0 ) ( f : Y --> ft X ), ll ( f_star gt0 f ) > 0.
 
 Definition C0ax5b_type ( CC : lC0system_data ) :=
-  forall ( X Y : CC ) ( gt0 : ll X > 0 ) ( f : Y --> ft X ) , ft ( f_star gt0 f ) = Y .
+  forall ( X Y : CC ) ( gt0 : ll X > 0 ) ( f : Y --> ft X ), ft ( f_star gt0 f ) = Y.
 
 (** A construction needed to formulate further properties of the C0-system data. *)
 
 Definition C0ax5b_mor { CC : lC0system_data } ( ax5b : C0ax5b_type CC )
-           { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ) :
-  ft ( f_star gt0 f ) --> Y := idtomor _ _ ( ax5b X Y gt0 f ) . 
+           { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ):
+  ft ( f_star gt0 f ) --> Y := idtomor _ _ ( ax5b X Y gt0 f ). 
   
 
 (** The description of properties continues *)
 
-Definition C0ax5c_type { CC : lC0system_data }
-           ( ax5b : C0ax5b_type CC ) := 
-  forall ( X Y : CC ) ( gt0 : ll X > 0 ) ( f : Y --> ft X ) , 
-    pX ( f_star gt0 f ) ;; ( ( C0ax5b_mor ax5b gt0 f ) ;; f ) = ( q_of_f gt0 f ) ;; ( pX X ) . 
+Definition C0ax5c_type { CC : lC0system_data } ( ax5b : C0ax5b_type CC ) := 
+  forall ( X Y : CC ) ( gt0 : ll X > 0 ) ( f : Y --> ft X ), 
+    pX ( f_star gt0 f ) ;; ( ( C0ax5b_mor ax5b gt0 f ) ;; f ) = ( q_of_f gt0 f ) ;; ( pX X ). 
 
 Definition C0ax6_type ( CC : lC0system_data ) :=
-  forall ( X : CC ) ( gt0 : ll X > 0 ) ,
-    q_of_f gt0 ( identity ( ft X ) ) = mor_to_constr ( identity X ) . 
+  forall ( X : CC ) ( gt0 : ll X > 0 ),
+    q_of_f gt0 ( identity ( ft X ) ) = mor_to_constr ( identity X ). 
 
 Definition C0ax7_type { CC : lC0system_data } 
   ( ax5a : C0ax5a_type CC ) ( ax5b : C0ax5b_type CC ) :=
-  forall ( X Y Z : CC ) ( gt0 : ll X > 0 ) ( f : Y --> ft X ) ( g : Z --> ft ( f_star gt0 f ) ) ,
+  forall ( X Y Z : CC ) ( gt0 : ll X > 0 ) ( f : Y --> ft X ) ( g : Z --> ft ( f_star gt0 f ) ),
     mor_to_constr ( ( q_of_f ( ax5a _ _ gt0 f ) g ) ;; ( q_of_f gt0 f ) ) =
-    q_of_f gt0 ( g ;; ( ( C0ax5b_mor ax5b gt0 f ) ;; f ) ) . 
+    q_of_f gt0 ( g ;; ( ( C0ax5b_mor ax5b gt0 f ) ;; f ) ). 
 
 
 
@@ -244,82 +235,76 @@ Definition lC0system :=
                           ( C0ax6_type CC ) ×
                           ( C0ax7_type ( pr1 axs ) ( pr1 ( pr2 axs ) ) ) ).
 
-Definition lC0system_pr1 : lC0system -> lC0system_data := pr1 .
-Coercion lC0system_pr1 : lC0system >-> lC0system_data .
+Definition lC0system_pr1: lC0system -> lC0system_data := pr1.
+Coercion lC0system_pr1: lC0system >-> lC0system_data.
 
 (* Definition C0_isaset_Ob ( CC : lC0system ) : isaset CC := pr1 ( pr1 ( pr2 CC ) ) .
 
 Definition C0_has_homsets ( CC : lC0system ) : has_homsets CC := pr2 ( pr1 ( pr2 CC ) ) . *)
 
-Definition C0ax4 ( CC : lC0system ) : C0ax4_type CC := pr1 ( pr2 CC ) . 
+Definition C0ax4 ( CC : lC0system ): C0ax4_type CC := pr1 ( pr2 CC ). 
 
-Definition C0ax5a { CC : lC0system } { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ) :
-  ll ( f_star gt0 f ) > 0 := pr1 ( pr1 ( pr2 ( pr2 CC ) ) ) X Y gt0 f .
+Definition C0ax5a { CC : lC0system } { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ):
+  ll ( f_star gt0 f ) > 0 := pr1 ( pr1 ( pr2 ( pr2 CC ) ) ) X Y gt0 f.
 
-Definition C0ax5b { CC : lC0system } { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ) :
-  ft ( f_star gt0 f ) = Y := pr1 ( pr2 ( pr1 ( pr2 ( pr2 CC )))) X Y gt0 f .
+Definition C0ax5b { CC : lC0system } { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ):
+  ft ( f_star gt0 f ) = Y := pr1 ( pr2 ( pr1 ( pr2 ( pr2 CC )))) X Y gt0 f.
 
-Notation ft_f_star := C0ax5b . 
+Notation ft_f_star := C0ax5b. 
 
-Definition C0emor { CC : lC0system } { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ) :
-  ft ( f_star gt0 f ) --> Y := C0ax5b_mor ( @C0ax5b CC ) gt0 f . 
+Definition C0emor { CC : lC0system } { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ):
+  ft ( f_star gt0 f ) --> Y := C0ax5b_mor ( @C0ax5b CC ) gt0 f. 
 
 
 Definition C0ax5c { CC : lC0system }
-           { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ) : 
+           { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ): 
   pX ( f_star gt0 f ) ;; ( ( C0emor gt0 f ) ;; f ) =
   ( q_of_f gt0 f ) ;; ( pX X ) :=
-  pr2 ( pr2 ( pr1 ( pr2 ( pr2 CC )))) X Y gt0 f . 
+  pr2 ( pr2 ( pr1 ( pr2 ( pr2 CC )))) X Y gt0 f. 
 
 
-Definition C0ax6 { CC : lC0system } { X : CC } ( gt0 : ll X > 0 ) :
+Definition C0ax6 { CC : lC0system } { X : CC } ( gt0 : ll X > 0 ):
   q_of_f gt0 ( identity ( ft X ) ) = mor_to_constr ( identity X ) :=
-  pr1 ( pr2 ( pr2 ( pr2 CC ))) X gt0 .
+  pr1 ( pr2 ( pr2 ( pr2 CC ))) X gt0.
 
-Definition C0ax6a { CC : lC0system } { X : CC } ( gt0 : ll X > 0 ) :
-  f_star gt0 ( identity ( ft X ) ) = X :=
-  maponpaths pr1 ( C0ax6 gt0 ) . 
+Definition C0ax6a { CC : lC0system } { X : CC } ( gt0 : ll X > 0 ):
+  f_star gt0 ( identity ( ft X ) ) = X := maponpaths pr1 ( C0ax6 gt0 ). 
 
-Definition C0ax7 { CC : lC0system }
-           { X Y Z : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ) ( g : Z --> ft ( f_star gt0 f ) ) :
+Definition C0ax7 { CC : lC0system } { X Y Z : CC }
+  ( gt0 : ll X > 0 ) ( f : Y --> ft X ) ( g : Z --> ft ( f_star gt0 f ) ):
   mor_to_constr ( ( q_of_f ( C0ax5a gt0 f ) g ) ;; ( q_of_f gt0 f ) ) =
   q_of_f gt0 ( g ;; ( ( C0emor gt0 f ) ;; f ) ) :=
-  pr2 ( pr2 ( pr2 ( pr2 CC ))) X Y Z gt0 f g . 
+  pr2 ( pr2 ( pr2 ( pr2 CC ))) X Y Z gt0 f g. 
 
-Definition C0ax7a { CC : lC0system }
-           { X Y Z : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ) ( g : Z --> ft ( f_star gt0 f ) ) :
+Definition C0ax7a { CC : lC0system } { X Y Z : CC }
+  ( gt0 : ll X > 0 ) ( f : Y --> ft X ) ( g : Z --> ft ( f_star gt0 f ) ):
   f_star ( C0ax5a gt0 f ) g = f_star gt0 ( g ;; ( ( C0emor gt0 f ) ;; f ) ) :=
-  maponpaths pr1 ( C0ax7 gt0 f g ) . 
+  maponpaths pr1 ( C0ax7 gt0 f g ). 
 
 (** **** Some simple properties of lC0systems *)
 
-Lemma ll_f_star { CC : lC0system } { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ) :
-  ll ( f_star gt0 f ) = 1 + ll Y .
-Proof .
-  assert ( gt0' : ll ( f_star gt0 f ) > 0 ) . apply C0ax5a .
-  rewrite <- ( S_ll_ft gt0' ) . 
-  rewrite C0ax5b . 
-  apply idpath . 
-
-Defined.
-
-Lemma isover_f_star { CC : lC0system } { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ) :
-  isover ( f_star gt0 f ) Y .
+Lemma ll_f_star { CC : lC0system } { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ):
+  ll ( f_star gt0 f ) = 1 + ll Y.
 Proof.
-  set ( eq := C0ax5b gt0 f ) . unfold isover . 
-  assert ( eq1 : ll ( f_star gt0 f ) - ll Y = 1 ) .
-  rewrite ll_f_star . 
-  apply plusminusnmm . 
-  rewrite eq1 . 
-  exact ( ! eq ) . 
-
+  assert ( gt0': ll ( f_star gt0 f ) > 0 ) by apply C0ax5a.
+  rewrite <- ( S_ll_ft gt0' ). 
+  rewrite C0ax5b. 
+  apply idpath. 
 Defined.
 
 
-
-
-
-
+Lemma isover_f_star { CC : lC0system } { X Y : CC } ( gt0 : ll X > 0 ) ( f : Y --> ft X ):
+  isover ( f_star gt0 f ) Y.
+Proof.
+  set ( eq := C0ax5b gt0 f ).
+  unfold isover. 
+  assert ( eq1 : ll ( f_star gt0 f ) - ll Y = 1 ).
+  { rewrite ll_f_star. 
+    apply plusminusnmm.
+  }
+  rewrite eq1. 
+  exact ( ! eq ). 
+Defined.
   
 
 
@@ -328,17 +313,13 @@ Defined.
 
 (** **** Operations qn and fn_star *)
 
-
-
-Definition qn { CC : lC0system_data } { A X : CC } ( f : mor_to A ) ( isov : isover X A )  :
+Definition qn { CC : lC0system_data } { A X : CC } ( f : mor_to A ) ( isov : isover X A ):
   mor_to X :=
   isover_ind ( fun X Y : CC => mor_to Y -> mor_to X )
              ( fun X => idfun _ )
              ( fun X gt0 => q_of_mor_to gt0 )
              ( fun X Y f g => funcomp g f )
-             X A isov f . 
-
-
+             X A isov f. 
 
 
 (* Definition qn { CC : lC0system_data } { Y A : CC } ( f : Y --> A ) ( n : nat ) 
@@ -359,10 +340,8 @@ Proof.
 Defined. *)
 
 
-Definition fn_star { CC : lC0system_data } { X A : CC } ( f : mor_to A ) ( isov : isover X A ) :
-  CC := dom ( qn f isov ) .
-
-
+Definition fn_star { CC : lC0system_data } { X A : CC }
+  ( f : mor_to A ) ( isov : isover X A ): CC := dom ( qn f isov ).
 
 
 
@@ -392,55 +371,52 @@ Proof.
 Defined. *)
 
 
-Lemma q_XX { CC : lC0system_data } { X : CC } ( f : mor_to X ) ( isov : isover X X ) :
-  qn f isov = f .
-Proof .
-  unfold qn .
-  assert ( int := @isover_ind_XX CC ( fun X Y : CC => mor_to Y -> mor_to X )
+Lemma q_XX { CC : lC0system_data } { X : CC } ( f : mor_to X ) ( isov : isover X X ):
+  qn f isov = f.
+Proof.
+  unfold qn.
+  set ( int := @isover_ind_XX CC ( fun X Y : CC => mor_to Y -> mor_to X )
                             ( fun X => idfun _ )
                             ( fun X gt0 => q_of_mor_to gt0 )
-                            ( fun X Y f g => funcomp g f ) X isov ) .
-  apply ( maponpaths ( fun g => g f ) int ) .
-  
+                            ( fun X Y f g => funcomp g f ) X isov ).
+  apply ( maponpaths ( fun g => g f ) int ).
 Defined.
 
 Opaque q_XX.
 
 
-Lemma q_isab { CC : lC0system_data } { X A : CC } ( f : mor_to A ) ( isab : isabove X A ) :
-  qn f isab = q_of_mor_to ( isabove_gt0 isab ) ( qn f ( isover_ft' isab ) ) . 
+Lemma q_isab { CC : lC0system_data } { X A : CC } ( f : mor_to A ) ( isab : isabove X A ):
+  qn f isab = q_of_mor_to ( isabove_gt0 isab ) ( qn f ( isover_ft' isab ) ). 
 Proof.
-  assert ( int := isover_ind_isab ( fun X Y : CC => mor_to Y -> mor_to X )
+  set ( int := isover_ind_isab ( fun X Y : CC => mor_to Y -> mor_to X )
                             ( fun X => idfun _ )
                             ( fun X gt0 => q_of_mor_to gt0 )
-                            ( fun X Y f g => funcomp g f ) X A isab ) .
-  apply ( maponpaths ( fun g => g f ) int ) .
-
+                            ( fun X Y f g => funcomp g f ) X A isab ).
+  apply ( maponpaths ( fun g => g f ) int ).
 Defined.
 
-Opaque q_isab .
+Opaque q_isab.
 
 
-Lemma q_X_ftX { CC : lC0system_data } { X : CC } ( f : mor_to ( ft X ) ) ( gt0 : ll X > 0 ) :
-  qn f ( isover_X_ftX X ) = q_of_mor_to gt0 f .
+Lemma q_X_ftX { CC : lC0system_data } { X : CC } ( f : mor_to ( ft X ) ) ( gt0 : ll X > 0 ):
+  qn f ( isover_X_ftX X ) = q_of_mor_to gt0 f.
 Proof.
-  unfold qn . 
-  apply ( maponpaths ( fun g => g f ) ) .
+  unfold qn. 
+  apply ( maponpaths ( fun g => g f ) ).
   use isover_ind_X_ftX.
-  intros X0 gt1 . 
-  apply idpath . 
-
+  intros X0 gt1. 
+  apply idpath. 
 Defined.
 
-Opaque q_X_ftX . 
+Opaque q_X_ftX. 
 
 
 
-Lemma f_star_XX { CC : lC0system_data } { X : CC } ( f : mor_to X ) ( isov : isover X X ) :
-  fn_star f isov =  dom f .
-Proof .
-  apply ( maponpaths dom ) . apply q_XX . 
-  
+Lemma f_star_XX { CC : lC0system_data } { X : CC } ( f : mor_to X ) ( isov : isover X X ):
+  fn_star f isov =  dom f.
+Proof.
+  apply ( maponpaths dom ).
+  apply q_XX. 
 Defined.
 
 Opaque f_star_XX.
@@ -448,26 +424,21 @@ Opaque f_star_XX.
 
 Lemma f_star_isab { CC : lC0system_data } { X A : CC } 
       ( f : mor_to A ) ( isab : isabove X A ) :
-  fn_star f isab = f_star ( isabove_gt0 isab ) ( qn f ( isover_ft' isab ) ) . 
+  fn_star f isab = f_star ( isabove_gt0 isab ) ( qn f ( isover_ft' isab ) ). 
 Proof.
-  apply ( maponpaths dom ) . apply q_isab. 
-  
+  apply ( maponpaths dom ).
+  apply q_isab. 
 Defined.
 
 Opaque f_star_isab.
 
 
-Lemma f_star_X_ftX { CC : lC0system_data } { X : CC } ( f : mor_to ( ft X ) ) ( gt0 : ll X > 0 ) :
-  fn_star f ( isover_X_ftX X ) = f_star gt0 f .
+Lemma f_star_X_ftX { CC : lC0system_data } { X : CC } ( f : mor_to ( ft X ) ) ( gt0 : ll X > 0 ):
+  fn_star f ( isover_X_ftX X ) = f_star gt0 f.
 Proof.
-  apply ( maponpaths dom ) . 
-  apply q_X_ftX .
-
+  apply ( maponpaths dom ). 
+  apply q_X_ftX.
 Defined.
-
-
-
-
 
 
 
@@ -528,92 +499,92 @@ Definition fn_star_to_fsm_star { CC : lC0system } { Y A : CC } ( f : Y --> A ) {
   fn_star f ( S m ) ( qsn_new_gtn gtn eqnat ) ( qsn_new_eq eq eqnat ) :=
   maponpaths pr1 ( qn_to_qsm _ _ _ _ ) . 
 
-
 *)
 
 
-
-
-
-Lemma ll_fn_star { CC : lC0system } { A X : CC } ( f : mor_to A ) ( isov : isover X A ) :
-  ll ( fn_star f isov ) + ll A  = ll ( dom f ) + ll X . 
+Lemma ll_fn_star { CC : lC0system } { A X : CC } ( f : mor_to A ) ( isov : isover X A ):
+  ll ( fn_star f isov ) + ll A  = ll ( dom f ) + ll X. 
 Proof.
   set ( P := fun ( X0 Y0 : CC ) ( isov0 : isover X0 Y0 ) =>
-               forall ( f0 : mor_to Y0 ) , ll ( fn_star f0 isov0 ) + ll Y0  = ll ( dom f0 ) + ll X0 ) .
-  assert ( P0 : forall X0 , P X0 X0 ( isover_XX X0 ) ) . intro . unfold P . intro. 
-  rewrite f_star_XX . apply idpath .
-
-  assert ( Pft : forall X0 ( gt0 : ll X0 > 0 )  , P X0 ( ft X0 ) ( isover_X_ftX X0 ) ) .    
-  intros . unfold P . intro f0 . rewrite ( f_star_X_ftX f0 gt0 ) .
-  rewrite ( ll_f_star gt0 f0 ) . 
-  rewrite ( natpluscomm 1 _ ) . 
-  rewrite natplusassoc . 
-  apply ( maponpaths ( fun x => ll (dom f0) + x ) ) .
-  apply S_ll_ft . 
-  apply gt0.
-
-  assert ( Pcomp : forall ( X Y : CC ) ,
-                       ( forall isov1 , P X ( ft X ) isov1 ) ->
-                       ( forall isov2 , P ( ft X ) Y isov2 ) ->
-                       forall ( isab : isabove X Y ) , P X Y isab )  . 
-  intros X0 Y0 F0 G0 isab . 
-  unfold P . 
-  intro f0 . 
-  rewrite f_star_isab . 
-  rewrite ll_f_star . 
-  assert ( eq := G0 (isover_ft' isab) ) . unfold P in eq .
-  change (pr1 (qn f0 (isover_ft' isab))) with ( fn_star f0 (isover_ft' isab) ) . 
-  rewrite natplusassoc . rewrite ( eq f0 ) . 
-  rewrite ( natpluscomm ( ll ( dom f0 ) ) ) . rewrite <- natplusassoc.
-  rewrite S_ll_ft . 
-  apply natpluscomm . 
-
-  apply ( isabove_gt0 isab ) . 
-
-  apply ( isover_strong_ind_int P P0 Pft Pcomp _ _ _ isov _ ) . 
-
+               forall ( f0 : mor_to Y0 ), ll ( fn_star f0 isov0 ) + ll Y0  = ll ( dom f0 ) + ll X0 ).
+  assert ( P0 : forall X0 , P X0 X0 ( isover_XX X0 ) ).
+  { intro.
+    unfold P.
+    intro. 
+    rewrite f_star_XX.
+    apply idpath.
+  }
+  assert ( Pft : forall X0 ( gt0 : ll X0 > 0 ), P X0 ( ft X0 ) ( isover_X_ftX X0 ) ).    
+  { intros.
+    unfold P.
+    intro f0.
+    rewrite ( f_star_X_ftX f0 gt0 ).
+    rewrite ( ll_f_star gt0 f0 ). 
+    rewrite ( natpluscomm 1 _ ). 
+    rewrite natplusassoc. 
+    apply ( maponpaths ( fun x => ll (dom f0) + x ) ).
+    apply S_ll_ft. 
+    apply gt0.
+  }
+  assert ( Pcomp : forall ( X Y : CC ),
+                       ( forall isov1, P X ( ft X ) isov1 ) ->
+                       ( forall isov2, P ( ft X ) Y isov2 ) ->
+                       forall ( isab : isabove X Y ), P X Y isab ). 
+  { intros X0 Y0 F0 G0 isab. 
+    unfold P. 
+    intro f0. 
+    rewrite f_star_isab. 
+    rewrite ll_f_star. 
+    assert ( eq := G0 (isover_ft' isab) ).
+    { unfold P in eq.
+      change (pr1 (qn f0 (isover_ft' isab))) with ( fn_star f0 (isover_ft' isab) ). 
+      rewrite natplusassoc.
+      rewrite ( eq f0 ). 
+      rewrite ( natpluscomm ( ll ( dom f0 ) ) ).
+      rewrite <- natplusassoc.
+      rewrite S_ll_ft. 
+      - apply natpluscomm. 
+      - apply ( isabove_gt0 isab ). 
+    }
+  }
+  apply ( isover_strong_ind_int P P0 Pft Pcomp _ _ _ isov _ ). 
 Defined.
-
-
  
 
-Lemma isover_fn_star { CC : lC0system } { X A : CC } ( f : mor_to A ) ( isov : isover X A ) :
-  isover ( fn_star f isov ) ( dom f ) .
+Lemma isover_fn_star { CC : lC0system } { X A : CC } ( f : mor_to A ) ( isov : isover X A ):
+  isover ( fn_star f isov ) ( dom f ).
 Proof.
   set ( P := fun ( X0 Y0 : CC ) ( isov0 : isover X0 Y0 ) =>
-               forall ( f0 : mor_to Y0 ) , isover ( fn_star f0 isov0 ) ( dom f0 ) ) .
-  assert ( P0 : forall X0 , P X0 X0 ( isover_XX X0 ) ) . intro . unfold P . intro. 
-  rewrite f_star_XX . apply isover_XX.
-
-  assert ( Pft : forall X0 ( gt0 : ll X0 > 0 )  , P X0 ( ft X0 ) ( isover_X_ftX X0 ) ) .    
-  intros . unfold P . intro f0 . rewrite ( f_star_X_ftX f0 gt0 ) .
-  apply isover_f_star . 
-  
-  assert ( Pcomp : forall ( X Y : CC ) ,
-                       ( forall isov1 , P X ( ft X ) isov1 ) ->
-                       ( forall isov2 , P ( ft X ) Y isov2 ) ->
-                       forall ( isab : isabove X Y ) , P X Y isab )  . 
-  intros X0 Y0 F0 G0 isab . 
-  unfold P . 
-  intro f0 . 
-  rewrite f_star_isab .
-  use isover_trans.
-  apply ( dom (qn f0 (isover_ft' isab))). 
-  apply isover_f_star .
-  apply G0 . 
-
-  apply ( isover_strong_ind_int P P0 Pft Pcomp _ _ _ isov _ ) . 
-
-
+               forall ( f0 : mor_to Y0 ) , isover ( fn_star f0 isov0 ) ( dom f0 ) ).
+  assert ( P0 : forall X0 , P X0 X0 ( isover_XX X0 ) ).
+  { intro.
+    unfold P.
+    intro. 
+    rewrite f_star_XX.
+    apply isover_XX.
+  }
+  assert ( Pft : forall X0 ( gt0 : ll X0 > 0 )  , P X0 ( ft X0 ) ( isover_X_ftX X0 ) ).    
+  { intros.
+    unfold P.
+    intro f0.
+    rewrite ( f_star_X_ftX f0 gt0 ).
+    apply isover_f_star. 
+  }  
+  assert ( Pcomp : forall ( X Y : CC ),
+                       ( forall isov1, P X ( ft X ) isov1 ) ->
+                       ( forall isov2, P ( ft X ) Y isov2 ) ->
+                       forall ( isab : isabove X Y ), P X Y isab ). 
+  { intros X0 Y0 F0 G0 isab. 
+    unfold P. 
+    intro f0. 
+    rewrite f_star_isab.
+    use isover_trans.
+    - apply ( dom (qn f0 (isover_ft' isab)) ). 
+    - apply isover_f_star.
+    - apply G0. 
+  }
+  apply ( isover_strong_ind_int P P0 Pft Pcomp _ _ _ isov _ ). 
 Defined.
-
-
-
-
-
-
-
-
 
 
 

--- a/TypeTheory/Csystems/lC0systems.v
+++ b/TypeTheory/Csystems/lC0systems.v
@@ -160,7 +160,7 @@ Definition q_data_type ( CC : ltower_precat_and_p ) :=
   forall ( X Y : CC ) ( gt0 : ll X > 0 ) ( f : Y --> ft X ) , mor_to X . 
 Identity Coercion from_q_data_type : q_data_type >-> Funclass .  
 
-Definition lC0system_data := total2 ( fun CC : pltower_precat_and_p => q_data_type CC ) .
+Definition lC0system_data := ∑ CC : pltower_precat_and_p, q_data_type CC.
 
 Definition lC0system_data_pr1 : lC0system_data -> pltower_precat_and_p  := pr1 .
 Coercion lC0system_data_pr1 : lC0system_data >-> pltower_precat_and_p .

--- a/TypeTheory/Csystems/lCsystems.v
+++ b/TypeTheory/Csystems/lCsystems.v
@@ -11,10 +11,19 @@ proporties of the identity morphisms but does require associativity.
 
  *)
 
-Require Export TypeTheory.Auxiliary.CategoryTheoryImports.
-Require Export TypeTheory.Csystems.lC0systems.
 
-Unset Automatic Introduction.
+
+Require Import UniMath.Combinatorics.StandardFiniteSets.
+Require Import TypeTheory.Csystems.prelim.
+Require Import TypeTheory.Csystems.lTowers.
+
+Require Import TypeTheory.Csystems.ltowers_over.
+
+
+(* Require Import UniMath.CategoryTheory.Categories. *)
+Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
+Require Import TypeTheory.Csystems.hSet_ltowers.
+Require Import TypeTheory.Csystems.lC0systems.
 
 
 
@@ -26,7 +35,7 @@ Unset Automatic Introduction.
 Definition sf_type ( CC : lC0system_data ) :=
   forall ( Y X : CC ) ( gt0 : ll X > 0 ) ( f : Y --> X ) , sec_pX ( f_star gt0 ( ftf f ) ) .
 
-Definition lCsystem_data := total2 ( fun CC : lC0system_data => sf_type CC ) .
+Definition lCsystem_data := ∑ CC : lC0system_data, sf_type CC.
 
 Definition lCsystem_data_constr { CC : lC0system_data } ( sf0 : sf_type CC ) : lCsystem_data :=
   tpair _ _ sf0 . 
@@ -57,7 +66,6 @@ Lemma sf_ax2_type_l1 { CC : lC0system } ( sf0 : sf_type CC )
       ( g : Y' --> ft U ) ( f : Y --> f_star gt0 g ) :
   f_star (C0ax5a gt0 g) (ftf f) = f_star gt0 (ftf (f ;; q_of_f gt0 g)) .
 Proof.
-  intros. 
   assert ( int1 : f_star (C0ax5a gt0 g) (ftf f) =
                   f_star gt0 ( ( ftf f ) ;; ( ( C0emor gt0 g ) ;; g ) ) ) .
   apply C0ax7a.
@@ -92,9 +100,8 @@ Definition sf_ax2_type { CC : lC0system } ( sf : sf_type CC ) :=
 
 
 Definition lCsystem :=
-  total2 ( fun CC : lC0system =>
-             total2 ( fun sf0 : sf_type CC =>
-                        dirprod ( sf_ax1_type sf0 ) ( sf_ax2_type sf0 ) ) ) .
+             ∑ (CC : lC0system) (sf0 : sf_type CC),
+                        ( sf_ax1_type sf0 ) × ( sf_ax2_type sf0 ).
 
 Definition lCsystem_pr1 : lCsystem -> lC0system := pr1 .
 Coercion lCsystem_pr1 : lCsystem >-> lC0system .
@@ -127,7 +134,6 @@ Definition f_star_of_s { CC : lCsystem } { Y X : CC } ( f : Y --> ft X )
            ( gt0 : ll X > 0 ) ( r : sec_pX X ) :
   sec_pX ( f_star gt0 f ) . 
 Proof .
-  intros . 
   assert ( int := sf gt0 ( f ;; r ) ) .  
   assert ( inteq : ftf ( f ;; r ) = f ) . 
   unfold ftf . 
@@ -150,7 +156,6 @@ Defined.
 Definition fsn_star_of_s { CC : lCsystem } { A X : CC } ( f : mor_to A ) ( isab : isabove X A )
            ( r : sec_pX X ) : sec_pX ( fn_star f isab ) .  
 Proof.
-  intros.
   rewrite f_star_isab .
   apply f_star_of_s . 
   exact r .

--- a/TypeTheory/Csystems/lCsystems.v
+++ b/TypeTheory/Csystems/lCsystems.v
@@ -9,7 +9,7 @@ The definition of an lC-system given below does not require that the types of ob
 of the underlying precategory form a set. It also does not require the
 proporties of the identity morphisms but does require associativity. 
 
- *)
+*)
 
 
 Require Import UniMath.Foundations.All.
@@ -25,136 +25,121 @@ Require Export TypeTheory.Csystems.lC0systems.
 (** **** l-C-system data *) 
 
 Definition sf_type ( CC : lC0system_data ) :=
-  forall ( Y X : CC ) ( gt0 : ll X > 0 ) ( f : Y --> X ) , sec_pX ( f_star gt0 ( ftf f ) ) .
+  forall ( Y X : CC ) ( gt0 : ll X > 0 ) ( f : Y --> X ), sec_pX ( f_star gt0 ( ftf f ) ).
 
 Definition lCsystem_data := ∑ CC : lC0system_data, sf_type CC.
 
-Definition lCsystem_data_constr { CC : lC0system_data } ( sf0 : sf_type CC ) : lCsystem_data :=
-  tpair _ _ sf0 . 
+Definition lCsystem_data_constr { CC : lC0system_data }
+  ( sf0 : sf_type CC ) : lCsystem_data := tpair _ _ sf0 . 
 
-Definition lCsystem_data_pr1 : lCsystem_data -> lC0system_data := pr1 .
-Coercion lCsystem_data_pr1 : lCsystem_data >-> lC0system_data .
+Definition lCsystem_data_pr1 : lCsystem_data -> lC0system_data := pr1.
+Coercion lCsystem_data_pr1 : lCsystem_data >-> lC0system_data.
 
-Definition sf_from_data { CC : lCsystem_data } { Y X : CC } ( gt0 : ll X > 0 ) ( f : Y --> X ) :
-  sec_pX ( f_star gt0 ( ftf f ) ) :=
-  pr2 CC Y X gt0 f . 
-
+Definition sf_from_data { CC : lCsystem_data } { Y X : CC } ( gt0 : ll X > 0 ) ( f : Y --> X ):
+  sec_pX ( f_star gt0 ( ftf f ) ) := pr2 CC Y X gt0 f . 
 
 
-
-
-
-(** **** Properties on l-C-system data 
-
-that later become axioms of l-C-systems. *)
+(** **** Properties on l-C-system data that later become axioms of l-C-systems. *)
 
 
 Definition sf_ax1_type { CC : lC0system } ( sf0 : sf_type CC ) :=
-  forall ( Y X : CC ) ( gt0 : ll X > 0 ) ( f : Y --> X ) ,
-    ( C0emor gt0 ( ftf f ) ) ;; f = ( sf0 _ _ gt0 f ) ;; ( q_of_f gt0 ( ftf f ) ) .
+  forall ( Y X : CC ) ( gt0 : ll X > 0 ) ( f : Y --> X ),
+    ( C0emor gt0 ( ftf f ) ) ;; f = ( sf0 _ _ gt0 f ) ;; ( q_of_f gt0 ( ftf f ) ).
 
 Lemma sf_ax2_type_l1 { CC : lC0system } ( sf0 : sf_type CC )
       { Y Y' U : CC } ( gt0 : ll U > 0 )
-      ( g : Y' --> ft U ) ( f : Y --> f_star gt0 g ) :
-  f_star (C0ax5a gt0 g) (ftf f) = f_star gt0 (ftf (f ;; q_of_f gt0 g)) .
+      ( g : Y' --> ft U ) ( f : Y --> f_star gt0 g ):
+  f_star (C0ax5a gt0 g) (ftf f) = f_star gt0 (ftf (f ;; q_of_f gt0 g)).
 Proof.
   assert ( int1 : f_star (C0ax5a gt0 g) (ftf f) =
-                  f_star gt0 ( ( ftf f ) ;; ( ( C0emor gt0 g ) ;; g ) ) ) .
-  apply C0ax7a.
+                  f_star gt0 ( ( ftf f ) ;; ( ( C0emor gt0 g ) ;; g ) ) )
+  by apply C0ax7a.
 
   assert ( int2 : f_star gt0 ( ( ftf f ) ;; ( ( C0emor gt0 g ) ;; g ) ) =
-                  f_star gt0 ( f ;; ( ( pX _ ) ;; ( ( C0emor gt0 g ) ;; g ) ) ) ) . 
-  unfold ftf . rewrite <- assoc . 
-  apply idpath . 
-
+                  f_star gt0 ( f ;; ( ( pX _ ) ;; ( ( C0emor gt0 g ) ;; g ) ) ) ). 
+  { unfold ftf.
+    rewrite <- assoc. 
+    apply idpath.
+  }
   assert ( int3 : f_star gt0 ( f ;; ( ( pX _ ) ;; ( ( C0emor gt0 g ) ;; g ) ) ) =
-                  f_star gt0 ( f ;; ( ( q_of_f gt0 g ) ;; ( pX U ) ) ) ) .
-  unfold ftf . rewrite C0ax5c .
-  apply idpath . 
-
+                  f_star gt0 ( f ;; ( ( q_of_f gt0 g ) ;; ( pX U ) ) ) ).
+  { unfold ftf.
+    rewrite C0ax5c.
+    apply idpath. 
+  }
   assert ( int4 : f_star gt0 ( f ;; ( ( q_of_f gt0 g ) ;; ( pX U ) ) ) =
-                  f_star gt0 (ftf (f ;; q_of_f gt0 g)) ) .
-  unfold ftf . rewrite assoc .
-  apply idpath . 
-
-  exact ( ( int1 @ int2 ) @ ( int3 @ int4 ) ) . 
-
+                  f_star gt0 (ftf (f ;; q_of_f gt0 g)) ).
+  { unfold ftf.
+    rewrite assoc.
+    apply idpath. 
+  }
+  exact ( ( int1 @ int2 ) @ ( int3 @ int4 ) ). 
 Defined.
+
 
 Definition sf_ax2_type { CC : lC0system } ( sf : sf_type CC ) :=
   forall ( Y Y' U : CC ) ( gt0 : ll U > 0 )
-         ( g : Y' --> ft U ) ( f : Y --> f_star gt0 g ) ,
+    ( g : Y' --> ft U ) ( f : Y --> f_star gt0 g ),
      transportf sec_pX  (sf_ax2_type_l1 sf gt0 g f ) ( sf Y _ ( C0ax5a gt0 g ) f ) =
-     sf Y _ gt0 ( f ;; q_of_f gt0 g ) .  
+     sf Y _ gt0 ( f ;; q_of_f gt0 g ).  
 
 
 (** **** The definition of the type of l-C-systems *)
-
 
 Definition lCsystem :=
              ∑ (CC : lC0system) (sf0 : sf_type CC),
                         ( sf_ax1_type sf0 ) × ( sf_ax2_type sf0 ).
 
-Definition lCsystem_pr1 : lCsystem -> lC0system := pr1 .
-Coercion lCsystem_pr1 : lCsystem >-> lC0system .
+Definition lCsystem_pr1: lCsystem -> lC0system := pr1.
+Coercion lCsystem_pr1: lCsystem >-> lC0system.
 
-Definition lCsystem_to_lCsystem_data ( CC : lCsystem ) : lCsystem_data :=
-  @lCsystem_data_constr CC ( pr1 ( pr2 CC ) ) .
-Coercion lCsystem_to_lCsystem_data : lCsystem >-> lCsystem_data .
+Definition lCsystem_to_lCsystem_data ( CC : lCsystem ): lCsystem_data :=
+  @lCsystem_data_constr CC ( pr1 ( pr2 CC ) ).
+Coercion lCsystem_to_lCsystem_data : lCsystem >-> lCsystem_data.
 
-Definition sf { CC : lCsystem } { Y X : CC } ( gt0 : ll X > 0 ) ( f : Y --> X ) :
-  sec_pX ( f_star gt0 ( ftf f ) ) := ( pr1 ( pr2 CC ) ) Y X gt0 f . 
+Definition sf { CC : lCsystem } { Y X : CC } ( gt0 : ll X > 0 ) ( f : Y --> X ):
+  sec_pX ( f_star gt0 ( ftf f ) ) := ( pr1 ( pr2 CC ) ) Y X gt0 f. 
 
-Definition sf_ax1 { CC : lCsystem } { Y X : CC } ( gt0 : ll X > 0 ) ( f : Y --> X ) :
+Definition sf_ax1 { CC : lCsystem } { Y X : CC } ( gt0 : ll X > 0 ) ( f : Y --> X ):
   ( C0emor gt0 ( ftf f ) ) ;; f  = ( sf gt0 f ) ;; ( q_of_f gt0 ( ftf f ) ) :=
-  pr1 ( pr2 ( pr2 CC ) ) Y X gt0 f .
+  pr1 ( pr2 ( pr2 CC ) ) Y X gt0 f.
 
 Definition sf_ax2 { CC : lCsystem } { Y Y' U : CC } ( gt0 : ll U > 0 )
-           ( g : Y' --> ft U ) ( f : Y --> f_star gt0 g ) :
+           ( g : Y' --> ft U ) ( f : Y --> f_star gt0 g ):
   transportf sec_pX  (sf_ax2_type_l1 ( @sf CC ) gt0 g f ) ( sf ( C0ax5a gt0 g ) f ) =
   sf gt0 ( f ;; q_of_f gt0 g ) :=
-  pr2 ( pr2 ( pr2 CC ) ) Y Y' U gt0 g f .
+  pr2 ( pr2 ( pr2 CC ) ) Y Y' U gt0 g f.
 
-
-
-
-  
 
 (** **** Operation f_star_of_s *)
 
 Definition f_star_of_s { CC : lCsystem } { Y X : CC } ( f : Y --> ft X )
-           ( gt0 : ll X > 0 ) ( r : sec_pX X ) :
-  sec_pX ( f_star gt0 f ) . 
-Proof .
-  assert ( int := sf gt0 ( f ;; r ) ) .  
-  assert ( inteq : ftf ( f ;; r ) = f ) . 
-  unfold ftf . 
-  rewrite <- assoc.
-  set ( eq := sec_pX_eq r : (r;; pX X)= _) . 
-  change ( f ;; (r ;; pX X ) = f ) .  
-  rewrite eq .
-  apply id_right . 
-
-  rewrite inteq in int . 
-  apply int . 
-
+  ( gt0 : ll X > 0 ) ( r : sec_pX X ): sec_pX ( f_star gt0 f ). 
+Proof.
+  set ( int := sf gt0 ( f ;; r ) ).  
+  assert ( inteq : ftf ( f ;; r ) = f ). 
+  { unfold ftf. 
+    rewrite <- assoc.
+    set ( eq := sec_pX_eq r : (r;; pX X)= _). 
+    change ( f ;; (r ;; pX X ) = f ).  
+    rewrite eq.
+    apply id_right. 
+  }
+  rewrite inteq in int. 
+  apply int. 
 Defined.
-
   
 
 (** **** Operation fsn_star_of_s *)
 
 
-Definition fsn_star_of_s { CC : lCsystem } { A X : CC } ( f : mor_to A ) ( isab : isabove X A )
-           ( r : sec_pX X ) : sec_pX ( fn_star f isab ) .  
+Definition fsn_star_of_s { CC : lCsystem } { A X : CC } ( f : mor_to A )
+  ( isab : isabove X A ) ( r : sec_pX X ) : sec_pX ( fn_star f isab ).  
 Proof.
-  rewrite f_star_isab .
-  apply f_star_of_s . 
-  exact r .
-
+  rewrite f_star_isab.
+  apply f_star_of_s. 
+  exact r.
 Defined.
-
-
  
    
 (*
@@ -203,16 +188,6 @@ Proof.
   apply idpath .
 
 Defined.
-
-
-
-
-  
-  
-
-
-
-
 
 
 

--- a/TypeTheory/Csystems/lCsystems.v
+++ b/TypeTheory/Csystems/lCsystems.v
@@ -12,14 +12,11 @@ proporties of the identity morphisms but does require associativity.
  *)
 
 
-
+Require Import UniMath.Foundations.All.
 Require Import UniMath.Combinatorics.StandardFiniteSets.
 Require Import TypeTheory.Csystems.prelim.
 Require Import TypeTheory.Csystems.lTowers.
-
 Require Import TypeTheory.Csystems.ltowers_over.
-
-
 (* Require Import UniMath.CategoryTheory.Categories. *)
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 Require Import TypeTheory.Csystems.hSet_ltowers.

--- a/TypeTheory/Csystems/lCsystems.v
+++ b/TypeTheory/Csystems/lCsystems.v
@@ -13,14 +13,9 @@ proporties of the identity morphisms but does require associativity.
 
 
 Require Import UniMath.Foundations.All.
-Require Import UniMath.Combinatorics.StandardFiniteSets.
-Require Import TypeTheory.Csystems.prelim.
-Require Import TypeTheory.Csystems.lTowers.
-Require Import TypeTheory.Csystems.ltowers_over.
 (* Require Import UniMath.CategoryTheory.Categories. *)
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
-Require Import TypeTheory.Csystems.hSet_ltowers.
-Require Import TypeTheory.Csystems.lC0systems.
+Require Export TypeTheory.Csystems.lC0systems.
 
 
 

--- a/TypeTheory/Csystems/lTowers.v
+++ b/TypeTheory/Csystems/lTowers.v
@@ -6,8 +6,7 @@ lBsystems_carriers.v
  *)
 
 Require Import UniMath.Foundations.All.
-Require Import UniMath.Combinatorics.StandardFiniteSets.
-Require Import TypeTheory.Csystems.prelim.
+Require Export TypeTheory.Csystems.prelim.
 
 
 (** To uu0a.v *)

--- a/TypeTheory/Csystems/lTowers.v
+++ b/TypeTheory/Csystems/lTowers.v
@@ -116,7 +116,15 @@ Proof.
       exact (negpathssx0 _ H).
 Defined.
 
-(** not yet shown that the two transformations create an isomorphism *)
+(*
+Lemma weq_pretower_ltower: ltower ≃ pretower.
+Proof.
+  apply (weq_iso ltower_to_pretower pretower_to_ltower).
+  - intro lt.
+    induction lt as [T [[ll ft] [H1 H2]]].
+  How to proceed?
+*)  
+
 
 
 (** Some useful lemmas about ltower *)

--- a/TypeTheory/Csystems/lTowers.v
+++ b/TypeTheory/Csystems/lTowers.v
@@ -3,8 +3,9 @@
 by Vladimir Voevodsky, started on Jan. 22, 2015, most material migrated from 
 lBsystems_carriers.v 
 
-*)
+ *)
 
+Require Import UniMath.Foundations.All.
 Require Import UniMath.Combinatorics.StandardFiniteSets.
 Require Import TypeTheory.Csystems.prelim.
 

--- a/TypeTheory/Csystems/lTowers.v
+++ b/TypeTheory/Csystems/lTowers.v
@@ -81,11 +81,9 @@ Proof.
   exists (ft t).
   rewrite ll_ft.
   rewrite H.
-  replace (S n) with (n + 1).
-  - apply plusminusnmm.
-  - rewrite natpluscomm.
-    simpl.
-    reflexivity. (* why does apply idpath not work? *)
+  change (S n) with (1 + n).
+  rewrite natpluscomm.
+  apply plusminusnmm.
 Defined.
 
 Definition pretower_to_ltower: pretower -> ltower.

--- a/TypeTheory/Csystems/lTowers.v
+++ b/TypeTheory/Csystems/lTowers.v
@@ -212,7 +212,7 @@ Proof.
   unfold isover .
   destruct ( natgehchoice _ _ ( natgehn0 ( ll X ) ) )  as [ gt | eq ] . 
   rewrite ll_ft . 
-  assert ( eq : ll X - ( ll X - 1 ) = 1 ) . refine ( natminusmmk _ ) . 
+  assert ( eq : ll X - ( ll X - 1 ) = 1 ) . use natminusmmk. 
   exact ( natgthtogehsn _ _ gt ) . 
 
   rewrite eq .
@@ -263,14 +263,14 @@ Proof.
   intros .  exact is .
 
   intros . simpl .
-  refine ( isover_ft _ _ ) .
-  refine ( IHn _ _ _ _ ) . 
+  use isover_ft.
+  use IHn.
   exact is .
 
   exact ( istransnatgeh _ _ _ gte ( natgehsnn n ) ) .
 
   rewrite ll_ftn . 
-  refine ( natgthleftminus _ _ _ _ ) . 
+  use natgthleftminus.
   assert ( int := natgehgthtrans _ _ _ gte ( natgthsnn n ) ) . 
   rewrite natpluscomm . 
   exact ( natgthrightplus _ _ _ int ) .
@@ -322,7 +322,7 @@ Coercion isabove_to_isover : isabove >-> isover .
 
 Lemma isabove_X_ftX { BB : ltower } ( X : BB ) ( gt0 : ll X > 0 ) : isabove X ( ft X ) .
 Proof .
-  refine ( isabove_constr _ _ ) .
+  use isabove_constr.
   rewrite ll_ft . 
   exact ( natgthnnmius1 gt0 ) . 
 
@@ -336,7 +336,7 @@ Proof.
   induction n as [ | n IHn ] .
   destruct ( negnatgthnn _ gt0' ) .
 
-  refine ( isabove_constr _ _ ) .
+  use isabove_constr.
   rewrite ll_ftn .
   apply natminuslthn . 
   exact gt0 . 
@@ -355,7 +355,7 @@ Defined.
 Lemma isabove_X_ftA { BB : ltower } { X A : BB }
       ( is : isabove X A ) : isabove X ( ft A ) .
 Proof .
-  refine ( isabove_constr _ _ ) .
+  use isabove_constr.
   rewrite ll_ft . 
   exact ( natgthgehtrans _ _ _ ( isabove_gth is ) ( natminuslehn _ 1 ) ) . 
 
@@ -367,9 +367,9 @@ Defined.
 Lemma isabove_X_ftA' { BB : ltower } { X A : BB }
       ( is : isover X A ) ( gt0 : ll A > 0 ) : isabove X ( ft A ) .
 Proof .
-  refine ( isabove_constr _ _ ) .
+  use isabove_constr.
   rewrite ll_ft .
-  refine ( natgehgthtrans _ _ _ ( isover_geh is ) _ ) .
+  use ( natgehgthtrans _ _ _ ( isover_geh is ) ) .
   exact ( natgthnnmius1 gt0 ) . 
 
   exact ( isover_X_ftA is ) . 
@@ -381,7 +381,7 @@ Defined.
 Lemma isabove_trans { BB : ltower } { X A A' : BB } :
   isabove X A -> isabove A A' -> isabove X A' .
 Proof.
-  intros is is' . refine ( isabove_constr _ _ ) .
+  intros is is' . use isabove_constr.
   exact ( istransnatgth _ _ _ ( isabove_gth is ) ( isabove_gth is' ) ) .
 
   exact ( isover_trans is is' ) .
@@ -391,7 +391,7 @@ Defined.
 Lemma isabov_trans { BB : ltower } { X A A' : BB } :
   isabove X A -> isover A A' -> isabove X A' .
 Proof.
-  intros is is' . refine ( isabove_constr _ _ ) .
+  intros is is' . use isabove_constr.
   exact ( natgthgehtrans _ _ _ ( isabove_gth is ) ( isover_geh is' ) ) .
 
   exact ( isover_trans is is' ) .
@@ -401,7 +401,7 @@ Defined.
 Lemma isovab_trans { BB : ltower } { X A A' : BB } :
   isover X A -> isabove A A' -> isabove X A' .
 Proof.
-  intros is is' . refine ( isabove_constr _ _ ) .
+  intros is is' . use isabove_constr.
   exact ( natgehgthtrans _ _ _ ( isover_geh is ) ( isabove_gth is' ) ) .
 
   exact ( isover_trans is is' ) .
@@ -477,7 +477,7 @@ Proof .
   destruct ( isabove_choice isab' ) as [ isab'' | iseq ] .
   exact ( ii1 isab'' ) .
 
-  refine ( ii2 _ ) . 
+  use ii2.
   unfold isover .
   rewrite iseq . 
   rewrite natminusnn . 

--- a/TypeTheory/Csystems/ltowers_over.v
+++ b/TypeTheory/Csystems/ltowers_over.v
@@ -9,342 +9,296 @@ Require Import UniMath.Foundations.All.
 Require Export TypeTheory.Csystems.lTowers.
 
 
-
-
-
-
-
-
 (** ltowers of objects over an object *)
 
 
-Definition ltower_over_carrier { T : ltower } ( A : T ) :=
-  ∑ X : T, isover X A .
+Definition ltower_over_carrier { T : ltower } ( A : T ) := ∑ X : T, isover X A.
 
-Definition obj_over_constr { T : ltower } { A : T } { X : T } ( isov : isover X A ) :
-  ltower_over_carrier A := tpair ( fun X : T => isover X A ) _ isov .
+Definition obj_over_constr { T : ltower } { A : T } { X : T } ( isov : isover X A ):
+  ltower_over_carrier A := tpair ( fun X : T => isover X A ) _ isov.
 
-Definition isov_isov { T : ltower } { A : T } ( X : ltower_over_carrier A ) :
-  isover ( pr1 X ) A := pr2 X . 
+Definition isov_isov { T : ltower } { A : T } ( X : ltower_over_carrier A ):
+  isover ( pr1 X ) A := pr2 X. 
 
-Definition ltower_over_ll { T : ltower } { A : T } ( X : ltower_over_carrier A ) : nat :=
-  ll ( pr1 X ) - ll A .
+
+(** ltower operations on this carrier *)
+Definition ltower_over_ll { T : ltower } { A : T } ( X : ltower_over_carrier A ): nat :=
+  ll ( pr1 X ) - ll A.
       
-Definition ltower_over_ft { T : ltower } { A : T } ( X : ltower_over_carrier A ) :
-  ltower_over_carrier A .
-Proof .
-  destruct ( isover_choice ( isov_isov X ) ) as [ isov | eq ] .
-  exact ( tpair _ ( ft ( pr1 X ) )  isov ) .
-
-  exact ( tpair ( fun X : T => isover X A ) A ( isover_XX A ) ) . 
-
-Defined.
-
-Lemma ltower_over_ll_ft_eq { T : ltower } { A : T } ( X : ltower_over_carrier A ) :
-  ltower_over_ll ( ltower_over_ft X ) = ltower_over_ll X - 1 .
-Proof .
-  unfold ltower_over_ft . 
-  destruct ( isover_choice ( isov_isov X ) ) as [ isov | eq ] .
-  unfold ltower_over_ll .  
-  simpl .
-  rewrite ll_ft . 
-  rewrite natminusassoc . 
-  rewrite natpluscomm . 
-  rewrite <- natminusassoc . 
-  apply idpath . 
-
-  unfold ltower_over_ll .
-  simpl . 
-  rewrite natminusnn . 
-  rewrite <- eq . 
-  rewrite natminusnn .
-  apply idpath . 
-
-Defined.
-
-
-Lemma ispointed_ltower_over_int { T : ltower } ( A : T ) :
-  iscontr ( ∑ X : ltower_over_carrier A ,
-                       ltower_over_ll X = 0 ) .
+Definition ltower_over_ft { T : ltower } { A : T } ( X : ltower_over_carrier A ):
+  ltower_over_carrier A.
 Proof.
-  assert ( weq1 : ( ∑ X : ltower_over_carrier A,
-                                   ltower_over_ll X = 0 ) ≃
-                      ( ∑ X : T, ( isover X A ) × ( ll X - ll A = 0 ) ) ).
-  apply weqtotal2asstor . 
+  destruct ( isover_choice ( isov_isov X ) ) as [ isov | eq ].
+  - exact ( ( ft ( pr1 X ) ) ,, isov ).
+  - exact ( tpair ( fun X : T => isover X A ) A ( isover_XX A ) ). 
+Defined.
 
-  assert ( weq2 : ( ∑ X : T,  ( isover X A ) × ( ll X - ll A = 0 ) ) ≃
-                      ( ∑ X : T, A = X ) ).
-  use weqfibtototal.
-  intro X . 
-  assert ( weq3 : ((isover X A) × (ll X - ll A = 0)) ≃
-                      ((ll X - ll A = 0) × (isover X A)) ) .
-  apply weqdirprodcomm . 
 
-  assert ( weq4 :  ((ll X - ll A = 0) × (isover X A)) ≃
-                      ((ll X - ll A = 0) × ( A = X ) ) ) .
-  use weqfibtototal.
-  intro eq . 
-  unfold isover . 
-  rewrite eq . 
-  apply idweq.
+(** ltower laws for these operations *)
+Lemma ltower_over_ll_ft_eq { T : ltower } { A : T } ( X : ltower_over_carrier A ):
+  ltower_over_ll ( ltower_over_ft X ) = ltower_over_ll X - 1.
+Proof.
+  unfold ltower_over_ft. 
+  destruct ( isover_choice ( isov_isov X ) ) as [ isov | eq ]; unfold ltower_over_ll; simpl.
+  - rewrite ll_ft. 
+    rewrite natminusassoc. 
+    rewrite natpluscomm. 
+    rewrite <- natminusassoc. 
+    apply idpath. 
+  - rewrite natminusnn. 
+    rewrite <- eq. 
+    rewrite natminusnn.
+    apply idpath. 
+Defined.
 
-  assert ( weq5 :  ((ll X - ll A = 0) × (A = X)) ≃
-                      ( (A = X) × (ll X - ll A = 0))).
-  apply weqdirprodcomm . 
 
-  assert ( weq6 :  ((A = X) × (ll X - ll A = 0)) ≃
-                      ( A = X ) ) .
-  apply weqpr1 . 
-  intro eq . 
-  rewrite eq . 
-  rewrite natminusnn . 
-  apply iscontraprop1 . 
-  apply isasetnat . 
-
-  apply idpath . 
-
-  apply ( weqcomp weq3 ( weqcomp weq4 ( weqcomp weq5 weq6 ) ) ) .  
-
-  assert ( weq := weqcomp weq1 weq2 ) . 
-  apply ( iscontrweqb weq ) .
-
-  apply iscontrpathsfrom .
-
+Lemma ispointed_ltower_over_int { T : ltower } ( A : T ):
+  iscontr ( ∑ X : ltower_over_carrier A , ltower_over_ll X = 0 ).
+Proof.
+  assert ( weq1 : ( ∑ X : ltower_over_carrier A, ltower_over_ll X = 0 ) ≃
+                  ( ∑ X : T, ( isover X A ) × ( ll X - ll A = 0 ) ) )
+  by apply weqtotal2asstor. 
+  assert ( weq2 : ( ∑ X : T, ( isover X A ) × ( ll X - ll A = 0 ) ) ≃
+                  ( ∑ X : T, A = X ) ).
+  { use weqfibtototal.
+    intro X. 
+    assert ( weq3 : ( (isover X A) × (ll X - ll A = 0) ) ≃
+                    ( (ll X - ll A = 0) × (isover X A) ) )
+    by apply weqdirprodcomm. 
+    assert ( weq4 :  ( (ll X - ll A = 0) × (isover X A) ) ≃
+                     ( (ll X - ll A = 0) × ( A = X ) ) ).
+    { use weqfibtototal.
+      intro eq . 
+      unfold isover. 
+      rewrite eq. 
+      apply idweq.
+    }
+    assert ( weq5 : ( (ll X - ll A = 0) × (A = X) ) ≃
+                    ( (A = X) × (ll X - ll A = 0) ) )
+    by apply weqdirprodcomm. 
+    assert ( weq6 : ( (A = X) × (ll X - ll A = 0) ) ≃
+                    ( A = X ) ).
+    { apply weqpr1. 
+      intro eq . 
+      rewrite eq. 
+      rewrite natminusnn. 
+      apply iscontraprop1. 
+      - apply isasetnat. 
+      - apply idpath. 
+    }
+    apply ( weqcomp weq3 ( weqcomp weq4 ( weqcomp weq5 weq6 ) ) ).  
+  }
+  set ( weq := weqcomp weq1 weq2 ). 
+  apply ( iscontrweqb weq ).
+  apply iscontrpathsfrom.
 Defined.
 
   
-
-         
-
-
 Lemma ltower_over_ll0_eq { T : ltower } { A : T }
-      ( X : ltower_over_carrier A ) ( eq0 : ltower_over_ll X = 0 ) : 
-  ltower_over_ft X = X .
-Proof .
-  assert ( eq0' : ltower_over_ll ( ltower_over_ft X ) = 0 ) . 
-  rewrite ltower_over_ll_ft_eq . 
-  rewrite eq0 . 
-  apply idpath .
-
+      ( X : ltower_over_carrier A ) ( eq0 : ltower_over_ll X = 0 ): 
+  ltower_over_ft X = X.
+Proof.
+  assert ( eq0' : ltower_over_ll ( ltower_over_ft X ) = 0 ). 
+  { rewrite ltower_over_ll_ft_eq. 
+    rewrite eq0. 
+    apply idpath.
+  }
   assert ( int : tpair ( fun X' => ltower_over_ll X' = 0 ) _ eq0' =
-                 tpair ( fun X' => ltower_over_ll X' = 0 ) X eq0 ) .
-  apply ( proofirrelevancecontr ( ispointed_ltower_over_int _ ) _ _ ) .
-
-  apply ( maponpaths ( @pr1 _ ( fun X' => ltower_over_ll X' = 0 ) ) int ) .
-
+                 tpair ( fun X' => ltower_over_ll X' = 0 ) X eq0 )
+  by use ( proofirrelevancecontr ( ispointed_ltower_over_int _ ) ).
+  apply ( maponpaths ( @pr1 _ ( fun X' => ltower_over_ll X' = 0 ) ) int ).
 Defined.
-
-
   
-
-Definition ltower_over { T : ltower } ( A : T ) : ltower :=
+(** put these findings together *)
+Definition ltower_over { T : ltower } ( A : T ): ltower :=
   ltower_constr ( @ltower_over_ll _ A ) ( @ltower_over_ft _ A )
-                ( @ltower_over_ll_ft_eq _ A ) ( @ltower_over_ll0_eq _ A ) .
+                ( @ltower_over_ll_ft_eq _ A ) ( @ltower_over_ll0_eq _ A ).
 
   
 
 (** The name of the following function comes from the word octothrope that is the official name for the 
 "pound sign". This symbol, as a subscript, is used sometimes to denote the left adjoint to the pull-back 
-functor that takes a presheaf represneted by p : X -> B over B to the presheaf represented by X. *)
+functor that takes a presheaf represented by p : X -> B over B to the presheaf represented by X. *)
 
-Definition pocto { T : ltower } { A : T } ( X : ltower_over A ) : T := pr1 X . 
+Definition pocto { T : ltower } { A : T } ( X : ltower_over A ): T := pr1 X. 
 
-Definition ll_pocto { T : ltower } { A : T } ( X : ltower_over A ) :
-  ll ( pocto X ) = ll X + ll A .
+Definition ll_pocto { T : ltower } { A : T } ( X : ltower_over A ):
+  ll ( pocto X ) = ll X + ll A.
 Proof.
-  intros .
-  change ( ll X ) with ( ltower_over_ll X ) . 
-  unfold ltower_over_ll .
-  rewrite minusplusnmm . 
-  apply idpath . 
-
-  apply ( isover_geh ( pr2 X ) ) . 
-
+  intros.
+  change ( ll X ) with ( ltower_over_ll X ). 
+  unfold ltower_over_ll.
+  rewrite minusplusnmm. 
+  - apply idpath. 
+  - apply ( isover_geh ( pr2 X ) ). 
 Defined.
 
 
   
-Definition ispointed_ltower_over { T : ltower } ( A : T ) : ispointed_type ( ltower_over A ) :=
-  ispointed_ltower_over_int A .
+Definition ispointed_ltower_over { T : ltower } ( A : T ): ispointed_type ( ltower_over A ) :=
+  ispointed_ltower_over_int A.
 
-Definition pltower_over { T : ltower } ( A : T ) : pltower := pltower_constr ( ispointed_ltower_over A ) . 
+Definition pltower_over { T : ltower } ( A : T ): pltower := pltower_constr ( ispointed_ltower_over A ). 
 
-Definition ltower_over_to_pltower_over { T : ltower } ( A : T ) ( X : ltower_over A ) :
-  pltower_over A := X .
+Definition ltower_over_to_pltower_over { T : ltower } ( A : T ) ( X : ltower_over A ):
+  pltower_over A := X.
 
 Lemma ltower_over_ftn { T : ltower } { A : T } ( n : nat )
-      ( X : ltower_over A ) ( ge : ll X >= n ) : pr1 ( ftn n X ) = ftn n ( pr1 X ) .
-Proof .
+      ( X : ltower_over A ) ( ge : ll X >= n ): pr1 ( ftn n X ) = ftn n ( pr1 X ).
+Proof.
   revert X ge. 
-  induction n .
-  + intros . 
-    apply idpath . 
-
+  induction n.
   + intros. 
-    rewrite <- ftn_ft . 
-    rewrite <- ftn_ft . 
-    assert ( int : ft ( pr1 X ) = pr1 ( ft X ) ) . 
-    - change ( ft X ) with ( ltower_over_ft X ) . 
-      unfold ltower_over_ft . 
-      destruct ( isover_choice (isov_isov X) ) as [ isov | eq ] . 
-      *  simpl . 
-         apply idpath . 
-
-      *  change ( ll X ) with ( ll ( pr1 X ) - ll A ) in ge .
-         rewrite <- eq in ge . 
-         rewrite natminusnn in ge .
+    apply idpath. 
+  + intros. 
+    do 2 rewrite <- ftn_ft. 
+    assert ( int : ft ( pr1 X ) = pr1 ( ft X ) ). 
+    { change ( ft X ) with ( ltower_over_ft X ). 
+      unfold ltower_over_ft. 
+      destruct ( isover_choice (isov_isov X) ) as [ isov | eq ]. 
+      *  simpl. 
+         apply idpath. 
+      *  change ( ll X ) with ( ll ( pr1 X ) - ll A ) in ge.
+         rewrite <- eq in ge. 
+         rewrite natminusnn in ge.
          destruct (nopathsfalsetotrue ge).
-    -  rewrite int . 
-       use ( IHn ( ft X ) ) . 
-       apply ( ll_ft_gtn ge ) . 
+    }
+    rewrite int. 
+    use ( IHn ( ft X ) ). 
+    apply ( ll_ft_gtn ge ). 
 Defined.
 
 
 (** **** Standard constructions of over-objects *)
 
-Definition X_over_X { T : ltower } ( X : T ) : ltower_over X :=
-  obj_over_constr ( isover_XX X ) .
+Definition X_over_X { T : ltower } ( X : T ): ltower_over X :=
+  obj_over_constr ( isover_XX X ).
 
-Lemma ll_X_over_X { T : ltower } ( X : T ) : ll ( X_over_X X ) = 0 .
+Lemma ll_X_over_X { T : ltower } ( X : T ): ll ( X_over_X X ) = 0.
 Proof.
-  change _ with ( ll X - ll X = 0 ) .
-  apply natminusnn . 
-
+  change ( ll X - ll X = 0 ).
+  apply natminusnn. 
 Defined.
 
 
-  
+Definition X_over_ftX { T : ltower } ( X : T ): ltower_over ( ft X ) :=
+  obj_over_constr ( isover_X_ftX X ).
 
-Definition X_over_ftX { T : ltower } ( X : T ) : ltower_over ( ft X ) :=
-  obj_over_constr ( isover_X_ftX X ) .
-
-Lemma ll_X_over_ftX { T : ltower } { X : T } ( gt0 : ll X > 0 ) :
-  ll ( X_over_ftX X ) = 1 .
+Lemma ll_X_over_ftX { T : ltower } { X : T } ( gt0 : ll X > 0 ):
+  ll ( X_over_ftX X ) = 1.
 Proof.
-  change _ with ( ltower_over_ll (X_over_ftX X) = 1 ) . 
-  unfold ltower_over_ll .
-  rewrite ll_ft . 
-  change _ with ( ll X - ( ll X - 1 ) = 1 ) . 
-  apply natminusmmk . 
-  apply ( @natgthminus1togeh 1 _ gt0 ) . 
-
+  change ( ltower_over_ll (X_over_ftX X) = 1 ). 
+  unfold ltower_over_ll.
+  rewrite ll_ft. 
+  change ( ll X - ( ll X - 1 ) = 1 ). 
+  apply natminusmmk. 
+  apply ( @natgthminus1togeh 1 _ gt0 ). 
 Defined.
 
 
 
 (** The projection pocto from the over-tower to the tower is over-monotone *)
 
-
-
-Lemma ll_over_minus_ll_over { T : ltower } { A : T } ( X1 X2 : ltower_over A ) :
-  ll X1 - ll X2 = ll ( pocto X1 ) - ll ( pocto X2 ) . 
-Proof .
-  destruct X1 as [ X1 isov1 ] . destruct X2 as [ X2 isov2 ] . 
-  unfold ll . 
-  simpl . 
-  unfold ltower_over_ll .  simpl . 
-  change _ with ( ( ll X1 - ll A ) - ( ll X2 - ll A ) = ( ll X1 - ll X2 ) ) . 
-  rewrite natminusassoc . 
-  rewrite natpluscomm . 
-  rewrite ( minusplusnmm _ _ ( isover_geh isov2 ) ) . 
-  apply idpath . 
-
+Lemma ll_over_minus_ll_over { T : ltower } { A : T } ( X1 X2 : ltower_over A ):
+  ll X1 - ll X2 = ll ( pocto X1 ) - ll ( pocto X2 ). 
+Proof.
+  destruct X1 as [ X1 isov1 ].
+  destruct X2 as [ X2 isov2 ]. 
+  unfold ll. 
+  simpl. 
+  unfold ltower_over_ll.
+  simpl. 
+  change ( ( ll X1 - ll A ) - ( ll X2 - ll A ) = ( ll X1 - ll X2 ) ). 
+  rewrite natminusassoc. 
+  rewrite natpluscomm. 
+  rewrite ( minusplusnmm _ _ ( isover_geh isov2 ) ). 
+  apply idpath. 
 Defined.
 
 
-Definition isovmonot_pocto { T : ltower } ( A : T ) { X Y : ltower_over A } ( isov : isover X Y ) :
-isover ( pocto X ) ( pocto Y ) .  
-Proof .
-  destruct X as [ X isovX ] .
-  destruct Y as [ Y isovY ] .
-  simpl . 
-  assert ( int := maponpaths pr1 isov ) . 
-  simpl in int .
-  rewrite ltower_over_ftn in int . 
-  simpl in int . 
-  rewrite ll_over_minus_ll_over in int . 
-  simpl in int . 
-  exact int . 
-
-  exact ( natminuslehn _ _ ) . 
-
+Definition isovmonot_pocto { T : ltower } ( A : T ) { X Y : ltower_over A } ( isov : isover X Y ):
+isover ( pocto X ) ( pocto Y ).  
+Proof.
+  destruct X as [ X isovX ].
+  destruct Y as [ Y isovY ].
+  simpl. 
+  set ( int := maponpaths pr1 isov ). 
+  simpl in int.
+  rewrite ltower_over_ftn in int. 
+  - simpl in int. 
+    rewrite ll_over_minus_ll_over in int. 
+    simpl in int. 
+    exact int. 
+  - use natminuslehn.
 Defined.
 
 
-
-Lemma isllmonot_pocto { T : ltower } { A : T } : isllmonot ( @pocto T A ) . 
-Proof .
-  unfold isllmonot .
-  intros X Y .
-  apply ( ! ( ll_over_minus_ll_over X Y ) ) .
-
+Lemma isllmonot_pocto { T : ltower } { A : T }: isllmonot ( @pocto T A ). 
+Proof.
+  unfold isllmonot.
+  intros X Y.
+  apply ( ! ( ll_over_minus_ll_over X Y ) ).
 Defined.
 
 
 (** **** The projection pocto and ft *)
 
-Lemma ft_pocto { T : ltower } { A : T } { X : ltower_over A } ( gt0 : ll X > 0 ) :
-  ft ( pocto X ) = pocto ( ft X ) .
+Lemma ft_pocto { T : ltower } { A : T } { X : ltower_over A } ( gt0 : ll X > 0 ):
+  ft ( pocto X ) = pocto ( ft X ).
 Proof.
-  change ( ft X ) with ( ltower_over_ft X ) . 
-  unfold ltower_over_ft .
-  destruct (isover_choice (isov_isov X)) as [ isov | eq ] . 
-  simpl . 
-  apply idpath . 
-
-  assert ( absd : empty ) . 
-  assert ( eq0 : ll X = 0 ) .  change _ with ( ll ( pr1 X ) - ll A = 0 ) . 
-  rewrite <- eq . 
-  apply natminusnn .
-
-  rewrite eq0 in gt0 . apply ( negnatgthnn _ gt0 ) . 
-
-  destruct absd .
-
+  change ( ft X ) with ( ltower_over_ft X ). 
+  unfold ltower_over_ft.
+  destruct (isover_choice (isov_isov X)) as [ isov | eq ]. 
+  - simpl. 
+    apply idpath. 
+  - apply fromempty. 
+    assert ( eq0 : ll X = 0 ).
+    { change ( ll ( pr1 X ) - ll A = 0 ). 
+      rewrite <- eq. 
+      apply natminusnn.
+    }
+    rewrite eq0 in gt0.
+    apply ( negnatgthnn _ gt0 ). 
 Defined.
-
-
 
   
 (** **** Some functions between over-towers *)
 
-
-Definition to_ltower_over { T : pltower } ( X : T ) : ltower_over ( cntr T ) .
-Proof .
-  exact ( obj_over_constr ( isoverll0 ( ll_cntr T ) X ) ) .
-
+Definition to_ltower_over { T : pltower } ( X : T ): ltower_over ( cntr T ).
+Proof.
+  exact ( obj_over_constr ( isoverll0 ( ll_cntr T ) X ) ).
 Defined.
 
 
-Lemma ll_to_ltower_over { T : pltower } ( X : T ) :
-  ll ( to_ltower_over X ) = ll X .
-Proof .
-  unfold ll . 
-  simpl .
-  unfold ltower_over_ll . 
-  rewrite ll_cntr . 
-  rewrite natminuseqn .
-  apply idpath . 
-
+Lemma ll_to_ltower_over { T : pltower } ( X : T ):
+  ll ( to_ltower_over X ) = ll X.
+Proof.
+  unfold ll. 
+  simpl.
+  unfold ltower_over_ll. 
+  rewrite ll_cntr. 
+  rewrite natminuseqn.
+  apply idpath. 
 Defined.
 
   
-Lemma isllmonot_to_ltower_over ( T : pltower )  :
-  isllmonot ( @to_ltower_over T ) .
-Proof .
-  unfold isllmonot . intros .
-  repeat rewrite ll_to_ltower_over . apply idpath . 
-  
+Lemma isllmonot_to_ltower_over ( T : pltower ):
+  isllmonot ( @to_ltower_over T ).
+Proof.
+  unfold isllmonot.
+  intros.
+  do 2 rewrite ll_to_ltower_over.
+  apply idpath. 
 Defined.
 
 
-Lemma isbased_to_ltower_over ( T : pltower ) :
-  isbased ( @to_ltower_over T ) .
-Proof .
-  unfold isbased. intros X eq0 .
-  rewrite ll_to_ltower_over . 
-  exact eq0 .
-
+Lemma isbased_to_ltower_over ( T : pltower ):
+  isbased ( @to_ltower_over T ).
+Proof.
+  unfold isbased.
+  intros X eq0.
+  rewrite ll_to_ltower_over. 
+  exact eq0.
 Defined.
 
 

--- a/TypeTheory/Csystems/ltowers_over.v
+++ b/TypeTheory/Csystems/ltowers_over.v
@@ -5,7 +5,7 @@ by Vladimir Voevodsky, started on Feb. 3, 2015.
 *)
 
 
-
+Require Import UniMath.Foundations.All.
 Require Import UniMath.Combinatorics.StandardFiniteSets.
 Require Import TypeTheory.Csystems.prelim.
 Require Import TypeTheory.Csystems.lTowers.

--- a/TypeTheory/Csystems/ltowers_over.v
+++ b/TypeTheory/Csystems/ltowers_over.v
@@ -76,7 +76,7 @@ Proof.
   assert ( weq2 : weq ( total2 ( fun X : T => dirprod
                                                 ( isover X A ) ( ll X - ll A = 0 ) ) )
                       ( total2 ( fun X : T => A = X ) ) ) .
-  refine ( weqfibtototal _ _ _ ) . 
+  use weqfibtototal.
   intro X . 
   assert ( weq3 : weq (dirprod (isover X A) (ll X - ll A = 0))
                       (dirprod (ll X - ll A = 0) (isover X A)) ) .
@@ -84,7 +84,7 @@ Proof.
 
   assert ( weq4 : weq (dirprod (ll X - ll A = 0) (isover X A))
                       (dirprod (ll X - ll A = 0) ( A = X ) ) ) .
-  refine ( weqfibtototal _ _ _ ) . 
+  use weqfibtototal.
   intro eq . 
   unfold isover . 
   rewrite eq . 
@@ -197,7 +197,7 @@ Proof .
          rewrite natminusnn in ge .
          destruct (nopathsfalsetotrue ge).
     -  rewrite int . 
-       refine ( IHn ( ft X ) _ ) . 
+       use ( IHn ( ft X ) ) . 
        apply ( ll_ft_gtn ge ) . 
 Defined.
 

--- a/TypeTheory/Csystems/ltowers_over.v
+++ b/TypeTheory/Csystems/ltowers_over.v
@@ -67,34 +67,32 @@ Lemma ispointed_ltower_over_int { T : ltower } ( A : T ) :
   iscontr ( ∑ X : ltower_over_carrier A ,
                        ltower_over_ll X = 0 ) .
 Proof.
-  assert ( weq1 : weq ( total2 ( fun X : ltower_over_carrier A =>
-                                   ltower_over_ll X = 0 ) )
-                      ( total2 ( fun X : T => dirprod
-                                                ( isover X A ) ( ll X - ll A = 0 ) ) ) ) .
+  assert ( weq1 : ( ∑ X : ltower_over_carrier A,
+                                   ltower_over_ll X = 0 ) ≃
+                      ( ∑ X : T, ( isover X A ) × ( ll X - ll A = 0 ) ) ).
   apply weqtotal2asstor . 
 
-  assert ( weq2 : weq ( total2 ( fun X : T => dirprod
-                                                ( isover X A ) ( ll X - ll A = 0 ) ) )
-                      ( total2 ( fun X : T => A = X ) ) ) .
+  assert ( weq2 : ( ∑ X : T,  ( isover X A ) × ( ll X - ll A = 0 ) ) ≃
+                      ( ∑ X : T, A = X ) ).
   use weqfibtototal.
   intro X . 
-  assert ( weq3 : weq (dirprod (isover X A) (ll X - ll A = 0))
-                      (dirprod (ll X - ll A = 0) (isover X A)) ) .
+  assert ( weq3 : ((isover X A) × (ll X - ll A = 0)) ≃
+                      ((ll X - ll A = 0) × (isover X A)) ) .
   apply weqdirprodcomm . 
 
-  assert ( weq4 : weq (dirprod (ll X - ll A = 0) (isover X A))
-                      (dirprod (ll X - ll A = 0) ( A = X ) ) ) .
+  assert ( weq4 :  ((ll X - ll A = 0) × (isover X A)) ≃
+                      ((ll X - ll A = 0) × ( A = X ) ) ) .
   use weqfibtototal.
   intro eq . 
   unfold isover . 
   rewrite eq . 
   apply idweq.
 
-  assert ( weq5 : weq (dirprod (ll X - ll A = 0) (A = X))
-                      (dirprod (A = X)(ll X - ll A = 0))).
+  assert ( weq5 :  ((ll X - ll A = 0) × (A = X)) ≃
+                      ( (A = X) × (ll X - ll A = 0))).
   apply weqdirprodcomm . 
 
-  assert ( weq6 : weq (dirprod (A = X) (ll X - ll A = 0))
+  assert ( weq6 :  ((A = X) × (ll X - ll A = 0)) ≃
                       ( A = X ) ) .
   apply weqpr1 . 
   intro eq . 

--- a/TypeTheory/Csystems/ltowers_over.v
+++ b/TypeTheory/Csystems/ltowers_over.v
@@ -6,9 +6,7 @@ by Vladimir Voevodsky, started on Feb. 3, 2015.
 
 
 Require Import UniMath.Foundations.All.
-Require Import UniMath.Combinatorics.StandardFiniteSets.
-Require Import TypeTheory.Csystems.prelim.
-Require Import TypeTheory.Csystems.lTowers.
+Require Export TypeTheory.Csystems.lTowers.
 
 
 

--- a/TypeTheory/Csystems/ltowers_over.v
+++ b/TypeTheory/Csystems/ltowers_over.v
@@ -1,13 +1,14 @@
-(** ** Constructions related to ltowers opver an object  
+(** ** Constructions related to ltowers over an object  
 
 by Vladimir Voevodsky, started on Feb. 3, 2015.
 
 *)
 
-Unset Automatic Introduction.
 
 
-Require Export TypeTheory.Csystems.lTowers.
+Require Import UniMath.Combinatorics.StandardFiniteSets.
+Require Import TypeTheory.Csystems.prelim.
+Require Import TypeTheory.Csystems.lTowers.
 
 
 
@@ -20,7 +21,7 @@ Require Export TypeTheory.Csystems.lTowers.
 
 
 Definition ltower_over_carrier { T : ltower } ( A : T ) :=
-  total2 ( fun X : T => isover X A ) .
+  ∑ X : T, isover X A .
 
 Definition obj_over_constr { T : ltower } { A : T } { X : T } ( isov : isover X A ) :
   ltower_over_carrier A := tpair ( fun X : T => isover X A ) _ isov .
@@ -34,7 +35,6 @@ Definition ltower_over_ll { T : ltower } { A : T } ( X : ltower_over_carrier A )
 Definition ltower_over_ft { T : ltower } { A : T } ( X : ltower_over_carrier A ) :
   ltower_over_carrier A .
 Proof .
-  intros .
   destruct ( isover_choice ( isov_isov X ) ) as [ isov | eq ] .
   exact ( tpair _ ( ft ( pr1 X ) )  isov ) .
 
@@ -45,7 +45,6 @@ Defined.
 Lemma ltower_over_ll_ft_eq { T : ltower } { A : T } ( X : ltower_over_carrier A ) :
   ltower_over_ll ( ltower_over_ft X ) = ltower_over_ll X - 1 .
 Proof .
-  intros . 
   unfold ltower_over_ft . 
   destruct ( isover_choice ( isov_isov X ) ) as [ isov | eq ] .
   unfold ltower_over_ll .  
@@ -67,10 +66,9 @@ Defined.
 
 
 Lemma ispointed_ltower_over_int { T : ltower } ( A : T ) :
-  iscontr ( total2 ( fun X : ltower_over_carrier A =>
-                       ltower_over_ll X = 0 ) ) .
+  iscontr ( ∑ X : ltower_over_carrier A ,
+                       ltower_over_ll X = 0 ) .
 Proof.
-  intros .
   assert ( weq1 : weq ( total2 ( fun X : ltower_over_carrier A =>
                                    ltower_over_ll X = 0 ) )
                       ( total2 ( fun X : T => dirprod
@@ -127,7 +125,6 @@ Lemma ltower_over_ll0_eq { T : ltower } { A : T }
       ( X : ltower_over_carrier A ) ( eq0 : ltower_over_ll X = 0 ) : 
   ltower_over_ft X = X .
 Proof .
-  intros .
   assert ( eq0' : ltower_over_ll ( ltower_over_ft X ) = 0 ) . 
   rewrite ltower_over_ll_ft_eq . 
   rewrite eq0 . 
@@ -182,7 +179,7 @@ Definition ltower_over_to_pltower_over { T : ltower } ( A : T ) ( X : ltower_ove
 Lemma ltower_over_ftn { T : ltower } { A : T } ( n : nat )
       ( X : ltower_over A ) ( ge : ll X >= n ) : pr1 ( ftn n X ) = ftn n ( pr1 X ) .
 Proof .
-  intros T A n . 
+  revert X ge. 
   induction n .
   + intros . 
     apply idpath . 
@@ -214,7 +211,6 @@ Definition X_over_X { T : ltower } ( X : T ) : ltower_over X :=
 
 Lemma ll_X_over_X { T : ltower } ( X : T ) : ll ( X_over_X X ) = 0 .
 Proof.
-  intros .
   change _ with ( ll X - ll X = 0 ) .
   apply natminusnn . 
 
@@ -229,7 +225,6 @@ Definition X_over_ftX { T : ltower } ( X : T ) : ltower_over ( ft X ) :=
 Lemma ll_X_over_ftX { T : ltower } { X : T } ( gt0 : ll X > 0 ) :
   ll ( X_over_ftX X ) = 1 .
 Proof.
-  intros.
   change _ with ( ltower_over_ll (X_over_ftX X) = 1 ) . 
   unfold ltower_over_ll .
   rewrite ll_ft . 
@@ -248,7 +243,6 @@ Defined.
 Lemma ll_over_minus_ll_over { T : ltower } { A : T } ( X1 X2 : ltower_over A ) :
   ll X1 - ll X2 = ll ( pocto X1 ) - ll ( pocto X2 ) . 
 Proof .
-  intros . 
   destruct X1 as [ X1 isov1 ] . destruct X2 as [ X2 isov2 ] . 
   unfold ll . 
   simpl . 
@@ -265,7 +259,6 @@ Defined.
 Definition isovmonot_pocto { T : ltower } ( A : T ) { X Y : ltower_over A } ( isov : isover X Y ) :
 isover ( pocto X ) ( pocto Y ) .  
 Proof .
-  intros . 
   destruct X as [ X isovX ] .
   destruct Y as [ Y isovY ] .
   simpl . 
@@ -285,7 +278,6 @@ Defined.
 
 Lemma isllmonot_pocto { T : ltower } { A : T } : isllmonot ( @pocto T A ) . 
 Proof .
-  intros .
   unfold isllmonot .
   intros X Y .
   apply ( ! ( ll_over_minus_ll_over X Y ) ) .
@@ -298,7 +290,6 @@ Defined.
 Lemma ft_pocto { T : ltower } { A : T } { X : ltower_over A } ( gt0 : ll X > 0 ) :
   ft ( pocto X ) = pocto ( ft X ) .
 Proof.
-  intros . 
   change ( ft X ) with ( ltower_over_ft X ) . 
   unfold ltower_over_ft .
   destruct (isover_choice (isov_isov X)) as [ isov | eq ] . 
@@ -324,7 +315,6 @@ Defined.
 
 Definition to_ltower_over { T : pltower } ( X : T ) : ltower_over ( cntr T ) .
 Proof .
-  intros . 
   exact ( obj_over_constr ( isoverll0 ( ll_cntr T ) X ) ) .
 
 Defined.
@@ -333,7 +323,6 @@ Defined.
 Lemma ll_to_ltower_over { T : pltower } ( X : T ) :
   ll ( to_ltower_over X ) = ll X .
 Proof .
-  intros.
   unfold ll . 
   simpl .
   unfold ltower_over_ll . 
@@ -356,7 +345,6 @@ Defined.
 Lemma isbased_to_ltower_over ( T : pltower ) :
   isbased ( @to_ltower_over T ) .
 Proof .
-  intros . 
   unfold isbased. intros X eq0 .
   rewrite ll_to_ltower_over . 
   exact eq0 .

--- a/TypeTheory/Csystems/prelim.v
+++ b/TypeTheory/Csystems/prelim.v
@@ -3,7 +3,7 @@
 by Vladimir Voevodsky, file created on Jan. 6, 2015 *)
 
 Require Import UniMath.Foundations.All.
-Require Import UniMath.Combinatorics.StandardFiniteSets.
+Require Export UniMath.Combinatorics.StandardFiniteSets.
 
 
 (* To upsetream files *)
@@ -207,7 +207,7 @@ Definition natminusinter { n m k : nat } ( ge1 : n >= m ) ( ge2 : m >= k ):
   n - k = ( n - m ) + ( m - k ).
 Proof.
   assert ( int1 : n - m + (m - k) = n - ( m - ( m - k ) ) ).
-  { refine ( natassocmpeq _ _ _ _ _ ) .
+  { use natassocmpeq.
     - exact ge1 . 
     - exact ( natminuslehn _ _ ). 
   }

--- a/TypeTheory/Csystems/prelim.v
+++ b/TypeTheory/Csystems/prelim.v
@@ -3,304 +3,299 @@
 by Vladimir Voevodsky, file created on Jan. 6, 2015 *)
 
 
-Unset Automatic Introduction.
-
-Require Export UniMath.Combinatorics.StandardFiniteSets.
+Require Import UniMath.Combinatorics.StandardFiniteSets.
 
 
 (* To upsetream files *)
 
 
-Notation isaproptotal2 := ( isofhleveltotal2 1 )  .
+Notation isaproptotal2 := ( isofhleveltotal2 1 ).
 
 
-Lemma gth0_to_geh1 { n : nat } ( gt0 : n > 0 ) : n >= 1 .
+Lemma gth0_to_geh1 { n : nat } ( gt0 : n > 0 ): n >= 1.
 Proof.
-  intros.
   induction n as [ | n IHn ] .
-  assert ( absd : empty ) .
-  apply ( negnatgthnn _ gt0 ) . 
-  destruct absd .
-
-  apply ( natgehn0 n ) . 
-
+  - apply fromempty.
+    apply ( negnatgthnn _ gt0 ). 
+  - apply ( natgehn0 n ). 
 Defined.
 
 
-Lemma geh1_to_gth0 { n : nat } ( geh1 : n >= 1 ) : n > 0 .
+Lemma geh1_to_gth0 { n : nat } ( geh1 : n >= 1 ): n > 0.
 Proof.
-  intros .
-  apply ( natgehgthtrans _ _ _ geh1 ( natgthsnn 0 ) ) .
-
-Defined.
-
-Lemma natminusind ( m n : nat ) : m - S n = ( m - 1 ) - n . 
-Proof . intros .
-        induction m as [ | m IHm ] .  apply idpath . simpl .  rewrite ( natminuseqn m ) . 
-        apply idpath .
+  apply ( natgehgthtrans _ _ _ geh1 ( natgthsnn 0 ) ).
 Defined.
 
 
-
-
-Lemma natgthnnmius1 { n : nat } ( gt : n > 0 ) : n > n - 1 .
+Lemma natminusind ( m n : nat ): m - S n = ( m - 1 ) - n. 
 Proof.
-  intros . induction n as [ | n ] . 
-  induction ( negnatgthnn _ gt ) . 
-
-  change ( S n > n - 0 ) . 
-  rewrite natminuseqn . 
-  exact ( natgthsnn _ ) .
-
+  induction m as [ | m IHm ].
+  - apply idpath.
+  - simpl.
+    rewrite ( natminuseqn m ). 
+    apply idpath.
 Defined.
 
-Lemma natminusnn ( n : nat ) : n - n = 0 .
+
+Lemma natgthnnmius1 { n : nat } ( gt : n > 0 ): n > n - 1.
 Proof.
-  intro . induction n as [ | n IHn ] .
-  exact ( idpath _ ) .
-
-  exact IHn . 
-
+  induction n as [ | n ]. 
+  - induction ( negnatgthnn _ gt ). 
+  - change ( S n > n - 0 ). 
+    rewrite natminuseqn. 
+    exact ( natgthsnn _ ).
 Defined.
 
 
-Lemma natminusmequalsn { m n : nat } ( ge : n >= m ) ( eq0 : n - m = 0 ) : n = m .
-Proof .
-  intro m . induction m as [ | m IHm ] .
-  + intros . 
-
-    rewrite natminuseqn in eq0 . 
-    exact eq0 .
-
-  + intros .
-    induction n as [ | n ] .
-    * destruct (nopathsfalsetotrue ge).
-    * apply ( maponpaths S ) . exact ( IHm n ge eq0 ) . 
-
-Defined.
-
-
-Lemma natmiusmius1mminus1 { n m : nat } ( gt1 : n > 0 ) ( gt2 : m > 0 ) :
-  ( n - 1 ) - ( m - 1 ) = n - m .
-Proof .
-  intro n . induction n as [ | n IHn ] .
-  intros . 
-  destruct ( negnatgthnn _ gt1 ) . 
-
-  intros .
-  simpl . rewrite natminuseqn . induction m as [ | m ] .
-  destruct ( negnatgthnn _ gt2 ) . 
-
-  simpl . rewrite natminuseqn . apply idpath .
-
-Defined.
-
-Lemma natgthtominus1geh { m n : nat } : m > n -> m - 1 >= n .
+Lemma natminusnn ( n : nat ): n - n = 0.
 Proof.
-  intro m . induction m as [ | m IHm ] .
-  + intros n gt . 
-    destruct (nopathsfalsetotrue gt).
-  + intros n gt .
-    change ( m - 0 >= n ) . rewrite ( natminuseqn m ) . apply natgthsntogeh . exact gt .
-  
+  induction n as [ | n IHn ].
+  - exact ( idpath _ ).
+  - exact IHn. 
+Defined.
+
+
+Lemma natminusmequalsn { m n : nat } ( ge : n >= m ) ( eq0 : n - m = 0 ): n = m.
+Proof.
+  revert n ge eq0.
+  induction m as [ | m IHm ]; intros.
+  - rewrite natminuseqn in eq0. 
+    exact eq0.
+  - induction n as [ | n ].
+    + destruct (nopathsfalsetotrue ge).
+    + apply ( maponpaths S ).
+      exact ( IHm n ge eq0 ). 
+Defined.
+
+
+Lemma natmiusmius1mminus1 { n m : nat } ( gt1 : n > 0 ) ( gt2 : m > 0 ):
+  ( n - 1 ) - ( m - 1 ) = n - m.
+Proof.
+  revert m gt1 gt2.
+  induction n as [ | n IHn ]; intros.
+  - destruct ( negnatgthnn _ gt1 ). 
+  - simpl.
+    rewrite natminuseqn.
+    induction m as [ | m ].
+    + destruct ( negnatgthnn _ gt2 ). 
+    + simpl.
+      rewrite natminuseqn.
+      apply idpath.
+Defined.
+
+
+Lemma natgthtominus1geh { m n : nat }: m > n -> m - 1 >= n.
+Proof.
+  induction m as [ | m IHm ]; intros gt.
+  - destruct (nopathsfalsetotrue gt).
+  - change ( m - 0 >= n ).
+    rewrite ( natminuseqn m ).
+    apply natgthsntogeh.
+    exact gt.
+Defined.
+
+
+Lemma natgthminus1togeh { n m : nat }: m > n - 1 -> m >= n.
+Proof.
+  induction n as [ | n IHn ].
+  - intros gt.
+    exact ( natgehn0 _ ).
+  - intros gt.
+    change ( S n - 1 ) with ( n - 0 ) in gt.
+    rewrite ( natminuseqn n ) in gt.
+    apply natgthtogehsn.
+    exact gt.
 Defined .
 
-Lemma natgthminus1togeh { n m : nat } : m > n - 1 -> m >= n .
+
+Lemma nat1plusminusgt { n m : nat } ( gt : 1 + m > n ): ( 1 + m ) - n = 1 + ( m - n ).
 Proof.
-  intro n . induction n as [ | n IHn ] .
-  intros m gt . exact ( natgehn0 _ ) .
-  
-  intros m gt .
-  change ( S n - 1 ) with ( n - 0 ) in gt . rewrite ( natminuseqn n ) in gt .
-  apply natgthtogehsn . exact gt .
-  
-Defined .
-
-Lemma nat1plusminusgt { n m : nat } ( gt : 1 + m > n ) : ( 1 + m ) - n = 1 + ( m - n ) .
-Proof.
-  intros .
-  apply ( natplusrcan _ _ n ) . rewrite ( natplusassoc _ _ n ) .
-  rewrite ( minusplusnmm _ n ( natgthtogeh _ _ gt ) ) .
-  rewrite ( minusplusnmm _ n ) . 
-  apply idpath .
-
-  apply ( natgthsntogeh _ _ gt ) . 
-
+  apply ( natplusrcan _ _ n ).
+  rewrite ( natplusassoc _ _ n ).
+  rewrite ( minusplusnmm _ n ( natgthtogeh _ _ gt ) ).
+  rewrite ( minusplusnmm _ n ). 
+  - apply idpath.
+  - apply ( natgthsntogeh _ _ gt ). 
 Defined.
 
 
-Lemma lB_2014_12_07_l1 { m n : nat } ( gt : m > n ) : m - n = 1 + (( m - 1 ) - n ) .
+Lemma lB_2014_12_07_l1 { m n : nat } ( gt : m > n ): m - n = 1 + (( m - 1 ) - n ).
 Proof.
-  intros. induction m as [ | m IHm ] .
-
-  + destruct (nopathsfalsetotrue gt).
-
-  + clear IHm. change ( S m - n = S ( m - 0 - n ) ) . rewrite  ( natminuseqn m ) . 
-  exact ( nat1plusminusgt gt ) .
+  induction m as [ | m IHm ].
+  - destruct (nopathsfalsetotrue gt).
+  - clear IHm.
+    change ( S m - n = S ( m - 0 - n ) ).
+    rewrite  ( natminuseqn m ). 
+    exact ( nat1plusminusgt gt ).
 Defined.
 
 
-Lemma natminusmmk { m k : nat } ( ge : m >= k ) : m - ( m - k ) = k .
+Lemma natminusmmk { m k : nat } ( ge : m >= k ): m - ( m - k ) = k.
 Proof.
-  intros .
-  apply ( natplusrcan _ _ ( m - k ) ) .
-  rewrite minusplusnmm . 
-  rewrite natpluscomm . 
-  rewrite minusplusnmm .
-  apply idpath . 
-
-  apply ge . 
-
-  apply natminuslehn. 
-
+  apply ( natplusrcan _ _ ( m - k ) ).
+  rewrite minusplusnmm. 
+  - rewrite natpluscomm. 
+    rewrite minusplusnmm.
+    + apply idpath. 
+    + apply ge. 
+  - apply natminuslehn. 
 Defined.
 
- 
-  
-Lemma natleftplustorightminus ( n m k : nat ) : n + m = k -> n = k - m .
-Proof.
-  intros n m k e .
-  assert ( ge : k >= m ) . rewrite <- e . exact ( natgehplusnmm _ _ ) .  
 
-  apply ( natplusrcan _ _ m ) . rewrite ( minusplusnmm _ _ ge ) . 
+Lemma natleftplustorightminus ( n m k : nat ): n + m = k -> n = k - m.
+Proof.
+  intro e.
+  assert ( ge : k >= m ).
+  { rewrite <- e .
+    exact ( natgehplusnmm _ _ ). }  
+  apply ( natplusrcan _ _ m ).
+  rewrite ( minusplusnmm _ _ ge ). 
   exact e .
-
 Defined.
 
 
-
-
-Definition natassocpmeq ( n m k : nat ) ( ge : m >= k ) : ( n + m ) - k =  n + ( m - k ) .
+Definition natassocpmeq ( n m k : nat ) ( ge : m >= k ): ( n + m ) - k =  n + ( m - k ).
 Proof.
-  intros.  apply ( natplusrcan _ _ k ) . rewrite ( natplusassoc n _ k ) .
-  rewrite ( minusplusnmm _ k ge ) .
-  set ( ge' := istransnatgeh _ _ _ ( natgehplusnmm n m ) ge ) .
-  rewrite ( minusplusnmm _ k ge' ) . apply idpath.
-  
-Defined.
-
-Definition natassocmpeq ( n m k : nat ) ( isnm : n >= m ) ( ismk : m >= k ) :
-  ( n - m ) + k = n - ( m - k ) .
-Proof. intros.  apply ( natplusrcan _ _ ( m - k ) ) . 
-       assert ( is' : natleh ( m - k ) n ) .
-       apply ( istransnatleh (natminuslehn _ _ ) isnm ) .
-       rewrite ( minusplusnmm _ _ is' ) . rewrite (natplusassoc _ k _ ) .
-       rewrite ( natpluscomm k _ ) . rewrite ( minusplusnmm _ _ ismk ) .
-       rewrite ( minusplusnmm _ _ isnm ) . apply idpath.
+  apply ( natplusrcan _ _ k ).
+  rewrite ( natplusassoc n _ k ).
+  rewrite ( minusplusnmm _ k ge ).
+  set ( ge' := istransnatgeh _ _ _ ( natgehplusnmm n m ) ge ).
+  rewrite ( minusplusnmm _ k ge' ).
+  apply idpath.
 Defined.
 
 
-Definition natminusassoc ( n m k : nat ) : ( n  - m ) - k = n - ( m + k ) .
-Proof. intros n m . revert n . 
-
-       induction m as [ | m IHm ] .  intros  . simpl .  rewrite ( natminuseqn n ) . apply idpath .
-       intros .  rewrite ( natminusind n m ) .  rewrite ( IHm ( n - 1 ) k ) .
-       rewrite ( ! ( natminusind _ _ ) ) .  apply idpath . 
-Defined.
-
-
-Definition natminuscomm ( n m k : nat ) : ( n - m ) - k = ( n - k ) - m .
-Proof .
-  intros .
-  rewrite natminusassoc . 
-  rewrite natminusassoc . 
-  rewrite natpluscomm . 
-  apply idpath .
-
-Defined.
- 
-
-
-
-Definition natminusinter { n m k : nat } ( ge1 : n >= m ) ( ge2 : m >= k ) :
-  n - k = ( n - m ) + ( m - k ) .
+Definition natassocmpeq ( n m k : nat ) ( isnm : n >= m ) ( ismk : m >= k ):
+  ( n - m ) + k = n - ( m - k ).
 Proof.
-  intros .
-  assert ( int1 : n - m + (m - k) = n - ( m - ( m - k ))).   refine ( natassocmpeq _ _ _ _ _ ) . 
-  exact ge1 . 
+  apply ( natplusrcan _ _ ( m - k ) ). 
+  assert ( is' : ( m - k ) <= n ) by
+      apply ( istransnatleh (natminuslehn _ _ ) isnm ).
+  rewrite ( minusplusnmm _ _ is' ).
+  rewrite (natplusassoc _ k _ ).
+  rewrite ( natpluscomm k _ ).
+  rewrite ( minusplusnmm _ _ ismk ).
+  rewrite ( minusplusnmm _ _ isnm ).
+  apply idpath.
+Defined.
 
-  exact ( natminuslehn _ _ ) . 
 
-  assert ( int2 : m - ( m - k ) = k ) . exact ( natminusmmk ge2 ) .
+Definition natminusassoc ( n m k : nat ): ( n  - m ) - k = n - ( m + k ).
+Proof.
+  revert n. 
+  induction m as [ | m IHm ]; intros.
+  - simpl.
+    rewrite ( natminuseqn n ).
+    apply idpath.
+  - rewrite ( natminusind n m ).
+    rewrite ( IHm ( n - 1 ) ).
+    rewrite ( ! ( natminusind _ _ ) ).
+    apply idpath. 
+Defined.
 
-  rewrite int2 in int1 . exact ( ! int1 ) . 
+
+Definition natminuscomm ( n m k : nat ): ( n - m ) - k = ( n - k ) - m.
+Proof.
+  rewrite natminusassoc. 
+  rewrite natminusassoc. 
+  rewrite natpluscomm. 
+  apply idpath.
+Defined.
+
+
+Definition natminusinter { n m k : nat } ( ge1 : n >= m ) ( ge2 : m >= k ):
+  n - k = ( n - m ) + ( m - k ).
+Proof.
+  assert ( int1 : n - m + (m - k) = n - ( m - ( m - k ) ) ).
+  { refine ( natassocmpeq _ _ _ _ _ ) .
+    - exact ge1 . 
+    - exact ( natminuslehn _ _ ). 
+  }
+  assert ( int2 : m - ( m - k ) = k ) by exact ( natminusmmk ge2 ).
+  rewrite int2 in int1.
+  exact ( ! int1 ). 
 Defined.
 
 
 (** [ nateq ] *)
 
-Notation nateqandplusrinv := natplusrcan .
+Notation nateqandplusrinv := natplusrcan.
 
-Notation nateqandpluslinv := natpluslcan .
+Notation nateqandpluslinv := natpluslcan.
 
-Definition nateqandplusr ( n m k : nat ) : n = m -> n + k = m + k :=
-  maponpaths ( fun x => x + k ) .
+Definition nateqandplusr ( n m k : nat ): n = m -> n + k = m + k :=
+  maponpaths ( fun x => x + k ).
 
-Definition nateqandplusl ( n m k : nat ) : n = m -> k + n = k + m :=
-  maponpaths ( fun x => k + x ) .
+Definition nateqandplusl ( n m k : nat ): n = m -> k + n = k + m :=
+  maponpaths ( fun x => k + x ).
 
 
 
 
 (** **** Cancellation properties of minus on nat *)
 
-Lemma natminusrcan { n m k : nat } ( ge1 : n >= k ) ( ge2 : m >= k ) ( is : n - k = m - k ) :
-  n = m .
-Proof .
-  intros .
-  assert ( is' := nateqandplusr _ _ k is ) .
-  rewrite ( minusplusnmm _ _ ge1 ) in is' .
-  rewrite ( minusplusnmm _ _ ge2 ) in is' .
-  exact is' .
-
+Lemma natminusrcan { n m k : nat } ( ge1 : n >= k ) ( ge2 : m >= k ) ( is : n - k = m - k ):
+  n = m.
+Proof.
+  assert ( is' := nateqandplusr _ _ k is ).
+  rewrite ( minusplusnmm _ _ ge1 ) in is'.
+  rewrite ( minusplusnmm _ _ ge2 ) in is'.
+  exact is'.
 Defined.
-
-
-
   
 
 (* **** Greater and minus *)
 
 
-Definition natgthrightminus ( n m k : nat ) ( ge : k >= m ) : n + m > k -> n > k - m .
-Proof . intros n m k ge gt . apply ( natgthandplusrinv _ _ m ) .
-        rewrite ( minusplusnmm _ _ ge ) .
-        exact gt .
-Defined.
-
-Definition natgthrightplus ( n m k : nat ) : n - m > k -> n > k + m .
-Proof .
-  intros n m k gt . assert ( ge : n >= m ) . apply natgthtogeh .
-  
-  apply minusgth0inv .  apply ( natgthgehtrans _ _ _ gt ( natgehn0 k ) ) .
-  assert ( gt' : ( n - m ) + m > k + m ) . apply ( natgthandplusr _ _ _ gt ) .
-  
-  rewrite ( minusplusnmm _ _ ge ) in gt' . exact gt' .
-Defined.
-  
-Definition natgthleftminus ( n m k : nat ) : n > m + k -> n - k > m .
+Definition natgthrightminus ( n m k : nat ) ( ge : k >= m ): n + m > k -> n > k - m.
 Proof.
-  intros n m k gt .  apply ( natgthandplusrinv _ _ k ) .
-  assert ( ge' : n >= k ) . apply natgthtogeh .
-  exact ( natgthgehtrans _ _ _ gt ( natgehplusnmm _ _ ) ) .
-  
-  rewrite ( minusplusnmm _ _ ge' ) . 
-  exact gt .
+  intro gt.
+  apply ( natgthandplusrinv _ _ m ).
+  rewrite ( minusplusnmm _ _ ge ).
+  exact gt.
 Defined.
 
 
-Definition natgthleftplus ( n m k : nat ) : n > m - k -> n + k > m .
-Proof .
-  intros n m k gt .
-  assert ( gt' : n + k > m - k + k ) .  exact ( natgthandplusr _ _ k gt ) . 
-  exact ( natgthgehtrans _ _ _ gt' ( minusplusnmmineq _ _ ) ) . 
-Defined .
+Definition natgthrightplus ( n m k : nat ): n - m > k -> n > k + m.
+Proof.
+  intro gt.
+  assert ( ge : n >= m ).
+  { apply natgthtogeh.
+    apply minusgth0inv.
+    apply ( natgthgehtrans _ _ _ gt ( natgehn0 k ) ).
+  }
+  assert ( gt' : ( n - m ) + m > k + m ) by apply ( natgthandplusr _ _ _ gt ).
+  rewrite ( minusplusnmm _ _ ge ) in gt'.
+  exact gt'.
+Defined.
 
-Definition natgthleftminusminus ( n m k : nat ) : n - m > k -> n - k > m .
-Proof .
-  intros n m k gt . assert ( gt' : n > k + m ) . exact ( natgthrightplus _ _ _ gt ) .
 
-  rewrite ( natpluscomm _ _ ) in gt' . exact ( natgthleftminus _ _ _ gt' ) . 
+Definition natgthleftminus ( n m k : nat ): n > m + k -> n - k > m.
+Proof.
+  intro gt.
+  apply ( natgthandplusrinv _ _ k ).
+  assert ( ge' : n >= k ).
+  { apply natgthtogeh.
+    exact ( natgthgehtrans _ _ _ gt ( natgehplusnmm _ _ ) ).
+  }  
+  rewrite ( minusplusnmm _ _ ge' ). 
+  exact gt.
+Defined.
+
+
+Definition natgthleftplus ( n m k : nat ): n > m - k -> n + k > m.
+Proof .
+  intros gt.
+  assert ( gt' : n + k > m - k + k ) by exact ( natgthandplusr _ _ k gt ). 
+  exact ( natgthgehtrans _ _ _ gt' ( minusplusnmmineq _ _ ) ). 
+Defined.
+
+Definition natgthleftminusminus ( n m k : nat ): n - m > k -> n - k > m.
+Proof.
+  intro gt.
+  assert ( gt' : n > k + m ) by exact ( natgthrightplus _ _ _ gt ).
+  rewrite ( natpluscomm _ _ ) in gt'.
+  exact ( natgthleftminus _ _ _ gt' ). 
 Defined.
 
 
@@ -308,106 +303,107 @@ Defined.
 
 (* **** Greater or equal and minus *)
 
-Definition natgehrightminus ( n m k : nat ) ( ge : k >= m ) : n + m >= k -> n >= k - m .
+Definition natgehrightminus ( n m k : nat ) ( ge : k >= m ): n + m >= k -> n >= k - m.
 Proof.
-  intros n m k ge ge' . apply ( natgehandplusrinv _ _ m ) .  rewrite ( minusplusnmm _ _ ge ) .
-  exact ge' .
+  intro ge'.
+  apply ( natgehandplusrinv _ _ m ).
+  rewrite ( minusplusnmm _ _ ge ).
+  exact ge'.
 Defined.
 
 
-Definition natgehrightplus ( n m k : nat ) ( ge : n >= m ) : n - m >= k -> n >= k + m .
+Definition natgehrightplus ( n m k : nat ) ( ge : n >= m ): n - m >= k -> n >= k + m.
 Proof.
-  intros n m k ge ge' .  rewrite ( ! minusplusnmm _ _ ge ) .  apply ( natgehandplusr _ _ _ ) . 
-  exact ge' .
+  intro ge'.
+  rewrite ( ! minusplusnmm _ _ ge ).
+  apply ( natgehandplusr _ _ _ ). 
+  exact ge'.
 Defined.
 
-Definition natgehleftminus ( n m k : nat ) : n >= m + k ->  n - k >= m .
+
+Definition natgehleftminus ( n m k : nat ): n >= m + k ->  n - k >= m.
 Proof.
-  intros n m k ge .  apply ( natgehandplusrinv _ _ k ) .
-  assert ( ge' : n >= k ) . exact ( istransnatgeh _ _ _ ge ( natgehplusnmm _ _ ) ) .
-  rewrite ( minusplusnmm _ _ ge' ) . 
-  exact ge .
+  intro ge.
+  apply ( natgehandplusrinv _ _ k ).
+  assert ( ge' : n >= k ) by exact ( istransnatgeh _ _ _ ge ( natgehplusnmm _ _ ) ).
+  rewrite ( minusplusnmm _ _ ge' ). 
+  exact ge.
 Defined.
 
-Definition natgehleftplus ( n m k : nat ) : n >= m - k -> n + k  >= m .
+
+Definition natgehleftplus ( n m k : nat ): n >= m - k -> n + k  >= m.
 Proof.
-  intros n m k ge .
-  assert ( ge' : n + k >= m - k + k ) .  exact ( natgehandplusr _ _ k ge ) . 
-  exact ( istransnatgeh _ _ _ ge' ( minusplusnmmineq _ _ ) ) . 
+  intros ge.
+  assert ( ge' : n + k >= m - k + k ) by exact ( natgehandplusr _ _ k ge ). 
+  exact ( istransnatgeh _ _ _ ge' ( minusplusnmmineq _ _ ) ). 
 Defined .
 
-Definition natgehleftminusminus ( n m k : nat ) ( ge : n >= m ) : n - m >= k -> n - k >= m .
-Proof .
-  intros n m k ge ge' . assert ( ge'' : n >= k + m ) . exact ( natgehrightplus _ _ _ ge ge' ) .
 
-  rewrite ( natpluscomm _ _ ) in ge'' . exact ( natgehleftminus _ _ _ ge'' ) . 
+Definition natgehleftminusminus ( n m k : nat ) ( ge : n >= m ): n - m >= k -> n - k >= m.
+Proof .
+  intros ge'.
+  assert ( ge'' : n >= k + m ) by exact ( natgehrightplus _ _ _ ge ge' ).
+  rewrite ( natpluscomm _ _ ) in ge''.
+  exact ( natgehleftminus _ _ _ ge'' ). 
 Defined.
 
 
 (* Two-sided minus and greater *)
 
-Definition natgthandminusinvr { n m k : nat } ( is : n > m ) ( is' : m >= k ) :
-  n - k > m - k .
-Proof .
-  intro n. induction n as [ | n IHn ] .
-  intros . destruct ( negnatgth0n _ is ) .
-  
-  intro m . induction k as [ | k ] . intros .
-  repeat rewrite natminuseqn .
-  exact is .
-
-  intros . induction m as [ | m ] .
-  destruct ( negnatgeh0sn _ is' ) .
-
-  exact ( IHn m k is is' ) .
-
+Definition natgthandminusinvr { n m k : nat } ( is : n > m ) ( is' : m >= k ):
+  n - k > m - k.
+Proof.
+  revert m k is is'.
+  induction n as [ | n IHn ].
+  - intros.
+    destruct ( negnatgth0n _ is ).
+  - intro m.
+    induction k as [ | k ]; intros.
+    + do 2 rewrite natminuseqn.
+      exact is.
+    + induction m as [ | m ].
+      * destruct ( negnatgeh0sn _ is' ).
+      * exact ( IHn m k is is' ).
 Defined.
-
-
-
 
 
 (* Two-sided minus and greater or equal *) 
 
-Definition natgehandminusl ( n m k : nat ) ( ge : n >= m ) : k - m >= k - n .
+Definition natgehandminusl ( n m k : nat ) ( ge : n >= m ): k - m >= k - n.
 Proof.
-  intro n. induction n as [ | n IHn ] .
-  intros .  rewrite ( nat0gehtois0 _ ge ) . apply isreflnatleh .
-
-  intro m . induction m as [ | m ] . intros . induction k as [ | k ] .
-  apply natminuslehn .
-
-  apply natminuslehn .
-
-  intro k . induction k as [ | k ] . intro is .
-  apply isreflnatleh .
-
-  intro is .  apply ( IHn m k ) . apply is .
-
+  revert m k ge.
+  induction n as [ | n IHn ].
+  - intros.
+    rewrite ( nat0gehtois0 _ ge ).
+    apply isreflnatleh.
+  - induction m as [ | m ] .
+    + intros.
+      induction k as [ | k ].
+      * apply natminuslehn.
+      * apply natminuslehn.
+    + induction k as [ | k ]; intro is.
+      * apply isreflnatleh.
+      * apply ( IHn m k ).
+        apply is.
 Defined.
 
 
-Definition natgthandminuslinv { n m k : nat } ( gt : n - k > n - m ) : m > k .
-Proof .
-  intros .
-  apply negnatlehtogth . 
-  intro ge . 
-  assert ( ge' : n - m >= n - k ) by
-  exact ( natgehandminusl _ _ _ ge ) .
-
-  exact (natgthnegleh gt ge') . 
-
+Definition natgthandminuslinv { n m k : nat } ( gt : n - k > n - m ): m > k.
+Proof.
+  apply negnatlehtogth. 
+  intro ge. 
+  assert ( ge' : n - m >= n - k ) by exact ( natgehandminusl _ _ _ ge ).
+  exact (natgthnegleh gt ge'). 
 Defined.
-
   
 
 (* Decrement function on nat *)
 
-Definition dec ( n : nat ) : nat :=
+Definition dec ( n : nat ): nat :=
   match n with
       O => O |
     S n' => n'
-  end .
+  end.
 
 
 (* End of the file lBsystems_prelim.v *)

--- a/TypeTheory/Csystems/prelim.v
+++ b/TypeTheory/Csystems/prelim.v
@@ -2,7 +2,7 @@
 
 by Vladimir Voevodsky, file created on Jan. 6, 2015 *)
 
-
+Require Import UniMath.Foundations.All.
 Require Import UniMath.Combinatorics.StandardFiniteSets.
 
 

--- a/TypeTheory/Csystems/prelim.v
+++ b/TypeTheory/Csystems/prelim.v
@@ -86,7 +86,7 @@ Defined.
 
 Lemma natgthtominus1geh { m n : nat }: m > n -> m - 1 >= n.
 Proof.
-  induction m as [ | m IHm ]; intros gt.
+  induction m as [ | m IHm ]; intro gt.
   - destruct (nopathsfalsetotrue gt).
   - change ( m - 0 >= n ).
     rewrite ( natminuseqn m ).
@@ -98,9 +98,9 @@ Defined.
 Lemma natgthminus1togeh { n m : nat }: m > n - 1 -> m >= n.
 Proof.
   induction n as [ | n IHn ].
-  - intros gt.
+  - intro gt.
     exact ( natgehn0 _ ).
-  - intros gt.
+  - intro gt.
     change ( S n - 1 ) with ( n - 0 ) in gt.
     rewrite ( natminuseqn n ) in gt.
     apply natgthtogehsn.
@@ -285,7 +285,7 @@ Defined.
 
 Definition natgthleftplus ( n m k : nat ): n > m - k -> n + k > m.
 Proof .
-  intros gt.
+  intro gt.
   assert ( gt' : n + k > m - k + k ) by exact ( natgthandplusr _ _ k gt ). 
   exact ( natgthgehtrans _ _ _ gt' ( minusplusnmmineq _ _ ) ). 
 Defined.
@@ -333,7 +333,7 @@ Defined.
 
 Definition natgehleftplus ( n m k : nat ): n >= m - k -> n + k  >= m.
 Proof.
-  intros ge.
+  intro ge.
   assert ( ge' : n + k >= m - k + k ) by exact ( natgehandplusr _ _ k ge ). 
   exact ( istransnatgeh _ _ _ ge' ( minusplusnmmineq _ _ ) ). 
 Defined .
@@ -341,7 +341,7 @@ Defined .
 
 Definition natgehleftminusminus ( n m k : nat ) ( ge : n >= m ): n - m >= k -> n - k >= m.
 Proof .
-  intros ge'.
+  intro ge'.
   assert ( ge'' : n >= k + m ) by exact ( natgehrightplus _ _ _ ge ge' ).
   rewrite ( natpluscomm _ _ ) in ge''.
   exact ( natgehleftminus _ _ _ ge'' ). 


### PR DESCRIPTION
THIS IS NO PULL REQUEST since the code is not working fine. It is rather a request for help.

Proof General makes a lot of trouble with warnings - PG does not easily go beyond a warning.
There are in particular warnings about notation, starting with the first import statement in prelim.v
Warning: Notation _ ≠ _ was already used in scope nat_scope.
[notation-overridden,parsing]
I then replaced the Require Export by Require Import to have more control since, at some point, the warnings became errors.
I spare you the details if there is a solution to the very first problem that may even make disappear the others.
In any case, the code for B systems imports part of the C-system code, and I did not repair compilation for the B systems that are affected by the lacking export statements.
