### PR TITLE
Make TypeTheory compile with current UniMath

### DIFF
--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
@@ -178,7 +178,7 @@ Definition term_fun_data : precategory_data
 
 Definition term_fun_axioms : is_precategory term_fun_data.
 Proof.
-  use mk_is_precategory_one_assoc; intros; apply isaprop_term_fun_mor.
+  use make_is_precategory_one_assoc; intros; apply isaprop_term_fun_mor.
 Qed.
 
 Definition term_fun_precategory : precategory 
@@ -271,7 +271,7 @@ Definition strucs_compat_data : precategory_data
 
 Definition strucs_compat_axioms : is_precategory strucs_compat_data.
 Proof.
-  use mk_is_precategory_one_assoc; intros.
+  use make_is_precategory_one_assoc; intros.
   - apply dirprodeq; apply id_left.
   - apply dirprodeq; apply id_right.
   - apply dirprodeq; apply assoc.
@@ -397,9 +397,9 @@ Proof.
   - etrans. apply id_right.
     cbn. apply PullbackArrowUnique.
     + use (PullbackArrow_PullbackPr1
-                (mk_Pullback _ _ _ _ _ _ (qq_π_Pb _ f A))).
+                (make_Pullback _ _ _ _ _ _ (qq_π_Pb _ f A))).
     + cbn; cbn in FZ. etrans. apply maponpaths, @pathsinv0, FZ.
-      apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). 
+      apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)). 
 Qed.
 
 Lemma tm_from_qq_mor_TM {Z Z' : qq_structure_precategory} (FZ : Z --> Z')
@@ -426,10 +426,10 @@ Proof.
   - apply idpath.
   - etrans. apply id_right. 
     cbn. apply PullbackArrowUnique.
-    + cbn. apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)).
+    + cbn. apply (PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ _)).
     + cbn. cbn in FZ. 
       etrans. apply maponpaths, @pathsinv0, FZ.
-      apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). 
+      apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)). 
 Qed.
 
 End Rename_me.
@@ -457,7 +457,7 @@ Proof.
   simpl in Y, Y'.  (* To avoid needing casts [Y : term_fun_structure _]. *)
   simpl; unfold term_fun_mor.
   exists (term_from_qq_mor_TM FZ W W').
-  apply dirprodpair; try intros Γ A.
+  apply make_dirprod; try intros Γ A.
   - etrans. apply @pathsinv0, assoc.
     etrans. apply maponpaths, (pp_canonical_TM_to_given _ _ (_,,_)).
     etrans. apply @pathsinv0, assoc.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
@@ -56,7 +56,7 @@ Proof.
   etrans. apply (toforallpaths _ _ _ (!functor_comp (TM Y) _ _ ) _).
   etrans. Focus 2. apply (toforallpaths _ _ _ (functor_comp (TM Y) _ _ ) _).
   apply maponpaths_2. 
-  apply (@PullbackArrow_PullbackPr2 C _ _ _ _ _ (mk_Pullback _ _ _ _ _ _ _)).
+  apply (@PullbackArrow_PullbackPr2 C _ _ _ _ _ (make_Pullback _ _ _ _ _ _ _)).
 Qed.
 
 Definition canonical_TM_to_given : (preShv C) ⟦tm_from_qq Z, TM (pr1 Y)⟧.
@@ -180,7 +180,7 @@ Proof.
   etrans. apply maponpaths, (pr2 Y).
   etrans. use (toforallpaths _ _ _ (!functor_comp (TM Y) _ _ )).
   etrans. apply maponpaths_2; cbn.
-    apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). 
+    apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)). 
   apply (toforallpaths _ _ _ (functor_id (TM Y) _) _).
 Qed.
 
@@ -231,7 +231,7 @@ Proof.
       etrans. apply maponpaths, YH.
       etrans. use (toforallpaths _ _ _ (!functor_comp tm _ _ )).
       etrans. apply maponpaths_2; cbn.
-        apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). 
+        apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)). 
       apply (toforallpaths _ _ _ (functor_id tm _) _).
 Defined.
 
@@ -268,7 +268,7 @@ Proof.
   apply funextsec; intro Γ'.
   apply funextsec; intro f.
   apply funextsec; intro A.    
-  apply (invmaponpathsweq (weqpair _ (yoneda_fully_faithful _ (homset_property _) _ _ ))).
+  apply (invmaponpathsweq (make_weq _ (yoneda_fully_faithful _ (homset_property _) _ _ ))).
   apply pathsinv0.
   etrans. apply Yo_qq_term_Yo_of_qq.
   unfold Yo_of_qq.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
@@ -160,7 +160,7 @@ Proof.
     + intro. apply isasetaprop. apply homset_property.
 Qed.
 
-Definition tm_from_qq_functor_ob Γ : hSet := hSetpair _ (isaset_tm_from_qq Γ).
+Definition tm_from_qq_functor_ob Γ : hSet := make_hSet _ (isaset_tm_from_qq Γ).
 
 Definition tm_from_qq_functor_mor Γ Γ' (f : C⟦Γ',Γ⟧) : tm_from_qq_carrier Γ → tm_from_qq_carrier Γ'.
 Proof.
@@ -227,7 +227,7 @@ Proof.
     use tm_from_qq_eq; simpl.
     + exact (toforallpaths _ _ _ (functor_id (TY X) _ ) A).
     + etrans. apply maponpaths, @pathsinv0, qq_id.
-      etrans. apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). 
+      etrans. apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)). 
       apply id_left.
   - intros Γ Γ' Γ'' f g; apply funextsec; intro t.
     destruct t as [A [s e]]; cbn in *.
@@ -237,12 +237,12 @@ Proof.
       apply PullbackArrowUnique; cbn.
       - rewrite <- assoc.
         rewrite @comp_ext_compare_π.
-        apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)).
+        apply (PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ _)).
       - apply (MorphismsIntoPullbackEqual (qq_π_Pb Z _ _)).
         + etrans. Focus 2. apply assoc.
           etrans. Focus 2.
             apply maponpaths, @pathsinv0.
-            apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)).
+            apply (PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ _)).
           etrans. Focus 2. apply @pathsinv0, id_right.
           etrans. apply @pathsinv0, assoc.
           etrans. eapply maponpaths, qq_π.
@@ -251,15 +251,15 @@ Proof.
           apply maponpaths_2.
           etrans. apply @pathsinv0, assoc.
           rewrite @comp_ext_compare_π.
-          apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)).
+          apply (PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ _)).
         + repeat rewrite <- assoc.
           etrans. apply maponpaths. rewrite assoc.
             apply @pathsinv0, qq_comp_general.
-          etrans. apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)).
+          etrans. apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)).
           etrans. apply @pathsinv0, assoc.
           apply maponpaths.
           apply @pathsinv0.
-          apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). }
+          apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)). }
 Qed.
 
 Definition tm_from_qq : functor _ _
@@ -370,11 +370,11 @@ Proof.
   apply pathsinv0.
   etrans. {
     apply maponpaths_2.
-    apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). }
+    apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)). }
   use (_ @ id_right _).  
   etrans. apply @pathsinv0, assoc.
   apply maponpaths.
-  apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)).
+  apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)).
 Qed.
 
 (* TODO: try to speed this up! *)
@@ -403,7 +403,7 @@ Proof.
         use (_ @ !e).
         etrans. apply @pathsinv0, assoc.
         etrans. apply @maponpaths, comp_ext_compare_π.
-        apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)).
+        apply (PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ _)).
       * etrans. apply @pathsinv0, assoc.
         use (maponpaths _ _ @ _).
             { use (qq Z _ _ ;; qq Z _ _). }
@@ -419,11 +419,11 @@ Proof.
          apply (section_qq_π _ _ _ e). }
         etrans. apply assoc.
         etrans. { apply maponpaths_2,
-                  (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). }
+                  (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)). }
         etrans. apply @pathsinv0, assoc.
         etrans.
           apply maponpaths.
-          apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)).
+          apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)).
         apply id_right.
   - idtac. intros ft. apply subtypeEquality.
     { intro. apply isapropdirprod.
@@ -480,7 +480,7 @@ Proof.
     + cbn.
       etrans. apply @pathsinv0, assoc.
       etrans. apply maponpaths, comp_ext_compare_π.
-      apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)). 
+      apply (PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ _)). 
     + apply (map_into_Pb_unique _ (qq_π_Pb Z _ _)). 
       * cbn.
         etrans. apply @pathsinv0, assoc.
@@ -489,12 +489,12 @@ Proof.
         etrans. apply maponpaths_2.
           etrans. apply @pathsinv0, assoc.
           etrans. apply maponpaths, comp_ext_compare_π.
-          apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)).
+          apply (PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ _)).
         etrans. apply id_left.
         apply pathsinv0.
         etrans. apply @pathsinv0, assoc.
         etrans. apply maponpaths.
-          apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)).
+          apply (PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ _)).
         apply id_right.
       * cbn.
         etrans. apply @pathsinv0, assoc.
@@ -520,12 +520,12 @@ Proof.
               etrans. apply @pathsinv0, comp_ext_compare_comp.
               apply comp_ext_compare_id_general.
             apply id_left.
-          apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)).
+          apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)).
         etrans. apply id_left.
         apply pathsinv0.
         etrans. apply @pathsinv0, assoc.
         etrans. apply maponpaths.
-          apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)).
+          apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)).
         apply id_right.
 Time Qed.
 
@@ -556,7 +556,7 @@ Variables Γ Γ' : C.
 Variable f : C⟦Γ', Γ⟧.
 Variable A : Ty X Γ.
 
-Let Xk := mk_Pullback _ _ _ _ _ _ (isPullback_Q_pp Y A).
+Let Xk := make_Pullback _ _ _ _ _ _ (isPullback_Q_pp Y A).
 
 (** ** Groundwork in presheaves
 
@@ -608,7 +608,7 @@ Qed.
 (** ** Construction of the _q_-morphisms *)
 Definition qq_term :  _ ⟦Γ' ◂ A[f] , Γ ◂ A⟧.
 Proof.
-  apply (invweq (weqpair _ (yoneda_fully_faithful _ (homset_property _) _ _ ))).
+  apply (invweq (make_weq _ (yoneda_fully_faithful _ (homset_property _) _ _ ))).
   apply Yo_of_qq.
 Defined.
 
@@ -616,7 +616,7 @@ Lemma Yo_qq_term_Yo_of_qq : # Yo qq_term = Yo_of_qq.
 Proof.
   unfold qq_term.
   assert (XT := homotweqinvweq
-     (weqpair _ (yoneda_fully_faithful _ (homset_property _) (Γ'◂ A[f]) (Γ ◂ A)))).
+     (make_weq _ (yoneda_fully_faithful _ (homset_property _) (Γ'◂ A[f]) (Γ ◂ A)))).
   apply XT.
 Qed.
 
@@ -625,7 +625,7 @@ Proof.
   assert (XT:= Yo_of_qq_commutes_1).
   rewrite <- Yo_qq_term_Yo_of_qq in XT.
   do 2 rewrite <- functor_comp in XT.
-  apply (invmaponpathsweq (weqpair _ (yoneda_fully_faithful _ (homset_property _) _ _ ))).
+  apply (invmaponpathsweq (make_weq _ (yoneda_fully_faithful _ (homset_property _) _ _ ))).
   apply @pathsinv0, XT.
 Qed.
 
@@ -657,8 +657,8 @@ Lemma is_split_qq_from_term : qq_morphism_axioms qq_from_term_data.
 Proof.
   split.
   - intros Γ A. simpl.
-    apply (invmaponpathsweq (weqpair _ (yoneda_fully_faithful _ (homset_property _) _ _ ))).
-    etrans; [ apply (homotweqinvweq (weqpair _ (yoneda_fully_faithful _ (homset_property _) _ _ ))) | idtac ].    
+    apply (invmaponpathsweq (make_weq _ (yoneda_fully_faithful _ (homset_property _) _ _ ))).
+    etrans; [ apply (homotweqinvweq (make_weq _ (yoneda_fully_faithful _ (homset_property _) _ _ ))) | idtac ].    
     apply pathsinv0.
     unfold Yo_of_qq.
     apply PullbackArrowUnique. 
@@ -670,8 +670,8 @@ Proof.
     + etrans. apply maponpaths. cbn. apply idpath.
       apply comp_ext_compare_Q.
   - intros.
-    apply (invmaponpathsweq (weqpair _ (yoneda_fully_faithful _ (homset_property _) _ _ ))).
-    etrans; [ apply (homotweqinvweq (weqpair _ (yoneda_fully_faithful _ (homset_property _) _ _ ))) | idtac ].    
+    apply (invmaponpathsweq (make_weq _ (yoneda_fully_faithful _ (homset_property _) _ _ ))).
+    etrans; [ apply (homotweqinvweq (make_weq _ (yoneda_fully_faithful _ (homset_property _) _ _ ))) | idtac ].    
     sym. apply PullbackArrowUnique.
     + etrans. apply maponpaths. cbn. apply idpath.
       rewrite <- functor_comp.

--- a/TypeTheory/ALV1/CwF_def.v
+++ b/TypeTheory/ALV1/CwF_def.v
@@ -208,8 +208,8 @@ Proof.
   destruct H as [H isP].
   destruct H' as [H' isP'].
   use (total2_paths_f).
-  - set (T1 := mk_Pullback _ _ _ _ _ _ isP).
-    set (T2 := mk_Pullback _ _ _ _ _ _ isP').
+  - set (T1 := make_Pullback _ _ _ _ _ _ isP).
+    set (T2 := make_Pullback _ _ _ _ _ _ isP').
     set (i := iso_from_Pullback_to_Pullback T1 T2). cbn in i.
     set (i' := invmap (weq_ff_functor_on_iso (yoneda_fully_faithful _ _ ) _ _ ) i ).
     set (TT := isotoid _ isC i').
@@ -445,7 +445,7 @@ adj_equiv_of_cats_is_weq_of_objects
 Lemma Tm_transfer_recover : 
       TM = ηη TM'.
 Proof.
-  assert (XT := homotweqinvweq (weqpair _ isweq_Fcomp) TM).
+  assert (XT := homotweqinvweq (make_weq _ isweq_Fcomp) TM).
   apply pathsinv0.
   apply XT.
 Defined.  
@@ -453,7 +453,7 @@ Defined.
 Lemma Ty_transfer_recover : 
    TY = ηη TY'.
 Proof.
-  assert (XT := homotweqinvweq (weqpair _ isweq_Fcomp) TY).
+  assert (XT := homotweqinvweq (make_weq _ isweq_Fcomp) TY).
   apply pathsinv0.
   apply XT.
 Defined.  

--- a/TypeTheory/ALV1/RelativeUniverses.v
+++ b/TypeTheory/ALV1/RelativeUniverses.v
@@ -120,8 +120,8 @@ Proof.
     destruct H' as [H' isP'].
     use total2_paths_f.
     + unfold fpullback_prop in *.
-      set (T1 := mk_Pullback _ _ _ _ _ _ isP).
-      set (T2 := mk_Pullback _ _ _ _ _ _ isP').
+      set (T1 := make_Pullback _ _ _ _ _ _ isP).
+      set (T2 := make_Pullback _ _ _ _ _ _ isP').
       set (i := iso_from_Pullback_to_Pullback T1 T2). cbn in i.
       set (i' := invmap (weq_ff_functor_on_iso HJ a a') i ).
       set (TT := isotoid _ is_c i').
@@ -150,7 +150,7 @@ Proof.
         cbn in *.
         rewrite functor_comp. rewrite T. clear T.
         clear XT' XT. clear TT. 
-        assert (X1:= PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ isP)).
+        assert (X1:= PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ isP)).
         cbn in X1.
         apply X1.
       * unfold TT. clear TT. clear XT' XT.
@@ -160,7 +160,7 @@ Proof.
         cbn. unfold precomp_with. rewrite id_right. rewrite id_right.
         assert (XX:=homotweqinvweq (weq_from_fully_faithful HJ a' a  )).
         simpl in XX. rewrite XX. simpl. cbn.
-        assert (X1:= PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ isP)).
+        assert (X1:= PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ isP)).
         apply X1.
 Qed.
 
@@ -357,7 +357,7 @@ Definition fq_nat_fpb_mor (Y : functorial_structure_relu)
   := pr2 (pr2 (pr2 (pr2 Y))).                                                                       
 
 
-Definition mk_functorial_structure_relu
+Definition make_functorial_structure_relu
            (fpb_mor : fpullback_mor_type)
   : id_fpb_mor_type fpb_mor
     -> comp_fpb_mor_type fpb_mor
@@ -468,7 +468,7 @@ Qed.
 
 Definition ff_functorial_structure_relu : functorial_structure_relu.
 Proof.
-  use mk_functorial_structure_relu.
+  use make_functorial_structure_relu.
   - exact @rel_universe_fpullback_mor.
   - exact @rel_universe_fpullback_mor_id.
   - exact @rel_universe_fpullback_mor_comp.
@@ -561,7 +561,7 @@ Context
      surjectivity assumptions. 
 *)
 
-Let αiso := isopair α is_iso_α.
+Let αiso := make_iso α is_iso_α.
 Let α' := inv_from_iso αiso. 
 Let α'_α := nat_trans_eq_pointwise (iso_after_iso_inv αiso).
 Let α_α' := nat_trans_eq_pointwise (iso_inv_after_iso αiso).
@@ -738,7 +738,7 @@ Context
 
    (S_pb : maps_pb_squares_to_pb_squares _ _ S).
 
-Let αiso := isopair α is_iso_α.
+Let αiso := make_iso α is_iso_α.
 Let α' := inv_from_iso αiso. 
 Let α'_α := nat_trans_eq_pointwise (iso_after_iso_inv αiso).
 Let α_α' := nat_trans_eq_pointwise (iso_inv_after_iso αiso).
@@ -968,7 +968,7 @@ Definition weq_weak_relative_universe_transfer
            (eps : iso (C:=[D', D', pr2 D']) (T ∙ S) (functor_identity D'))
            (S_ff : fully_faithful S)
 : weak_relative_universe J ≃ weak_relative_universe J'
-:= weqpair _ (isweq_weak_relative_universe_transfer R_full isD isD' T eta eps S_ff).
+:= make_weq _ (isweq_weak_relative_universe_transfer R_full isD isD' T eta eps S_ff).
 
 End Is_universe_relative_to_Transfer.
 

--- a/TypeTheory/ALV1/TypeCat_Reassoc.v
+++ b/TypeTheory/ALV1/TypeCat_Reassoc.v
@@ -139,7 +139,7 @@ Proof.
   - exists (pr1 (pr1 (pr1 (pr1 (pr1 S)))) ,,
                 (pr1 (pr2 (pr1 S)) ,, (pr2 (pr1 (pr1 (pr1 S)))))).
     exact (pr2 (pr2 (pr1 S)),, pr1 (pr2 S)).
-  - repeat apply dirprodpair; simpl.
+  - repeat apply make_dirprod; simpl.
     + exact (pr2 (pr1 (pr1 (pr1 (pr1 S))))).
     + exact (pr1 (pr2 (pr1 (pr1 S))),, pr1 (pr2 (pr2 S))).
     + exact (pr2 (pr2 (pr1 (pr1 S))),, pr2 (pr2 (pr2 S))).

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Cats.v
@@ -141,7 +141,7 @@ Definition obj_ext_precat_data : precategory_data
 
 Definition obj_ext_precat_axioms : is_precategory obj_ext_precat_data.
 Proof.
-  use mk_is_precategory_one_assoc.
+  use make_is_precategory_one_assoc.
   - intros X X' F.
     use obj_ext_mor_eq; [ intros Γ A; apply idpath|].
     intros Γ A.

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
@@ -247,14 +247,14 @@ Proof.
       etrans. apply @pathsinv0, assoc.
       etrans. apply maponpaths, obj_ext_mor_ax.
       use (PullbackArrow_PullbackPr1
-                (mk_Pullback _ _ _ _ _ _ (qq_π_Pb _ f A))).
+                (make_Pullback _ _ _ _ _ _ (qq_π_Pb _ f A))).
     + cbn in FZ; cbn.
       etrans. apply maponpaths_2, @pathsinv0, assoc.
       etrans. apply @pathsinv0, assoc.
       etrans. apply maponpaths, @pathsinv0, FZ.
       etrans. apply assoc.
       etrans. apply maponpaths_2.
-        apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)). 
+        apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)). 
       apply pathsinv0, assoc.
 Time Qed.
 
@@ -290,7 +290,7 @@ Proof.
     etrans. Focus 2. cbn. apply maponpaths_2, @pathsinv0, obj_ext_mor_ax.
     exact (toforallpaths _ _ _ (nat_trans_ax (obj_ext_mor_TY F) _ _ _) _).
   - etrans. Focus 2. apply @pathsinv0, 
-        (postCompWithPullbackArrow _ _ _ (mk_Pullback _ _ _ _ _ _ _)).
+        (postCompWithPullbackArrow _ _ _ (make_Pullback _ _ _ _ _ _ _)).
     apply PullbackArrowUnique.
     + cbn.
       etrans. apply @pathsinv0, assoc.
@@ -303,7 +303,7 @@ Proof.
       etrans. apply maponpaths, comp_ext_compare_π.
       etrans. apply @pathsinv0, assoc.
       etrans. apply maponpaths, obj_ext_mor_ax.
-      apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _)).
+      apply (PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ _)).
     + etrans. Focus 2. apply @pathsinv0, id_right.
       etrans. cbn. apply maponpaths_2, maponpaths_2, maponpaths.
         etrans. apply comp_ext_compare_comp.
@@ -323,7 +323,7 @@ Proof.
         (* TODO: give access function [qq_structure_mor_ax]! *)
       etrans. apply assoc.
       etrans. apply maponpaths_2.
-        apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _)).
+        apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)).
       apply id_left.
 Time Qed.
 
@@ -353,7 +353,7 @@ Proof.
   simpl in Y, Y'.  (* To avoid needing casts [Y : term_fun_structure _]. *)
   use (_,,tt). simpl; unfold term_fun_mor.
   exists (term_from_qq_mor_TM FZ W W').
-  apply dirprodpair; try intros Γ A.
+  apply make_dirprod; try intros Γ A.
   - etrans. apply @pathsinv0, assoc.
     etrans. apply maponpaths, (pp_canonical_TM_to_given _ _ (_,,_)).
     etrans. apply @pathsinv0, assoc.

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
@@ -53,7 +53,7 @@ Definition obj_ext_iso_alt (X X' : obj_ext_Precat C) : UU :=
 (* TODO: anstract this as a general function on any [category] (if there isn’t one already provided). *) 
 Definition is_saturated_preShv (F G : preShv C) : F = G ≃ iso F G.
 Proof.
-  apply (weqpair idtoiso (pr1 (univalent_category_is_univalent _) _ _ )).
+  apply (make_weq idtoiso (pr1 (univalent_category_is_univalent _) _ _ )).
 Defined.
 
 Definition weq_eq_obj_ext_iso_alt (X X' : obj_ext_Precat C) :

--- a/TypeTheory/ALV2/RelUniv_Cat.v
+++ b/TypeTheory/ALV2/RelUniv_Cat.v
@@ -95,7 +95,7 @@ Coercion pre_functor_square_of_lax_functor_square
   : lax_functor_square J J' -> pre_functor_square J J'
 := pr1.
 
-Definition mk_lax_functor_square
+Definition make_lax_functor_square
     {C D : precategory} {J : C ⟶ D}
     {C' D' : precategory} {J' : C' ⟶ D'}
     (F : C ⟶ C') (G : D ⟶ D') (α : nat_trans (F ∙ J') (J ∙ G))

--- a/TypeTheory/Articles/ALV_2017.v
+++ b/TypeTheory/Articles/ALV_2017.v
@@ -133,7 +133,7 @@ Proof.
   eapply weqcomp.
     apply Rezk_on_rep_map.
   apply invweq.
-  use (weqpair _ (isweq_from_cwf_to_rep _ _ )).
+  use (make_weq _ (isweq_from_cwf_to_rep _ _ )).
   apply univalent_category_is_univalent.
 Defined.
 

--- a/TypeTheory/Auxiliary/Auxiliary.v
+++ b/TypeTheory/Auxiliary/Auxiliary.v
@@ -28,8 +28,8 @@ Set Automatic Introduction.
 
 Undelimit Scope transport.
 
-Notation "( x , y , .. , z )" := (dirprodpair .. (dirprodpair x y) .. z) : core_scope.
-(** Replaces builtin notation for [pair], since we use [dirprod, dirprodpair] instead of [prod, pair]. *)
+Notation "( x , y , .. , z )" := (make_dirprod .. (make_dirprod x y) .. z) : core_scope.
+(** Replaces builtin notation for [pair], since we use [dirprod, make_dirprod] instead of [prod, pair]. *)
 
 
 (** Redeclare this notation, along with a new scope. *)
@@ -318,7 +318,7 @@ Definition isweqbandfmap_var {X Y : UU} (w : X -> Y)
 : isweq w -> (∏ x, isweq (fw x)) -> isweq (bandfmap w P Q (λ x : X, fw x)).
 Proof.
   intros Hw Hfw.
-  apply (isweqbandfmap (weqpair w Hw) _ _ (fun x => weqpair _ (Hfw x))).
+  apply (isweqbandfmap (make_weq w Hw) _ _ (fun x => make_weq _ (Hfw x))).
 Defined.
 
 (* TODO: see if this can be used to more easily get other instances of [weqtotal2asstol] that currently need careful use of [specialize]. *)
@@ -404,13 +404,13 @@ Lemma is_iso_comp_is_iso {C : precategory} {a b c : ob C}
   : is_iso f -> is_iso g -> is_iso (f ;; g).
 Proof.
   intros Hf Hg.
-  apply (is_iso_comp_of_isos (isopair f Hf) (isopair g Hg)).
+  apply (is_iso_comp_of_isos (make_iso f Hf) (make_iso g Hg)).
 Defined.
 
 Lemma functor_is_iso_is_iso {C C' : precategory} (F : functor C C')
     {a b : ob C} (f : C ⟦a,b⟧) (fH : is_iso f) : is_iso (#F f).
 Proof.
-  apply (functor_on_iso_is_iso _ _ F _ _ (isopair f fH)).
+  apply (functor_on_iso_is_iso _ _ F _ _ (make_iso f fH)).
 Defined.
 
 
@@ -504,7 +504,7 @@ Definition iso_ob {C D : precategory} (hsD : has_homsets D)
   : ∏ c, iso (F c) (G c).
 Proof.
   intro c.
-  use isopair.
+  use make_iso.
   - cbn. apply ((pr1 a : nat_trans _ _ ) c).
   - apply is_functor_iso_pointwise_if_iso. apply (pr2 a).
 Defined.
@@ -572,16 +572,16 @@ Lemma fully_faithful_impl_ff_on_isos {C D : precategory} (F : functor C D)
 Proof.
   intros Fff c c'.
   use gradth.
-  - intro XR. exists (invmap (weqpair _ (Fff _ _ )) XR). cbn.
+  - intro XR. exists (invmap (make_weq _ (Fff _ _ )) XR). cbn.
     apply (ff_reflects_is_iso _ _ _ Fff).
-    assert (XT := homotweqinvweq (weqpair _ (Fff c c' ))).
+    assert (XT := homotweqinvweq (make_weq _ (Fff c c' ))).
     cbn in *.
     apply (transportb (λ i : _ --> _, is_iso i) (XT (pr1 XR) )).
     apply XR.
   - cbn. intro i. apply eq_iso. cbn.
-    apply (homotinvweqweq (weqpair _ (Fff _ _ ))).
+    apply (homotinvweqweq (make_weq _ (Fff _ _ ))).
   - cbn. intro i. apply eq_iso. cbn.
-    apply (homotweqinvweq (weqpair _ (Fff _ _ ))).
+    apply (homotweqinvweq (make_weq _ (Fff _ _ ))).
 Defined.
 
 
@@ -696,9 +696,9 @@ Proof.
     rewrite functor_comp.
     apply pathsinv0.
     etrans. apply maponpaths.
-       apply (homotweqinvweq (weqpair _ (Fff _ _ ))).
+       apply (homotweqinvweq (make_weq _ (Fff _ _ ))).
     etrans. apply maponpaths_2.
-       apply (homotweqinvweq (weqpair _ (Fff _ _ ))).
+       apply (homotweqinvweq (make_weq _ (Fff _ _ ))).
     repeat rewrite <- assoc. apply maponpaths. apply maponpaths.
     repeat rewrite assoc. apply maponpaths_2.
     etrans. apply maponpaths_2.  apply iso_after_iso_inv.
@@ -735,7 +735,7 @@ Lemma is_nat_trans_η_ff_split :
     (λ a : A, Finv (inv_from_iso (pr2 (Fses (F ((functor_identity A) a)))))).
 Proof.
   intros a a' f;
-  apply (invmaponpathsweq (weqpair _ (Fff _ _ )));
+  apply (invmaponpathsweq (make_weq _ (Fff _ _ )));
   cbn;
   rewrite functor_comp;
   rewrite functor_comp;
@@ -768,7 +768,7 @@ Lemma form_adjunction_ff_split
     apply iso_after_iso_inv.
   * intro b.
     cbn. 
-    apply (invmaponpathsweq (weqpair _ (Fff _ _ ))).
+    apply (invmaponpathsweq (make_weq _ (Fff _ _ ))).
     cbn.
     rewrite functor_comp.
     rewrite functor_id.
@@ -790,7 +790,7 @@ Proof.
     + apply form_adjunction_ff_split. 
   - split; cbn.
     + intro a. 
-      use (fully_faithful_reflects_iso_proof _ _ _ Fff _ _ (isopair _ _ )).
+      use (fully_faithful_reflects_iso_proof _ _ _ Fff _ _ (make_iso _ _ )).
       apply is_iso_inv_from_iso. 
     + intro b. apply pr2.
 Defined.
@@ -856,7 +856,7 @@ Defined.
 Definition preShv C := functor_univalent_category C^op HSET_univalent_category.
 
 Notation "'Yo'" := (yoneda _ (homset_property _) : functor _ (preShv _)).
-Notation "'Yo^-1'" := (invweq (weqpair _ (yoneda_fully_faithful _ (homset_property _) _ _ ))).
+Notation "'Yo^-1'" := (invweq (make_weq _ (yoneda_fully_faithful _ (homset_property _) _ _ ))).
 
 (* TODO: perhaps rename e.g. [yoneda_eq]? *)
 Definition yy {C : precategory} {hsC : has_homsets C}
@@ -1153,12 +1153,12 @@ Lemma isPullback_transfer_iso {C : category}
    -> isPullback _ _ _ _ H'.
 Proof.
   intros Hpb.
-  apply (mk_isPullback _ ).    
+  apply (make_isPullback _ ).    
   intros X h k H''.
   simple refine (tpair _ _ _ ).
   - simple refine (tpair _ _ _ ).
     { refine ( _ ;; i_d ).
-      simple refine (PullbackArrow (mk_Pullback _ _ _ _ _ _ Hpb) _ _ _ _).
+      simple refine (PullbackArrow (make_Pullback _ _ _ _ _ _ Hpb) _ _ _ _).
       + exact (h ;; iso_inv_from_iso i_b).
       + exact (k ;; iso_inv_from_iso i_c).
       + abstract (
@@ -1185,8 +1185,8 @@ Proof.
       | rewrite assoc;
       eapply @pathscomp0;
       [ apply maponpaths_2;
-        try apply (PullbackArrow_PullbackPr2 (mk_Pullback _ _ _ _ _ _ _));
-        try apply (PullbackArrow_PullbackPr1 (mk_Pullback _ _ _ _ _ _ _))
+        try apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _));
+        try apply (PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ _))
       | rewrite <- assoc, iso_after_iso_inv; apply id_right]] ).
   - intros hk'.
     apply subtypeEquality.
@@ -1268,7 +1268,7 @@ Section on_pullbacks.
 
   Local Definition Pbb : Pullback k h.
   Proof.
-    unshelve refine (mk_Pullback _ _ _ _ _ _ _ ).
+    unshelve refine (make_Pullback _ _ _ _ _ _ _ ).
       - apply a.
       - apply f.
       - apply g.
@@ -1387,7 +1387,7 @@ Lemma pullback_HSET_univprop_elements {P A B C : HSET}
   : (∏ a b (e : f a = g b), ∃! ab, p1 ab = a × p2 ab = b).
 Proof.
   intros a b e.
-  set (Pb := (mk_Pullback _ _ _ _ _ _ pb)).
+  set (Pb := (make_Pullback _ _ _ _ _ _ pb)).
   apply iscontraprop1.
   - apply invproofirrelevance; intros [ab [ea eb]] [ab' [ea' eb']].
     apply subtypeEquality; simpl.
@@ -1475,7 +1475,7 @@ Proof.
         HC :  (cone
               (@colimits.diagram_pointwise C^op HSET has_homsets_HSET
                                                pullback_graph (pullback_diagram (preShv C) f g) c) S)).
-    { use mk_cone.
+    { use make_cone.
       apply three_rec_dep; cbn.
       - apply h.
       - simpl. apply (h ;; (pr1 f c)).

--- a/TypeTheory/Auxiliary/Partial.v
+++ b/TypeTheory/Auxiliary/Partial.v
@@ -38,7 +38,7 @@ Section Ordering.
   Definition leq_partial_commutes {X} {x x' : partial X} (l : leq_partial x x')
     := pr2 l : forall x_def, _ = _.
 
-  Definition mk_leq_partial' {X} (x x' : partial X)
+  Definition make_leq_partial' {X} (x x' : partial X)
     (H : forall (x_def : is_defined x),
        ∑ (x'_def : is_defined x'), evaluate x'_def = evaluate x_def)
     : leq_partial x x'.
@@ -182,7 +182,7 @@ Section Monad.
       {X} {x x' : partial (partial X)} (l : leq_partial x x')
     : leq_partial (multiply_partial x) (multiply_partial x').
   Proof.
-    apply mk_leq_partial'. intros [H H'].
+    apply make_leq_partial'. intros [H H'].
     use tpair.
     - exists (l H).
       refine (transportb is_defined _ H').
@@ -199,7 +199,7 @@ Section Monad.
       (l1 : forall x_def, leq_partial (evaluate x_def) (evaluate (l0 x_def)))
     : leq_partial (multiply_partial x) (multiply_partial x').
   Proof.
-    apply mk_leq_partial'. intros [x_def x_def'].
+    apply make_leq_partial'. intros [x_def x_def'].
     use tpair.
     - exists (l0 x_def).
       apply l1, x_def'.
@@ -325,7 +325,7 @@ Section Monad.
     (l : forall i:p, leq_partial (x i) (y (f i)))
     : leq_partial (assume_partial p x) (assume_partial q y).
   Proof.
-    apply mk_leq_partial'. intros [i x_def].
+    apply make_leq_partial'. intros [i x_def].
     exists (f i,, l i x_def); cbn.
     apply leq_partial_commutes.
   Defined.
@@ -374,7 +374,7 @@ Section Various.
       {f g : forall x:X, partial (Y x)} (l : forall x, leq_partial (f x) (g x))
     : leq_partial (forall_partial f) (forall_partial g).
   Proof.
-    apply mk_leq_partial'. intros fs_def.
+    apply make_leq_partial'. intros fs_def.
     use tpair.
     - intros x; exact (l x (fs_def x)).
     - apply funextsec; intros x. apply leq_partial_commutes.

--- a/TypeTheory/Bsystems/T_fun.v
+++ b/TypeTheory/Bsystems/T_fun.v
@@ -122,10 +122,10 @@ Lemma ll_T_fun { BB : lBsystem_carrier }
       { X1 : BB } ( gt0 : ll X1 > 0 ) ( X2' : ltower_over ( ft X1 ) ) :
   ll ( T_fun_int ax1b gt0 X2' ) = ll X2' .
 Proof.
-  change ( ll ( T_ext T ( dirprodpair gt0 ( pr2 X2' ) ) ) - ll X1 = ll X2' ) .
+  change ( ll ( T_ext T ( make_dirprod gt0 ( pr2 X2' ) ) ) - ll X1 = ll X2' ) .
   change ( ll X2' ) with ( ll ( pr1 X2' ) - ll ( ft X1 ) ) . 
   unfold T_ext . 
-  destruct (ovab_choice (pr2 (dirprodpair gt0 (pr2 X2')))) as [ isab | eq ] . 
+  destruct (ovab_choice (pr2 (make_dirprod gt0 (pr2 X2')))) as [ isab | eq ] . 
   + rewrite ax0 . 
     rewrite ll_ft .
     assert ( ge : ll (pr1 X2') >= ll X1 ) .
@@ -511,7 +511,7 @@ Proof.
   simpl .
   assert ( gt : ll X > ll ( cntr BB ) ) . rewrite (@ll_cntr BB). apply gt0 .
   
-  set ( isab := dirprodpair gt (isoverll0 (ll_cntr BB) X) : isabove X ( cntr BB ) ) .  
+  set ( isab := make_dirprod gt (isoverll0 (ll_cntr BB) X) : isabove X ( cntr BB ) ) .  
   change (isoverll0 (ll_cntr BB) X) with ( isabove_to_isover isab ) . 
   rewrite Tj_fun_compt . 
   simpl .

--- a/TypeTheory/Categories/category_FAM.v
+++ b/TypeTheory/Categories/category_FAM.v
@@ -70,7 +70,7 @@ Proof.
 Qed.
 
 Definition weqpathscomp0l {X : UU} {x x' : X} (x'' : X) (e : x = x')
-  := weqpair _ (isweqpathscomp0l x'' e).
+  := make_weq _ (isweqpathscomp0l x'' e).
 
 End Auxiliary.
 
@@ -134,7 +134,7 @@ Definition FAM_obj_UU_weq (A B : obj_UU) : (A = B) ≃ FAM_obj_eq_type A B.
 Proof.
   eapply weqcomp.
   - apply total2_paths_equiv.
-  - apply (weqbandf (weqpair _ (univalenceAxiom _  _ ))).
+  - apply (weqbandf (make_weq _ (univalenceAxiom _  _ ))).
     simpl.
     intro p.
     destruct A as [A x].
@@ -192,7 +192,7 @@ Defined.
 
 Lemma is_precategory_FAM : is_precategory FAM_precategory_data.
 Proof.
-  use mk_is_precategory_one_assoc; intros; simpl.
+  use make_is_precategory_one_assoc; intros; simpl.
   - apply (invmap (FAM_mor_equiv _ _ )). 
     exists (fun _ => idpath _ ).
     intros; apply id_left.
@@ -282,7 +282,7 @@ Defined.
 
 (** Characterisation of isos in [FAM] as pairs of a bijection and a family of isos **)
 
-Definition isopair {C : precategory} {a b : C} (f : a --> b) (H : is_iso f) : iso a b 
+Definition make_iso {C : precategory} {a b : C} (f : a --> b) (H : is_iso f) : iso a b 
   := tpair _ f H.
 
 Section isos.
@@ -290,11 +290,11 @@ Section isos.
 Definition isweq_from_is_iso {A B : FAM} (f : A --> B) : is_iso f → isweq (pr1 f). 
 Proof.
   intro H.
-  apply (gradth _ (pr1 (inv_from_iso (isopair f H)))).
+  apply (gradth _ (pr1 (inv_from_iso (make_iso f H)))).
   - intro x. 
-    apply (toforallpaths _ _ _ (maponpaths pr1 (iso_inv_after_iso (isopair f H)))).
+    apply (toforallpaths _ _ _ (maponpaths pr1 (iso_inv_after_iso (make_iso f H)))).
   - intro x.
-    apply (toforallpaths _ _ _ (maponpaths pr1 (iso_after_iso_inv (isopair f H)))).
+    apply (toforallpaths _ _ _ (maponpaths pr1 (iso_after_iso_inv (make_iso f H)))).
 Defined.
 
 Definition FAM_is_iso {A B : FAM} (f : A --> B) : UU := 
@@ -302,14 +302,14 @@ Definition FAM_is_iso {A B : FAM} (f : A --> B) : UU :=
 
 Definition inv_from_FAM_is_iso {A B : FAM} {f : A --> B} (H : FAM_is_iso f) : B --> A.
 Proof.
-  set (finv := invmap (weqpair _ (pr1 H))).
+  set (finv := invmap (make_weq _ (pr1 H))).
   exists finv.
   intro b.
   set (H' := pr2 H (finv b)). simpl in H'.
-  set (x  := isopair _ H': iso (A ₂ (finv b)) (B ₂ (pr1 f (finv b)))).
+  set (x  := make_iso _ H': iso (A ₂ (finv b)) (B ₂ (pr1 f (finv b)))).
   set (xinv := inv_from_iso x).
   cbn in *.
-  use (transportf (λ b', B ₂ b' --> A ₂ (finv b)) (homotweqinvweq (weqpair _ (pr1 H)) _ )).
+  use (transportf (λ b', B ₂ b' --> A ₂ (finv b)) (homotweqinvweq (make_weq _ (pr1 H)) _ )).
   apply xinv.
 Defined.
 
@@ -336,9 +336,9 @@ Proof.
     exists (λ a, homotinvweqweq _ _ ).
     intro a. simpl.
     
-    set (p := homotinvweqweq (weqpair f1 H1) a).
-    set (p' := homotweqinvweq (weqpair f1 H1) (f1 a)).
-    assert (tri : maponpaths f1 p = p'). apply (homotweqinvweqweq (weqpair _ _)).
+    set (p := homotinvweqweq (make_weq f1 H1) a).
+    set (p' := homotweqinvweq (make_weq f1 H1) (f1 a)).
+    assert (tri : maponpaths f1 p = p'). apply (homotweqinvweqweq (make_weq _ _)).
     clearbody p'. destruct tri. simpl in *.
 
     assert (transp_lem : forall (a1 a2 : A ₁) (q : a2 = a1),
@@ -347,20 +347,20 @@ Proof.
         transportf
           (λ b' : B ₁, B ₂ b' --> A ₂ a2)
           (maponpaths f1 q)
-          (inv_from_iso (isopair (f2 a2) (H2 a2))))
+          (inv_from_iso (make_iso (f2 a2) (H2 a2))))
       = identity (A ₂ a1)).
       intros. destruct q; cbn.
-      apply (iso_inv_after_iso (isopair _ _)).
+      apply (iso_inv_after_iso (make_iso _ _)).
     apply transp_lem.
 
   - apply (invmap (FAM_mor_equiv _ _ )).
-    exists (λ a, homotweqinvweq (weqpair _ _) _).
+    exists (λ a, homotweqinvweq (make_weq _ _) _).
     intro b. simpl.
-    set (p := (homotweqinvweq (weqpair f1 H1) b)).
+    set (p := (homotweqinvweq (make_weq f1 H1) b)).
     change (transportf (λ b0 : B ₁, B ₂ b --> B ₂ b0)
-                         (homotweqinvweq (weqpair f1 H1) b))
+                         (homotweqinvweq (make_weq f1 H1) b))
     with (transportf (λ b0 : B ₁, B ₂ b --> B ₂ b0) p).
-    set (a := (invmap (weqpair f1 H1) b)) in *. clearbody p. clearbody a.
+    set (a := (invmap (make_weq f1 H1) b)) in *. clearbody p. clearbody a.
     destruct p. cbn. unfold idfun; simpl. apply iso_after_iso_inv.
 Qed.
 
@@ -370,7 +370,7 @@ Proof.
   intro f_iso.
   split.
   - apply isweq_from_is_iso. assumption.
-  - set (g := iso_inv_from_iso (isopair f f_iso) : B --> A).
+  - set (g := iso_inv_from_iso (make_iso f f_iso) : B --> A).
     set (fg' := iso_inv_after_iso _ : f ;; g = identity A).
     set (gf' := iso_after_iso_inv _ : g ;; f = identity B).
     set (fg:= FAM_mor_equiv _ _ fg'). clearbody fg; clear fg'.

--- a/TypeTheory/Categories/category_of_elements.v
+++ b/TypeTheory/Categories/category_of_elements.v
@@ -48,7 +48,7 @@ Defined.
   
 Lemma is_precategory_precategory_of_elements : is_precategory precategory_of_elements_data.
 Proof.
-  use mk_is_precategory_one_assoc; intros.
+  use make_is_precategory_one_assoc; intros.
   - apply subtypeEquality.
     + intro. apply setproperty.
     + apply id_left.
@@ -190,7 +190,7 @@ Lemma bla (H : is_univalent C) (ac bd : ∫) :
 Proof.
   eapply weqcomp.
   apply total2_paths_equiv.
-  unshelve refine (weqbandf (weqpair (@idtoiso _ _ _ ) _ ) _ _ _ ).
+  unshelve refine (weqbandf (make_weq (@idtoiso _ _ _ ) _ ) _ _ _ ).
   - apply (pr1 H).
   - simpl. intro x.
     destruct ac. destruct bd.

--- a/TypeTheory/Categories/ess_and_gen_alg_cats.v
+++ b/TypeTheory/Categories/ess_and_gen_alg_cats.v
@@ -58,7 +58,7 @@ Proof.
   apply idpath.  
 Qed.
 
-Definition obmor : UU × UU := dirprodpair (ob C) (total_morphisms C).
+Definition obmor : UU × UU := make_dirprod (ob C) (total_morphisms C).
 
 Definition graph_from_gen_alg : graph.
 Proof.   
@@ -70,7 +70,7 @@ Defined.
 Definition graph_from_gen_alg_comp : @comp_op graph_from_gen_alg.
 Proof.
   intros f g e.
-  exists (dirprodpair (pr1 (pr1 f)) (pr2 (pr1 g))).
+  exists (make_dirprod (pr1 (pr1 f)) (pr2 (pr1 g))).
   exact ((pr2 f ;; idtomor _ _ e) ;; pr2 g).
 Defined.
 
@@ -78,7 +78,7 @@ Definition graph_w_comp_from_gen_alg : graph_w_comp :=
   tpair _ graph_from_gen_alg graph_from_gen_alg_comp.
 
 Definition id_op1 : @id_op graph_w_comp_from_gen_alg := 
-  λ c : C, tpair _ (dirprodpair c c) (identity c).
+  λ c : C, tpair _ (make_dirprod c c) (identity c).
 
 (** This proof should probably be transparent, since otherwise identity does not compute *)
 
@@ -196,7 +196,7 @@ Defined.
 Lemma is_precategory_precategory_data_from_ess_alg_cat : 
   is_precategory (precategory_data_from_ess_alg_cat).
 Proof.
-  use mk_is_precategory_one_assoc; intros.
+  use make_is_precategory_one_assoc; intros.
   - apply hom_eq. simpl. apply id_comp_l. 
     apply (pr1 (pr2 f)).
   - apply hom_eq, id_comp_r, (pr2 (pr2 f)).

--- a/TypeTheory/Csystems/lCsystems.v
+++ b/TypeTheory/Csystems/lCsystems.v
@@ -655,7 +655,7 @@ Proof.
   - red.
     intros Y X gt0 f.
     exact (s_sec_in_lC0system gt0 f (q_of_f_is_pb X Y gt0 f)).
-  - apply dirprodpair.
+  - apply make_dirprod.
     + red.
       intros Y X gt0 f.
       simpl.
@@ -682,7 +682,7 @@ Proof.
                   gt0
                   (f · q_of_f gt0 g)
                   (q_of_f_is_pb _ _ gt0 (f · q_of_f gt0 g)))).
-      apply dirprodpair.
+      apply make_dirprod.
       * apply (sec_pnX_eq (n:=1)).
       * assert (s_f_ok := pr2 (pr2 (iscontrpr1
           (s_pb_in_lC0system (C0ax5a gt0 g)

--- a/TypeTheory/Cubical/FillFromComp.v
+++ b/TypeTheory/Cubical/FillFromComp.v
@@ -153,7 +153,7 @@ Definition FF0 {I} : pr1 FF I : hSet := pr1 bot_FF I tt.
 (* The map that constantly returns FF1 *)
 Definition true : 1 --> FF.
 Proof.
-use mk_nat_trans.
+use make_nat_trans.
 + intros I _.
   exact (@FF1 I).
 + intros I J f; cbn.
@@ -205,7 +205,7 @@ Qed.
 (* Context restriction: Γ, φ |- *)
 Definition ctx_restrict (Γ : PreShv C) (φ : Γ --> FF) : PreShv C.
 Proof.
-use mk_functor.
+use make_functor.
 - use tpair.
   + simpl; intros I.
     exists (∑ ρ : pr1 ((pr1 Γ) I), pr1 φ I ρ = FF1).
@@ -231,7 +231,7 @@ Local Notation "Γ , φ" := (ctx_restrict Γ φ) (at level 30, format "Γ , φ")
 (* Canonical inclusion *)
 Definition ι {Γ : PreShv C} {φ : Γ --> FF} : Γ,φ --> Γ.
 Proof.
-use mk_nat_trans.
+use make_nat_trans.
 - simpl; intros I; cbn; apply pr1.
 - intros I J f; apply idpath.
 Defined.
@@ -247,7 +247,7 @@ Qed.
 
 Definition join_subst {Γ : PreShv C} (φ ψ : Γ --> FF) : Γ,φ --> Γ,(φ ∨ ψ).
 Proof.
-use mk_nat_trans.
+use make_nat_trans.
 - intros I ρ.
   exists (pr1 ρ).
   abstract (cbn; etrans; [apply maponpaths, (pathsdirprod (pr2 ρ) (idpath _))|];
@@ -260,7 +260,7 @@ Defined.
 Definition subst_restriction {Γ Δ : PreShv C} (σ : Δ --> Γ) (φ : Γ --> FF) :
   Δ,(σ · φ) --> Γ,φ.
 Proof.
-use mk_nat_trans.
+use make_nat_trans.
 + intros I u.
   apply (pr1 σ I (pr1 u),,pr2 u).
 + abstract (intros I J f; apply funextsec; intro ρ;
@@ -366,7 +366,7 @@ Definition p_PreShv (I : C) : yon (I+) --> yon I := # yon (p_F I).
 (* e₀ defines a natural map from yon(I) to yon(I+) *)
 Definition e₀_PreShv (I : C) : yon I --> yon (I +).
 Proof.
-use mk_nat_trans.
+use make_nat_trans.
 + intros J f.
   exact (f · e₀ I).
 + intros J K f.
@@ -375,7 +375,7 @@ Defined.
 
 Definition e₁_PreShv (I : C) : yon I --> yon (I +).
 Proof.
-use mk_nat_trans.
+use make_nat_trans.
 + intros J f.
   exact (f · e₁ I).
 + intros J K f.
@@ -384,7 +384,7 @@ Defined.
 
 Definition m_PreShv (I : C) : yon ((I +) +) --> yon (I+).
 Proof.
-use mk_nat_trans.
+use make_nat_trans.
 + intros J f.
   exact (f · m I).
 + intros J K f.
@@ -481,7 +481,7 @@ Definition box (I : C) (φ : yon I --> FF) : PreShv C :=
 Definition u_subst {I : C} (φ : yon I --> FF) : yon I,φ --> box I φ.
 Proof.
 assert (σ1 : yon(I),φ --> yon(I), (e₁_PreShv I · (p_PreShv I · φ))).
-{ use mk_nat_trans.
+{ use make_nat_trans.
   + intros J ρ.
     exists (pr1 ρ).
     abstract (rewrite <- (pr2 ρ); cbn; unfold yoneda_morphisms_data;
@@ -574,7 +574,7 @@ Definition box_subst {I J : C} (f : J --> I) (φ : yon I --> FF) :
 Proof.
 set (ψ := (p_PreShv I · φ ∨ δ₀ I) : yon (I+) --> FF).
 use (_ · subst_restriction (# yon (# F f)) ψ).
-use mk_nat_trans.
+use make_nat_trans.
 - intros K ρ'.
   exists (pr1 ρ').
   apply box_subst_prf.
@@ -612,7 +612,7 @@ Lemma box_b_subst {X Y : PreShv C} (α : X --> Y) (I : C) (φ : yon I --> FF)
 Proof.
 use (_ · subst_restriction (m_PreShv I) (b φ) · u).
 (* Make a special lemma for this? *)
-use mk_nat_trans.
+use make_nat_trans.
 - intros J XX.
   exists (pr1 XX).
   abstract (now rewrite m_b, (pr2 XX)).

--- a/TypeTheory/Initiality/Interpretation.v
+++ b/TypeTheory/Initiality/Interpretation.v
@@ -22,15 +22,15 @@ Section Auxiliary.
   (* TODO: work out better way to treat them? *)
   Definition mor_paths_hProp {C : category} {X Y : C} (f g : X --> Y)
     : hProp
-  := hProppair (f = g) (homset_property C _ _ _ _).
+  := make_hProp (f = g) (homset_property C _ _ _ _).
 
   Definition type_paths_hProp {C : split_typecat} {Γ : C} (A B : C Γ)
     : hProp
-  := hProppair (A = B) (isaset_types_typecat _ _ _).
+  := make_hProp (A = B) (isaset_types_typecat _ _ _).
 
   Definition tm_paths_hProp {C : split_typecat} {Γ : C} {A : C Γ} (s t : tm A)
     : hProp
-  := hProppair (s = t) (isaset_tm _ _).
+  := make_hProp (s = t) (isaset_tm _ _).
 
 End Auxiliary.
 
@@ -501,7 +501,7 @@ a little more work to state. *)
         (partial_interpretation_raw_context_map E
           (type_of ∘ E) (idmap_raw_context n)).
   Proof.
-    apply mk_leq_partial'; cbn; intros _.
+    apply make_leq_partial'; cbn; intros _.
     use tpair.
     - intros i; repeat constructor.
     - apply funextfun; intros i.
@@ -520,7 +520,7 @@ a little more work to state. *)
           (dB_Sn_rect _ B As)
           (add_to_raw_context_map f b)).
   Proof.
-    apply mk_leq_partial'; cbn; intros [f_def b_def].
+    apply make_leq_partial'; cbn; intros [f_def b_def].
     use tpair.
     - refine (dB_Sn_rect _ _ _); assumption.
     - apply funextfun. refine (dB_Sn_rect _ _ _); auto.
@@ -554,7 +554,7 @@ a little more work to state. *)
           (dB_Sn_rect _ (B ⦃dpr_typecat B⦄) (fun i => A i ⦃dpr_typecat B⦄))
           (weaken_raw_context_map f)).
   Proof.
-    apply mk_leq_partial'. cbn.
+    apply make_leq_partial'. cbn.
     intros fs_def.
     use tpair.
     - refine (dB_Sn_rect _ _ _).
@@ -673,7 +673,7 @@ a little more work to state. *)
   Proof.
     split.
     - intros ts_track.
-      apply mk_leq_partial'; cbn; intros _.
+      apply make_leq_partial'; cbn; intros _.
       use tpair.
       + intros i; apply ts_track.
       + cbn. apply funextfun; intros i.

--- a/TypeTheory/Initiality/SplitTypeCat_General.v
+++ b/TypeTheory/Initiality/SplitTypeCat_General.v
@@ -92,8 +92,8 @@ Section Terms.
 
   Definition ty (C : split_typecat) : PreShv C.
   Proof.
-    use mk_functor.
-    - use mk_functor_data.
+    use make_functor.
+    - use make_functor_data.
       + intros x.
         exists (ty_typecat C x).
         abstract (apply isaset_types_typecat).
@@ -161,7 +161,7 @@ Section Terms.
     : reind_tm f a ;; q_typecat A f = f ;; a.
   Proof.
     simpl.
-    set (pb := mk_Pullback _ _ _ _ _ _ _).
+    set (pb := make_Pullback _ _ _ _ _ _ _).
     now rewrite (PullbackArrow_PullbackPr2 pb).
   Qed.
 
@@ -230,7 +230,7 @@ Section Terms.
       = tm_transportb (reind_id_type_typecat _ _) a.
   Proof.
     apply subtypeEquality; [ intros x; apply homset_property|]; simpl.
-    set (pb := mk_Pullback _ _ _ _ _ _ _).
+    set (pb := make_Pullback _ _ _ _ _ _ _).
     (* Why is there a ' version of this lemma??? *)
     apply pathsinv0, (PullbackArrowUnique' _ _ pb).
     - rewrite <-assoc.
@@ -257,9 +257,9 @@ Section Terms.
           (reind_tm g (reind_tm f a)).
   Proof.
     apply subtypeEquality; [ intros x; apply homset_property|]; simpl.
-    set (pb := mk_Pullback _ _ _ _ _ _ _).
-    set (pb' := mk_Pullback _ _ _ _ _ _ _).
-    set (pb'' := mk_Pullback _ _ _ _ _ _ _).
+    set (pb := make_Pullback _ _ _ _ _ _ _).
+    set (pb' := make_Pullback _ _ _ _ _ _ _).
+    set (pb'' := make_Pullback _ _ _ _ _ _ _).
     apply pathsinv0, (PullbackArrowUnique' _ _ pb).
     - rewrite <- assoc.
       etrans; [eapply maponpaths, idtoiso_dpr_typecat|].
@@ -330,7 +330,7 @@ Section Terms.
     { apply (section_property (tm_transportb _ _)). }
     apply pathsinv0.
     etrans. { refine (postCompWithPullbackArrow _ _ _
-                                       (mk_Pullback _ _ _ _ _ _ _) _ _ _). }
+                                       (make_Pullback _ _ _ _ _ _ _) _ _ _). }
     apply pathsinv0, PullbackArrowUnique; cbn; refine (_ @ ! id_right _).
     - rewrite <- assoc.
       etrans. { apply maponpaths, dpr_q_typecat. }

--- a/TypeTheory/Initiality/SplitTypeCat_Maps.v
+++ b/TypeTheory/Initiality/SplitTypeCat_Maps.v
@@ -76,7 +76,7 @@ Definition typecat_mor_axioms
 Definition typecat_mor (C D : split_typecat) : UU
   := ∑ (F : typecat_mor_data C D), typecat_mor_axioms F.
 
-Definition mk_typecat_mor
+Definition make_typecat_mor
   {C D : split_typecat}
   (F : functor C D)
   (FTy : PreShv C ⟦ty C, functor_opp F ∙ ty D⟧)
@@ -166,7 +166,7 @@ Section Derived_Actions.
     reind_tm (# F f) (fmap_tm F a).
   Proof.
     apply paths_tm, PullbackArrowUnique; cbn; simpl;
-      set (pb := mk_Pullback _ _ _ _ _ _ _); rewrite <-!assoc.
+      set (pb := make_Pullback _ _ _ _ _ _ _); rewrite <-!assoc.
     - etrans; [apply maponpaths, maponpaths, comp_ext_compare_dpr_typecat|].
       etrans; [apply maponpaths, (!typecat_mor_triangle F (A ⦃f⦄))|].
       now rewrite <- functor_comp, (PullbackArrow_PullbackPr1 pb), functor_id.
@@ -182,7 +182,7 @@ Section Composition.
   Definition id_typecat (C : split_typecat)
     : typecat_mor C C.
   Proof.
-    use mk_typecat_mor.
+    use make_typecat_mor.
     - (* functor *)
       apply functor_identity.
     - (* naturality *)

--- a/TypeTheory/Initiality/SyntacticCategory.v
+++ b/TypeTheory/Initiality/SyntacticCategory.v
@@ -479,10 +479,10 @@ Section Contexts_Modulo_Equality.
   Definition context_mod_eq
   := ∑ (n:nat), context_of_length_mod_eq n.
 
-  Definition mk_context_mod_eq {n} (ΓΓ : context_of_length_mod_eq n)
+  Definition make_context_mod_eq {n} (ΓΓ : context_of_length_mod_eq n)
     : context_mod_eq
   := (n,,ΓΓ).
-  Coercion mk_context_mod_eq : context_of_length_mod_eq >-> context_mod_eq.
+  Coercion make_context_mod_eq : context_of_length_mod_eq >-> context_mod_eq.
 
   Local Definition length : context_mod_eq -> nat := pr1.
   Coercion length : context_mod_eq >-> nat.
@@ -733,11 +733,11 @@ Section Category.
     cbn. apply pathsinv0, assoc_raw_context.
   Qed.
 
-  (* TODO: issue to raise in UniMath: [mk_category] is constructor for a _univalent_ category! *)
+  (* TODO: issue to raise in UniMath: [make_category] is constructor for a _univalent_ category! *)
   Definition syntactic_category : category.
   Proof.
     use tpair.
-    - use mk_precategory_one_assoc.
+    - use make_precategory_one_assoc.
      + use ((context_mod_eq,,map_mod_eq),,_).
        exists idmap.
        intros Γ Δ Θ.
@@ -1101,7 +1101,7 @@ Section Split_Typecat.
            ff (dpr ΓΓ AA) (dpr ΓΓ' (reind AA ff)) (qmor AA ff)
            (! dpr_q AA ff).
   Proof.
-    use mk_isPullback; simpl.
+    use make_isPullback; simpl.
     intros ΓΓ'' gg hh Heq.
     use unique_exists; simpl.
     - admit.
@@ -1188,7 +1188,7 @@ Section Contextuality.
   (* TODO: opacify parts of this *)
   Lemma isTerminal_empty_context : isTerminal syntactic_typecat empty_context.
   Proof.
-    use mk_isTerminal.
+    use make_isTerminal.
     intros x.
     use tpair.
     - apply setquotpr.     

--- a/TypeTheory/Instances/Presheaves.v
+++ b/TypeTheory/Instances/Presheaves.v
@@ -230,7 +230,7 @@ Qed.
 (** Context extension: given a context Γ and a type Γ ⊢ A define Γ.A *)
 Definition ctx_ext {Γ : PreShv C} (A : Γ ⊢) : PreShv C.
 Proof.
-use mk_functor.
+use make_functor.
 - use tpair.
   + simpl; intros I.
     use total2_hSet.
@@ -263,7 +263,7 @@ Local Notation "Γ ⋆ A" := (@ctx_ext Γ A) (at level 30).
 (** Context projection *)
 Definition ctx_proj {Γ : PreShv C} {A : Γ ⊢} : Γ ⋆ A --> Γ.
 Proof.
-use mk_nat_trans.
+use make_nat_trans.
 - intros I X.
   apply (pr1 X).
 - now intros I J f; apply funextsec.
@@ -377,7 +377,7 @@ Qed.
 (** Pairing of substitutions *)
 Definition subst_pair {Γ Δ : PreShv C} {A : Γ ⊢} (σ : Δ --> Γ) (a : Δ ⊢ A⦃σ⦄) : Δ --> Γ ⋆ A.
 Proof.
-use mk_nat_trans.
+use make_nat_trans.
 - intros I ρ.
   apply (pr1 σ _ ρ,,pr1 a I ρ).
 - intros I J f.
@@ -508,7 +508,7 @@ Defined.
 (* Definition q' {Γ : PreShv C} (A : Γ ⊢) : TermInSection (A⦃@p Γ A⦄). *)
 (* Proof. *)
 (* mkpair. *)
-(* - use mk_nat_trans. *)
+(* - use make_nat_trans. *)
 (*   + intros I ρ. *)
 (*     exists ρ. *)
 (*     apply (pr2 ρ). *)
@@ -527,7 +527,7 @@ Defined.
 
 Definition p_gen {Γ Δ : PreShv C} {A : Δ ⊢} (σ : Δ --> Γ) : Δ ⋆ A --> Γ.
 Proof.
-use mk_nat_trans.
+use make_nat_trans.
 - intros I X.
   apply (pr1 σ _ (pr1 X)).
 - intros I J f; apply funextsec; intro ρ.

--- a/TypeTheory/OtherDefs/CwF_1.v
+++ b/TypeTheory/OtherDefs/CwF_1.v
@@ -707,7 +707,7 @@ Lemma is_pullback_reindx_cwf (hs : has_homsets CC) : ∏ (Γ : CC) (A : C⟨Γ�
    isPullback (π A) f (q_precwf A f) (π (A [[f]])) (dpr_q_precwf A f).
 Proof.
   intros.
-  apply mk_isPullback; try assumption.
+  apply make_isPullback; try assumption.
   intros e h k H.
   exists (dpr_q_pbpairing_precwf _ _ h k H).
   apply dpr_q_pbpairing_precwf_unique.

--- a/TypeTheory/OtherDefs/CwF_Pitts.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts.v
@@ -701,7 +701,7 @@ Lemma is_pullback_reindx_cwf (hs : has_homsets CC) : ∏ (Γ : CC) (A : C⟨Γ�
    isPullback (π A) f (q_precwf A f) (π (A {{f}})) (dpr_q_precwf A f).
 Proof.
   intros.
-  apply mk_isPullback; try assumption.
+  apply make_isPullback; try assumption.
   intros e h k H.
   exists (dpr_q_pbpairing_precwf _ _ h k H).
   apply dpr_q_pbpairing_precwf_unique.

--- a/TypeTheory/OtherDefs/CwF_Pitts_completion.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_completion.v
@@ -29,7 +29,7 @@ Definition Rezk_functor (C : precategory) (hs : has_homsets C) (D : univalent_ca
   :  functor (Rezk_completion C hs) D.
 Proof.
   set (H:=Rezk_eta_Universal_Property C hs D  (pr2 D)).
-  apply (invmap (weqpair _  H)).
+  apply (invmap (make_weq _  H)).
   apply F.
 Defined.
 
@@ -76,7 +76,7 @@ Proof.
   eapply weqcomp.
   - apply weqpathsinv0.
   - eapply weqcomp.
-    + apply (weqpair (@idtoiso C b a) (pr1 H b a)).
+    + apply (make_weq (@idtoiso C b a) (pr1 H b a)).
     + apply weq_opp_iso.
 Defined.
 
@@ -113,7 +113,7 @@ Context (CC : precategory) (C : cwf_struct CC).
     We thus obtain a "type" functor on RC(C) by univ property
 **)
 
-Definition type_hSet (Γ : CC) : hSet := hSetpair (C⟨Γ⟩) (cwf_types_isaset _ _ ). 
+Definition type_hSet (Γ : CC) : hSet := make_hSet (C⟨Γ⟩) (cwf_types_isaset _ _ ). 
 
 Definition type_functor_data : functor_data CC (opp_precat HSET).
 Proof.

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_CwF_1.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_CwF_1.v
@@ -39,7 +39,7 @@ Section fix_a_precategory.
   Definition type_functor : functor C^op HSET.
   Proof.
     refine (tpair _ _ _ ).
-    - exists (fun Γ => hSetpair
+    - exists (fun Γ => make_hSet
                          (CwF.type CC Γ)
                          (CwF.cwf_types_isaset CC Γ) ).
       simpl.
@@ -73,7 +73,7 @@ Section fix_a_precategory.
           exact (CwF.proj_mor  A).
       + simpl.
         intros Γ A; simpl in *.
-        refine (dirprodpair _ _ ).
+        refine (make_dirprod _ _ ).
         * apply (CwF.gen_elem  _ ).
         * intros Γ' γ a.
           apply (CwF.pairing γ a ).

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_DM.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_DM.v
@@ -80,7 +80,7 @@ Proof.
   }
   unfold DM_type in B. simpl in *.
   unfold dm_sub_struct_of_CwF in B.
-  set (T:= hProppair _ X).
+  set (T:= make_hProp _ X).
   set (T':= B T).
   apply T'.
   unfold T; simpl;
@@ -90,7 +90,7 @@ Proof.
   destruct T as [A [h e]].
   clear B.
   unshelve refine (tpair _ _ _ ).
-  - unshelve refine (mk_Pullback _ _ _ _ _ _ _ ).
+  - unshelve refine (make_Pullback _ _ _ _ _ _ _ ).
     + apply (Γ' ∙ (A{{f}})).
     + apply (q_precwf _ _ ;; h).
     + apply (π _ ). 

--- a/TypeTheory/OtherDefs/DM_to_TypeCat_to_DM.v
+++ b/TypeTheory/OtherDefs/DM_to_TypeCat_to_DM.v
@@ -35,7 +35,7 @@ Proof.
     unfold DM_type in X. simpl in *.
     unfold dm_sub_struct_of_TypeCat in X; simpl in X.
     unfold type_cat_struct_from_DM in X. simpl in *.
-    set (X' := hProppair (DM_type C f) (pr2 (pr2 C) _ _ _ )).
+    set (X' := make_hProp (DM_type C f) (pr2 (pr2 C) _ _ _ )).
     apply (X X'). unfold X'; clear X' X.
     intro T. simpl in *.
     unfold iso_to_dpr in T. simpl.

--- a/TypeTheory/OtherDefs/TypeCat_to_DM.v
+++ b/TypeTheory/OtherDefs/TypeCat_to_DM.v
@@ -67,7 +67,7 @@ Proof.
   }
   unfold DM_type in B. simpl in *.
   unfold dm_sub_struct_of_TypeCat in B.
-  set (T:= hProppair _ X).
+  set (T:= make_hProp _ X).
   set (T':= B T).
   apply T'.
   unfold T; simpl;
@@ -77,7 +77,7 @@ Proof.
   destruct T as [A [h e]].
   clear B.
   unshelve refine (tpair _ _ _ ).
-  - unshelve refine (mk_Pullback _ _ _ _ _ _ _ ).
+  - unshelve refine (make_Pullback _ _ _ _ _ _ _ ).
     + apply (Γ' ◂ (A{{f}})).
     + apply (q_typecat _ _ ;; h).
     + apply (dpr_typecat _ ).


### PR DESCRIPTION
This solves issue https://github.com/UniMath/TypeTheory/issues/155. I have used the following script:
```
#!/bin/bash

declare -A words

words[hProppair]=make_hProp
words[dirprodpair]=make_dirprod
words[weqpair]=make_weq
words[isopair]=make_iso
words[ringisopair]=make_ringiso
words[mk_isPullback]=make_isPullback
words[mk_Pullback]=make_Pullback
words[mk_cone]=make_cone
words[mk_is_precategory_one_assoc]=make_is_precategory_one_assoc
words[mk_functor]=make_functor
words[hSetpair]=make_hSet
words[mk_nat_trans]=make_nat_trans
words[mk_precategory_one_assoc]=make_precategory_one_assoc
words[mk_isTerminal]=make_isTerminal
words[mk_typecat_mor]=make_typecat_mor
words[mk_lax_functor_square]=make_lax_functor_square
words[mk_leq_partial\']=make_leq_partial\'
words[mk_context_mod_eq]=make_context_mod_eq
words[mk_category]=make_category

for w in ${!words[@]}; do
  echo $w '->' ${words[$w]}
  find -name *.v -exec bash ./sed_replace.sh {} "$w" "${words[$w]}" \;
done
```
and sed_replace.sh is
```
set -e
sed "s/$2/$3/g" "$1" > "$1".tmp
mv "$1".tmp "$1"
```