### PR TITLE
tiny changes to make it compile again after changes in UniMath

### DIFF
--- a/TypeTheory/Auxiliary/Auxiliary.v
+++ b/TypeTheory/Auxiliary/Auxiliary.v
@@ -335,7 +335,7 @@ Proof.
   apply isweqtotaltofib. (* first of the two key steps *)
   use gradth.
   - intros bp. exists (pr1 bp). apply v, (pr2 bp).
-  - intros be; apply connectedcoconusfromt. (* the second key step *)
+  - intros be; apply coconusfromt_isProofIrrelevant. (* the second key step *)
   - intros bp. use total2_paths_f. apply idpath. apply wv.
 Qed.
 

--- a/TypeTheory/Cubical/FillFromComp.v
+++ b/TypeTheory/Cubical/FillFromComp.v
@@ -77,7 +77,10 @@ category C with:
 Written by: Anders Mörtberg, 2017-2018
 
 *)
-Require Import UniMath.MoreFoundations.All.
+
+Require Import UniMath.MoreFoundations.Tactics.
+Require Import UniMath.MoreFoundations.PartA.
+Require Import UniMath.MoreFoundations.Notations.
 
 Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Functors.

--- a/TypeTheory/Instances/Presheaves.v
+++ b/TypeTheory/Instances/Presheaves.v
@@ -97,8 +97,12 @@ And the last square is a pullback square ([isPullback_q_gen_mor]).
 
 Written by: Anders Mörtberg, 2017
 
-*)
-Require Import UniMath.MoreFoundations.All.
+ *)
+
+Require Import UniMath.MoreFoundations.Tactics.
+Require Import UniMath.MoreFoundations.PartA.
+Require Import UniMath.MoreFoundations.Notations.
+Require Import UniMath.MoreFoundations.Univalence.
 
 Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Functors.


### PR DESCRIPTION
Auxiliary.v: name of lemma changed
the others need more precise import statements since, otherwise, Δ becomes a notation and cannot be used as variable name