### PR TITLE
Make the library compile again

### DIFF
--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
@@ -178,16 +178,11 @@ Definition term_fun_data : precategory_data
 
 Definition term_fun_axioms : is_precategory term_fun_data.
 Proof.
-  repeat apply tpair.
-  - intros. apply isaprop_term_fun_mor.
-  - intros. apply isaprop_term_fun_mor.
-  - intros. apply isaprop_term_fun_mor.
+  use mk_is_precategory_one_assoc; intros; apply isaprop_term_fun_mor.
 Qed.
-
 
 Definition term_fun_precategory : precategory 
   := (_ ,, term_fun_axioms).
-
 
 Lemma has_homsets_term_fun_precat 
   : has_homsets term_fun_precategory.
@@ -276,8 +271,8 @@ Definition strucs_compat_data : precategory_data
 
 Definition strucs_compat_axioms : is_precategory strucs_compat_data.
 Proof.
-  repeat apply tpair; intros.
-  - apply dirprodeq;    apply id_left.
+  use mk_is_precategory_one_assoc; intros.
+  - apply dirprodeq; apply id_left.
   - apply dirprodeq; apply id_right.
   - apply dirprodeq; apply assoc.
 Qed.

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Cats.v
@@ -83,7 +83,7 @@ Proof.
     intros Γ; apply funextsec; intros A.
     apply e_TY.
   apply funextsec; intros Γ; apply funextsec; intros A.
-  use total2_paths_f. Focus 2. apply homset_property.
+  use total2_paths_f; [| apply homset_property].
   use (_ @ e_comp Γ A).
   etrans.
     apply maponpaths.
@@ -141,19 +141,21 @@ Definition obj_ext_precat_data : precategory_data
 
 Definition obj_ext_precat_axioms : is_precategory obj_ext_precat_data.
 Proof.
-  repeat apply tpair.
-  - intros X X' F. use obj_ext_mor_eq.
-      intros Γ A; apply idpath.
+  use mk_is_precategory_one_assoc.
+  - intros X X' F.
+    use obj_ext_mor_eq; [ intros Γ A; apply idpath|].
+    intros Γ A.
+    rewrite id_right.
+    apply id_left.
+  - intros X X' F.
+    use obj_ext_mor_eq; [ intros Γ A; apply idpath |].
     intros Γ A; cbn.
-    etrans. apply id_right. apply id_left.
-  - intros X X' F. use obj_ext_mor_eq.
-      intros Γ A; apply idpath.
+    rewrite id_right.
+    apply id_right.
+  - intros X0 X1 X2 X3 F G H.
+    use obj_ext_mor_eq; [ intros Γ A; apply idpath |].
     intros Γ A; cbn.
-    etrans. apply id_right. apply id_right.
-  - intros X0 X1 X2 X3 F G H. use obj_ext_mor_eq.
-      intros Γ A; apply idpath.
-    intros Γ A; cbn.
-    etrans. apply id_right.
+    rewrite id_right.
     apply assoc.
 Qed.
 
@@ -263,11 +265,11 @@ Proof.
   apply (pullback_HSET_elements_unique Pb); clear Pb.
   - unfold yoneda_morphisms_data; cbn.
     etrans. use (pr2 (term_to_section t')). apply pathsinv0.
-    etrans. Focus 2. use (pr2 (term_to_section t)).
+    etrans; [| use (pr2 (term_to_section t))].
     etrans. apply @pathsinv0, assoc.
     etrans. apply @pathsinv0, assoc.
     apply maponpaths.
-    etrans. Focus 2. apply @obj_ext_mor_ax.
+    etrans; [|apply @obj_ext_mor_ax].
     apply maponpaths. 
     apply comp_ext_compare_π.
   - etrans. apply term_to_section_recover. apply pathsinv0.
@@ -343,20 +345,17 @@ Definition term_fun_data : disp_cat_data (obj_ext_Precat C)
 Definition term_fun_axioms : disp_cat_axioms _ term_fun_data.
 Proof.
   repeat apply tpair.
-  - intros. apply term_fun_mor_eq. intros.
-    etrans. Focus 2. apply @pathsinv0, term_fun_mor_transportf.
-    apply idpath.
-  - intros. apply term_fun_mor_eq. intros.
-    etrans. Focus 2. apply @pathsinv0, term_fun_mor_transportf.
-    apply idpath.
-  - intros. apply term_fun_mor_eq. intros.
-    etrans. Focus 2. apply @pathsinv0, term_fun_mor_transportf.
-    apply idpath.
-  - intros. apply isaset_total2.
-    apply homset_property.
-    intros. apply isasetaprop, isapropdirprod.
-    apply homset_property.
-    repeat (apply impred_isaprop; intro). apply setproperty.
+  - intros. apply term_fun_mor_eq. intros; cbn.
+    apply pathsinv0, term_fun_mor_transportf.
+  - intros. apply term_fun_mor_eq. intros; cbn.
+    apply pathsinv0, term_fun_mor_transportf.
+  - intros. apply term_fun_mor_eq. intros; simpl.
+    apply pathsinv0, term_fun_mor_transportf.
+  - intros. apply isaset_total2; [ apply homset_property|].
+    intros.
+    apply isasetaprop, isapropdirprod.
+    + apply homset_property.
+    + repeat (apply impred_isaprop; intro). apply setproperty.
 Qed.
 
 Definition term_fun_disp_cat : disp_cat (obj_ext_Precat C)
@@ -413,10 +412,10 @@ Proof.
     etrans. apply @pathsinv0, assoc.
     etrans. apply maponpaths, GG.
     etrans. apply @pathsinv0, assoc.
-    etrans. Focus 2. etrans; apply assoc.
+    etrans; [| etrans; apply assoc].
     apply maponpaths.
     etrans. apply assoc.
-    etrans. Focus 2. apply @pathsinv0, assoc.
+    etrans; [| apply @pathsinv0, assoc].
     apply maponpaths_2.
     etrans. apply assoc.
     etrans. apply maponpaths_2, Δ_φ.

--- a/TypeTheory/Categories/category_FAM.v
+++ b/TypeTheory/Categories/category_FAM.v
@@ -192,7 +192,7 @@ Defined.
 
 Lemma is_precategory_FAM : is_precategory FAM_precategory_data.
 Proof.
-  repeat split; intros; simpl.
+  use mk_is_precategory_one_assoc; intros; simpl.
   - apply (invmap (FAM_mor_equiv _ _ )). 
     exists (fun _ => idpath _ ).
     intros; apply id_left.
@@ -550,8 +550,7 @@ Proof.
   apply FAM_obj_weq_3_id.
   apply FAM_obj_weq_4_id.
   apply eq_iso, FAM_obj_weq_5_id.
-Admitted.
-(* TODO: can we improve efficiency here? *)
+Qed.
 
 Theorem FAM_is_univalent : is_univalent C -> is_univalent FAM.
 Proof.

--- a/TypeTheory/Categories/category_of_elements.v
+++ b/TypeTheory/Categories/category_of_elements.v
@@ -48,8 +48,7 @@ Defined.
   
 Lemma is_precategory_precategory_of_elements : is_precategory precategory_of_elements_data.
 Proof.
-  repeat split; intros;
-  simpl in *.
+  use mk_is_precategory_one_assoc; intros.
   - apply subtypeEquality.
     + intro. apply setproperty.
     + apply id_left.
@@ -62,7 +61,7 @@ Proof.
 Qed.
 
 Definition precategory_of_elements : precategory 
-  := tpair _ _ is_precategory_precategory_of_elements.
+  := (_,,is_precategory_precategory_of_elements).
 
 Local Notation "∫" := precategory_of_elements.
 (* written \int in agda input mode *)

--- a/TypeTheory/Categories/ess_and_gen_alg_cats.v
+++ b/TypeTheory/Categories/ess_and_gen_alg_cats.v
@@ -195,7 +195,7 @@ Defined.
 Lemma is_precategory_precategory_data_from_ess_alg_cat : 
   is_precategory (precategory_data_from_ess_alg_cat).
 Proof.
-  repeat split; intros.
+  use mk_is_precategory_one_assoc; intros.
   - apply hom_eq. simpl. apply id_comp_l. 
     apply (pr1 (pr2 f)).
   - apply hom_eq, id_comp_r, (pr2 (pr2 f)).
@@ -203,6 +203,6 @@ Proof.
 Qed.
 
 Definition precategory_from_ess_alg_cat : precategory := 
-  tpair _ _ is_precategory_precategory_data_from_ess_alg_cat.
+  (_,,is_precategory_precategory_data_from_ess_alg_cat).
 
 End gen_alg_from_ess_alg.


### PR DESCRIPTION
after the recent changes to UniMath. 

I also shortened some proofs and got rid of some uses of `Focus` as it is deprecated and might stop working soon (at least that's what Coq told me when I loaded the files). I also found an `Admitted` that seem to have been there because the proof used to be slow to `Qed`, but the `Qed` was instant now so I changed it.