### PR TITLE
make the library compile again, after upstream changes in UniMath

### DIFF
--- a/TypeTheory/Csystems/lC0systems.v
+++ b/TypeTheory/Csystems/lC0systems.v
@@ -20,7 +20,7 @@ Require Export TypeTheory.Csystems.hSet_ltowers.
 Section Upstream.
 
 Lemma idtoiso_inv0 (C : precategory) (a a' : ob C) (p : a = a'):
-  morphism_from_iso _ _ _ (idtoiso (!p)) = inv_from_iso (idtoiso p).
+  morphism_from_iso (idtoiso (!p)) = inv_from_iso (idtoiso p).
 Proof.
   destruct p.
   simpl.
@@ -34,7 +34,7 @@ Proof.
 Qed.
 
 Lemma idtoiso_idpath0 {C : precategory} (a : ob C):
-  morphism_from_iso _ _ _ (idtoiso (idpath a)) = identity a.
+  morphism_from_iso (idtoiso (idpath a)) = identity a.
 Proof.
   apply idpath.
 Qed.
@@ -49,8 +49,8 @@ Qed.
 
 Lemma idtoiso_concat0 (C : precategory) (a a' a'' : ob C)
   (p : a = a') (q : a' = a'') :
-  morphism_from_iso _ _ _ (idtoiso (p @ q)) =
-  morphism_from_iso _ _ _ (idtoiso p) · (morphism_from_iso _ _ _(idtoiso q)).
+  morphism_from_iso (idtoiso (p @ q)) =
+  morphism_from_iso (idtoiso p) · (morphism_from_iso (idtoiso q)).
 Proof.
   destruct p.
   destruct q.
@@ -193,8 +193,8 @@ Lemma cancelidtoiso_left {CC: precategory}(is: isaset (ob CC)) {a b c: CC}
   m1 = m2 -> idtoiso p1 · m1  = idtoiso p2 · m2.
 Proof.
   intro Hyp.
-  assert (H1: morphism_from_iso _ _ _ (idtoiso p1) =
-              morphism_from_iso _ _ _ (idtoiso p2)).
+  assert (H1: morphism_from_iso (idtoiso p1) =
+              morphism_from_iso (idtoiso p2)).
   apply maponpaths.
   apply maponpaths.
   apply is.
@@ -219,8 +219,8 @@ Lemma cancelidtoiso_right {CC: precategory}(is: isaset (ob CC)) {a b c: CC}
   m1 = m2 -> m1 · idtoiso q1  =  m2 · idtoiso q2.
 Proof.
   intro Hyp.
-  assert (H1: morphism_from_iso _ _ _ (idtoiso q1) =
-              morphism_from_iso _ _ _ (idtoiso q2)).
+  assert (H1: morphism_from_iso (idtoiso q1) =
+              morphism_from_iso (idtoiso q2)).
   apply maponpaths.
   apply maponpaths.
   apply is.

--- a/TypeTheory/Instances/Presheaves.v
+++ b/TypeTheory/Instances/Presheaves.v
@@ -100,7 +100,6 @@ Written by: Anders Mörtberg, 2017
 *)
 Require Import UniMath.MoreFoundations.All.
 
-Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Functors.
 Require Import UniMath.CategoryTheory.Adjunctions.Core.

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_DM.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_DM.v
@@ -12,7 +12,6 @@
 
 
 Require Import UniMath.Foundations.Sets.
-Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Isos.

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat.v
@@ -11,7 +11,6 @@ Contents:
 *)
 
 
-Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 
 Require Import UniMath.Foundations.Sets.

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat_to_DM.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat_to_DM.v
@@ -12,7 +12,6 @@ Contents:
 Require Import UniMath.Foundations.Sets.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
-Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 
 Require Import TypeTheory.ALV1.TypeCat.

--- a/TypeTheory/OtherDefs/DM_to_TypeCat.v
+++ b/TypeTheory/OtherDefs/DM_to_TypeCat.v
@@ -9,7 +9,6 @@
 *)
 
 
-Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 

--- a/TypeTheory/OtherDefs/DM_to_TypeCat_to_DM.v
+++ b/TypeTheory/OtherDefs/DM_to_TypeCat_to_DM.v
@@ -12,7 +12,6 @@ Require Import UniMath.Foundations.Sets.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import UniMath.CategoryTheory.Core.Categories.
-Require Import UniMath.CategoryTheory.total2_paths.
 
 Require Import TypeTheory.ALV1.TypeCat.
 Require Import TypeTheory.OtherDefs.DM.

--- a/TypeTheory/OtherDefs/TypeCat_to_CwF_Pitts.v
+++ b/TypeTheory/OtherDefs/TypeCat_to_CwF_Pitts.v
@@ -10,7 +10,6 @@
 *)
 
 Require Import UniMath.CategoryTheory.limits.pullbacks.
-Require Import UniMath.CategoryTheory.total2_paths.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 Require Import TypeTheory.Auxiliary.Auxiliary.
 

--- a/TypeTheory/OtherDefs/TypeCat_to_DM.v
+++ b/TypeTheory/OtherDefs/TypeCat_to_DM.v
@@ -8,7 +8,6 @@
       (assumption of saturatedness needed for pullbacks forming hprop)
 *)
 
-Require Import UniMath.CategoryTheory.total2_paths.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 Require Import TypeTheory.Auxiliary.Auxiliary.


### PR DESCRIPTION
just leave out
- `Require Import UniMath.CategoryTheory.total2_paths.`
- wildcards for implicit arguments of `morphism_from_iso`