### PR TITLE
ALV2 Commuting square of transfer constructions

### DIFF
--- a/TypeTheory/ALV1/RelativeUniverses.v
+++ b/TypeTheory/ALV1/RelativeUniverses.v
@@ -984,7 +984,7 @@ Section Weak_RelU_Comm_Square.
       apply impred. intros c'.
       apply impred. intros d'.
       apply isapropishinh.
-  Qed.
+  Defined.
 
 End Weak_RelU_Comm_Square.
 

--- a/TypeTheory/ALV1/RelativeUniverses.v
+++ b/TypeTheory/ALV1/RelativeUniverses.v
@@ -970,6 +970,25 @@ Definition weq_weak_relative_universe_transfer
 : weak_relative_universe J ≃ weak_relative_universe J'
 := make_weq _ (isweq_weak_relative_universe_transfer R_full isD isD' T eta eps S_ff).
 
+Section Weak_RelU_Comm_Square.
+
+  Definition weak_relu_comm_square
+  : ∏ (u : relative_universe J),
+    weak_from_relative_universe J' (transfer_of_rel_univ_with_ess_surj _ u _ _ _ _ is_iso_α S_pb R_es C'_sat J'_ff S_full)
+    = weak_relative_universe_transfer (weak_from_relative_universe J u).
+  Proof.
+    intros u.
+    use total2_paths_f.
+    - apply idpath.
+    - apply proofirrelevance.
+      apply impred. intros c'.
+      apply impred. intros d'.
+      apply isapropishinh.
+  Qed.
+
+End Weak_RelU_Comm_Square.
+
+
 End Is_universe_relative_to_Transfer.
 
 

--- a/TypeTheory/ALV2/RelUnivTransfer.v
+++ b/TypeTheory/ALV2/RelUnivTransfer.v
@@ -455,6 +455,90 @@ Section WeakRelUniv_Transfer.
     - apply weq_weak_relative_universe_transfer.
   Defined.
 
+  Local Definition relu_J_to_relu_J'
+        (C'_univ : is_univalent C')
+    : functor (reluniv_cat J) (reluniv_cat J')
+    := reluniv_functor_with_ess_surj
+         _ _ _ _ _ _ _ _ _ α_is_iso
+         S_pb C'_univ ff_J' S_full R_es.
+
+  Definition weak_relu_Rezk_square_commutes_on_mor
+        (C'_univ : is_univalent C')
+        (u1 u2 : reluniv_cat J)
+        (mor : reluniv_cat J ⟦ u1, u2 ⟧)
+    : pr21 (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J') u1 u2 mor
+    = pr21 (weak_from_reluniv_functor J ∙ weak_reluniv_functor) u1 u2 mor.
+  Proof.
+    use gen_reluniv_mor_eq.
+    - apply idpath.
+    - apply idpath.
+  Defined.
+
+  Definition weak_relu_Rezk_square_commutes
+        (C'_univ : is_univalent C')
+    : relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J'
+      = weak_from_reluniv_functor J ∙ weak_reluniv_functor.
+  Proof.
+    set (e := weak_relu_comm_square
+                J J' R S α α_is_iso S_pb R_es
+                C'_univ ff_J' S_full R_full
+                Dcat D'cat T η ε S_ff).
+    use total2_paths_f.
+    - use total2_paths_f.
+      + apply funextsec. use e. 
+      + etrans. use transportf_forall. apply funextsec. intros u1.
+        etrans. use transportf_forall. apply funextsec. intros u2.
+        etrans. use transportf_forall. apply funextsec. intros mor.
+
+        (* STUCK HERE *)
+        (* This should be straightforward,
+           but for some reason I fail to see the proof
+           Below are some of my attempts.
+        *)
+        
+        Search (transportf (λ (x : ?A), ?B x) ?e ?p = ?q).
+        use gen_reluniv_mor_eq.
+        * unfold F_Ũ, weak_from_reluniv_mor, reluniv_mor_J_to_J'_with_ess_surj. simpl.
+          
+        Search transportf.
+        set (A := reluniv_cat J → weak_reluniv_cat J').
+        set (B := λ (x : A), gen_reluniv_mor_data J' is_universe_relative_to (x u1) (x u2)).
+        apply (transportf_set B).
+        set (f := λ (x : reluniv_cat J → weak_reluniv_cat J'),
+                  _).
+        set (e' :=
+                (funextsec
+                (λ _ : reluniv_cat J, weak_reluniv_cat J')
+                (pr11 (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J'))
+                (pr11 (weak_from_reluniv_functor J ∙ weak_reluniv_functor)) e)).
+        apply (transport_section f e').
+        use gen_reluniv_mor_eq.
+        * 
+          set (P := λ (x : A) (mor : B x), is_gen_reluniv_mor J' is_universe_relative_to mor).
+
+
+          etrans.
+          set (xs := (((pr21 (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J')) u1 u2 mor) : ∑ (b : B _), P _ b)).
+          Locate "⟦".
+          unfold precategory_morphisms.
+          simpl.
+          unfold gen_reluniv_mor.
+          unfold F_Ũ.
+          
+          apply (pr1_transportf A B P _ _ e' xs).
+
+          Search transportf.
+          apply idpath.
+        use total2_paths_f.
+        * use total2_paths_f.
+          -- simpl. unfold weak_from_reluniv_mor. simpl. apply idpath.
+    apply funextsec2. intro.
+    simpl. unfold weak_from_relative_universe, transfer_of_rel_univ_with_ess_surj, weak_relative_universe_transfer. . apply idpath.
+    unfold relu_J_to_relu_J', weak_from_reluniv_functor, weak_reluniv_functor.
+    unfold functor_composite.
+    simpl.
+  Qed.
+
 End WeakRelUniv_Transfer.
 
 Section RelUniv_Yo_Rezk.

--- a/TypeTheory/ALV2/RelUnivTransfer.v
+++ b/TypeTheory/ALV2/RelUnivTransfer.v
@@ -476,19 +476,78 @@ Section WeakRelUniv_Transfer.
 
   Definition weak_relu_Rezk_square_commutes
         (C'_univ : is_univalent C')
+    : nat_iso
+        (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J')
+        (weak_from_reluniv_functor J ∙ weak_reluniv_functor).
+  Proof.
+    use tpair.
+    - use tpair.
+      + intros u.
+        use idtoiso.
+        apply (weak_relu_comm_square
+                J J' R S α α_is_iso S_pb R_es
+                C'_univ ff_J' S_full).
+      + intros u1 u2 mor.
+        etrans. apply idtoiso_postcompose.
+        simpl.
+        etrans. apply pathsinv0.
+        apply idtoiso_precompose.
+        Check idtoiso_precompose.
+        Check idtoiso_postcompose.
+  Defined.
+
+  Definition weak_relu_Rezk_square_commutes
+        (C'_univ : is_univalent C')
     : relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J'
       = weak_from_reluniv_functor J ∙ weak_reluniv_functor.
   Proof.
     set (e := weak_relu_comm_square
                 J J' R S α α_is_iso S_pb R_es
-                C'_univ ff_J' S_full R_full
-                Dcat D'cat T η ε S_ff).
+                C'_univ ff_J' S_full).
     use total2_paths_f.
     - use total2_paths_f.
       + apply funextsec. use e. 
       + etrans. use transportf_forall. apply funextsec. intros u1.
         etrans. use transportf_forall. apply funextsec. intros u2.
-        etrans. use transportf_forall. apply funextsec. intros mor.
+        etrans.
+          set (A := reluniv_cat J → weak_reluniv_cat J').
+          set (B := λ (x : A), gen_reluniv_mor_data J' is_universe_relative_to (x u1) (x u2)).
+          set (P := λ (x : A) (mor : B x), is_gen_reluniv_mor J' is_universe_relative_to mor).
+          set (BP := λ (x : A), ∑ mor0 : gen_reluniv_mor_data J' is_universe_relative_to (x u1) (x u2), is_gen_reluniv_mor J' is_universe_relative_to mor0).
+          etrans.
+        Check @transportf_funextfun.
+        Check (transportf_funextfun _ _ _ e u1 _).
+          use transportf_forall. apply funextsec. intros mor.
+
+        use gen_reluniv_mor_eq.
+        * etrans. unfold RelUniv_Cat_Simple.F_Ũ.
+          unfold weak_reluniv_cat.
+          unfold gen_reluniv_mor.
+          simpl.
+          unfold gen_reluniv_mor.
+          apply maponpaths.
+          Check (transportf_funextfun).
+
+
+       set (e' := (funextsec
+          (λ _ : ∑ X : mor_total D, rel_universe_structure J X,
+           ∑ X : mor_total D', is_universe_relative_to J' X)
+          (λ a : ∑ X : mor_total D, rel_universe_structure J X,
+           weak_from_relative_universe J'
+             (transfer_of_rel_univ_with_ess_surj J a J' R S α α_is_iso S_pb
+                R_es C'_univ ff_J' S_full))
+          (λ a : ∑ X : mor_total D, rel_universe_structure J X,
+           weak_relative_universe_transfer J J' R S α α_is_iso S_pb R_es
+             S_full (weak_from_relative_universe J a)) e)).
+       set (xs := weak_from_reluniv_mor J'
+          (transfer_of_rel_univ_with_ess_surj J u1 J' R S α α_is_iso S_pb
+             R_es C'_univ ff_J' S_full)
+          (transfer_of_rel_univ_with_ess_surj J u2 J' R S α α_is_iso S_pb
+             R_es C'_univ ff_J' S_full)
+          (reluniv_mor_J_to_J'_with_ess_surj C D C' D' J J' R S α α_is_iso
+             S_pb C'_univ ff_J' S_full R_es u1 u2 mor)).
+          Check (pr1_transportf A B P).
+          apply (pr1_transportf A B P).
 
         (* STUCK HERE *)
         (* This should be straightforward,
@@ -497,7 +556,6 @@ Section WeakRelUniv_Transfer.
         *)
         
         Search (transportf (λ (x : ?A), ?B x) ?e ?p = ?q).
-        use gen_reluniv_mor_eq.
         * unfold F_Ũ, weak_from_reluniv_mor, reluniv_mor_J_to_J'_with_ess_surj. simpl.
           
         Search transportf.

--- a/TypeTheory/ALV2/RelUnivTransfer.v
+++ b/TypeTheory/ALV2/RelUnivTransfer.v
@@ -474,6 +474,46 @@ Section WeakRelUniv_Transfer.
     - apply idpath.
   Defined.
 
+  Definition weak_relu_Rezk_square_nat_trans
+        (C'_univ : is_univalent C')
+    : nat_trans
+        (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J')
+        (weak_from_reluniv_functor J ∙ weak_reluniv_functor).
+  Proof.
+    use tpair.
+    + intros u.
+      use tpair.
+      * use tpair.
+        -- apply identity.
+        -- apply identity.
+      * unfold is_gen_reluniv_mor.
+        cbn.
+        etrans. apply id_left.
+        apply pathsinv0, id_right.
+    + intros u1 u2 mor.
+      use gen_reluniv_mor_eq.
+      * simpl.
+        etrans. apply id_right.
+        apply pathsinv0, id_left.
+      * simpl.
+        etrans. apply id_right.
+        apply pathsinv0, id_left.
+  Defined.
+
+  Definition weak_relu_Rezk_square_nat_trans_is_nat_iso
+        (C'_univ : is_univalent C')
+    : is_nat_iso (weak_relu_Rezk_square_nat_trans C'_univ).
+  Proof.
+    intros u1 wu1.
+    use isweq_iso.
+    - intros mor.
+      apply mor.
+    - intros mor.
+      use id_left. (* FIXME: works, but slow for some reason *)
+    - intros mor.
+      use id_left. (* FIXME: works, but slow for some reason *)
+  Defined.
+    
   Definition weak_relu_Rezk_square_commutes
         (C'_univ : is_univalent C')
     : nat_iso
@@ -481,121 +521,9 @@ Section WeakRelUniv_Transfer.
         (weak_from_reluniv_functor J ∙ weak_reluniv_functor).
   Proof.
     use tpair.
-    - use tpair.
-      + intros u.
-        use idtoiso.
-        apply (weak_relu_comm_square
-                J J' R S α α_is_iso S_pb R_es
-                C'_univ ff_J' S_full).
-      + intros u1 u2 mor.
-        etrans. apply idtoiso_postcompose.
-        simpl.
-        etrans. apply pathsinv0.
-        apply idtoiso_precompose.
-        Check idtoiso_precompose.
-        Check idtoiso_postcompose.
+    - apply weak_relu_Rezk_square_nat_trans.
+    - apply weak_relu_Rezk_square_nat_trans_is_nat_iso.
   Defined.
-
-  Definition weak_relu_Rezk_square_commutes
-        (C'_univ : is_univalent C')
-    : relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J'
-      = weak_from_reluniv_functor J ∙ weak_reluniv_functor.
-  Proof.
-    set (e := weak_relu_comm_square
-                J J' R S α α_is_iso S_pb R_es
-                C'_univ ff_J' S_full).
-    use total2_paths_f.
-    - use total2_paths_f.
-      + apply funextsec. use e. 
-      + etrans. use transportf_forall. apply funextsec. intros u1.
-        etrans. use transportf_forall. apply funextsec. intros u2.
-        etrans.
-          set (A := reluniv_cat J → weak_reluniv_cat J').
-          set (B := λ (x : A), gen_reluniv_mor_data J' is_universe_relative_to (x u1) (x u2)).
-          set (P := λ (x : A) (mor : B x), is_gen_reluniv_mor J' is_universe_relative_to mor).
-          set (BP := λ (x : A), ∑ mor0 : gen_reluniv_mor_data J' is_universe_relative_to (x u1) (x u2), is_gen_reluniv_mor J' is_universe_relative_to mor0).
-          etrans.
-        Check @transportf_funextfun.
-        Check (transportf_funextfun _ _ _ e u1 _).
-          use transportf_forall. apply funextsec. intros mor.
-
-        use gen_reluniv_mor_eq.
-        * etrans. unfold RelUniv_Cat_Simple.F_Ũ.
-          unfold weak_reluniv_cat.
-          unfold gen_reluniv_mor.
-          simpl.
-          unfold gen_reluniv_mor.
-          apply maponpaths.
-          Check (transportf_funextfun).
-
-
-       set (e' := (funextsec
-          (λ _ : ∑ X : mor_total D, rel_universe_structure J X,
-           ∑ X : mor_total D', is_universe_relative_to J' X)
-          (λ a : ∑ X : mor_total D, rel_universe_structure J X,
-           weak_from_relative_universe J'
-             (transfer_of_rel_univ_with_ess_surj J a J' R S α α_is_iso S_pb
-                R_es C'_univ ff_J' S_full))
-          (λ a : ∑ X : mor_total D, rel_universe_structure J X,
-           weak_relative_universe_transfer J J' R S α α_is_iso S_pb R_es
-             S_full (weak_from_relative_universe J a)) e)).
-       set (xs := weak_from_reluniv_mor J'
-          (transfer_of_rel_univ_with_ess_surj J u1 J' R S α α_is_iso S_pb
-             R_es C'_univ ff_J' S_full)
-          (transfer_of_rel_univ_with_ess_surj J u2 J' R S α α_is_iso S_pb
-             R_es C'_univ ff_J' S_full)
-          (reluniv_mor_J_to_J'_with_ess_surj C D C' D' J J' R S α α_is_iso
-             S_pb C'_univ ff_J' S_full R_es u1 u2 mor)).
-          Check (pr1_transportf A B P).
-          apply (pr1_transportf A B P).
-
-        (* STUCK HERE *)
-        (* This should be straightforward,
-           but for some reason I fail to see the proof
-           Below are some of my attempts.
-        *)
-        
-        Search (transportf (λ (x : ?A), ?B x) ?e ?p = ?q).
-        * unfold F_Ũ, weak_from_reluniv_mor, reluniv_mor_J_to_J'_with_ess_surj. simpl.
-          
-        Search transportf.
-        set (A := reluniv_cat J → weak_reluniv_cat J').
-        set (B := λ (x : A), gen_reluniv_mor_data J' is_universe_relative_to (x u1) (x u2)).
-        apply (transportf_set B).
-        set (f := λ (x : reluniv_cat J → weak_reluniv_cat J'),
-                  _).
-        set (e' :=
-                (funextsec
-                (λ _ : reluniv_cat J, weak_reluniv_cat J')
-                (pr11 (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J'))
-                (pr11 (weak_from_reluniv_functor J ∙ weak_reluniv_functor)) e)).
-        apply (transport_section f e').
-        use gen_reluniv_mor_eq.
-        * 
-          set (P := λ (x : A) (mor : B x), is_gen_reluniv_mor J' is_universe_relative_to mor).
-
-
-          etrans.
-          set (xs := (((pr21 (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J')) u1 u2 mor) : ∑ (b : B _), P _ b)).
-          Locate "⟦".
-          unfold precategory_morphisms.
-          simpl.
-          unfold gen_reluniv_mor.
-          unfold F_Ũ.
-          
-          apply (pr1_transportf A B P _ _ e' xs).
-
-          Search transportf.
-          apply idpath.
-        use total2_paths_f.
-        * use total2_paths_f.
-          -- simpl. unfold weak_from_reluniv_mor. simpl. apply idpath.
-    apply funextsec2. intro.
-    simpl. unfold weak_from_relative_universe, transfer_of_rel_univ_with_ess_surj, weak_relative_universe_transfer. . apply idpath.
-    unfold relu_J_to_relu_J', weak_from_reluniv_functor, weak_reluniv_functor.
-    unfold functor_composite.
-    simpl.
-  Qed.
 
 End WeakRelUniv_Transfer.
 

--- a/TypeTheory/ALV2/RelUnivTransfer.v
+++ b/TypeTheory/ALV2/RelUnivTransfer.v
@@ -525,6 +525,18 @@ Section WeakRelUniv_Transfer.
     - apply weak_relu_Rezk_square_nat_trans_is_nat_iso.
   Defined.
 
+  Definition weak_relu_Rezk_square_commutes_strictly
+             (C'_univ : is_univalent C')
+    : (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J')
+        = (weak_from_reluniv_functor J ∙ weak_reluniv_functor).
+  Proof.
+    use (isotoid _ (is_univalent_functor_category _ _ _)).
+    apply weak_reluniv_cat_is_univalent.
+    apply D'cat.
+    apply nat_iso_to_iso.
+    apply weak_relu_Rezk_square_commutes.
+  Defined.
+
 End WeakRelUniv_Transfer.
 
 Section RelUniv_Yo_Rezk.

--- a/TypeTheory/ALV2/RelUnivTransfer.v
+++ b/TypeTheory/ALV2/RelUnivTransfer.v
@@ -373,15 +373,19 @@ Section WeakRelUniv_Transfer.
   Context (T : functor D' D).
   Context (η : iso (C := [D, D, pr2 D]) (functor_identity D) (S ∙ T)).
   Context (ε : iso (C := [D', D', pr2 D']) (T ∙ S) (functor_identity D')).
-  Context (S_ff : fully_faithful S).
+  Context (S_full : full S).
+  Context (S_faithful : faithful S).
 
   (* R is essentially surjective and full *)
   Context (R_es : essentially_surjective R).
   Context (R_full : full R).
 
-  Local Definition S_full : full S.
+  Local Definition S_ff : fully_faithful S.
   Proof.
-    apply fully_faithful_implies_full_and_faithful, S_ff.
+    use full_and_faithful_implies_fully_faithful.
+    use make_dirprod.
+    - apply S_full.
+    - apply S_faithful.
   Defined.
 
   Let weq_weak_reluniv
@@ -462,7 +466,7 @@ Section WeakRelUniv_Transfer.
          _ _ _ _ _ _ _ _ _ α_is_iso
          S_pb C'_univ ff_J' S_full R_es.
 
-  Definition weak_relu_Rezk_square_commutes_on_mor
+  Definition weak_relu_square_commutes_on_mor
         (C'_univ : is_univalent C')
         (u1 u2 : reluniv_cat J)
         (mor : reluniv_cat J ⟦ u1, u2 ⟧)
@@ -474,7 +478,7 @@ Section WeakRelUniv_Transfer.
     - apply idpath.
   Defined.
 
-  Definition weak_relu_Rezk_square_nat_trans
+  Definition weak_relu_square_nat_trans
         (C'_univ : is_univalent C')
     : nat_trans
         (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J')
@@ -500,9 +504,9 @@ Section WeakRelUniv_Transfer.
         apply pathsinv0, id_left.
   Defined.
 
-  Definition weak_relu_Rezk_square_nat_trans_is_nat_iso
+  Definition weak_relu_square_nat_trans_is_nat_iso
         (C'_univ : is_univalent C')
-    : is_nat_iso (weak_relu_Rezk_square_nat_trans C'_univ).
+    : is_nat_iso (weak_relu_square_nat_trans C'_univ).
   Proof.
     intros u1 wu1.
     use isweq_iso.
@@ -514,18 +518,18 @@ Section WeakRelUniv_Transfer.
       use id_left. (* FIXME: works, but slow for some reason *)
   Defined.
     
-  Definition weak_relu_Rezk_square_commutes
+  Definition weak_relu_square_commutes
         (C'_univ : is_univalent C')
     : nat_iso
         (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J')
         (weak_from_reluniv_functor J ∙ weak_reluniv_functor).
   Proof.
     use tpair.
-    - apply weak_relu_Rezk_square_nat_trans.
-    - apply weak_relu_Rezk_square_nat_trans_is_nat_iso.
+    - apply weak_relu_square_nat_trans.
+    - apply weak_relu_square_nat_trans_is_nat_iso.
   Defined.
 
-  Definition weak_relu_Rezk_square_commutes_strictly
+  Definition weak_relu_square_commutes_strictly
              (C'_univ : is_univalent C')
     : (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J')
         = (weak_from_reluniv_functor J ∙ weak_reluniv_functor).
@@ -533,8 +537,8 @@ Section WeakRelUniv_Transfer.
     use (isotoid _ (is_univalent_functor_category _ _ _)).
     apply weak_reluniv_cat_is_univalent.
     apply D'cat.
-    apply nat_iso_to_iso.
-    apply weak_relu_Rezk_square_commutes.
+    use nat_iso_to_iso.
+    apply weak_relu_square_commutes.
   Defined.
 
 End WeakRelUniv_Transfer.
@@ -550,6 +554,11 @@ Section RelUniv_Yo_Rezk.
   Let S := Transport_along_Equivs.ext R R_ff R_es.
   Let S_pb := Transport_along_Equivs.preserves_pullbacks_ext R R_ff R_es.
   Let α := Transport_along_Equivs.fi R R_ff R_es.
+
+  Local Definition R_full : full R.
+  Proof.
+    apply fully_faithful_implies_full_and_faithful, R_ff.
+  Defined.
 
   Definition transfer_of_RelUnivYoneda_functor
     : functor (@reluniv_cat C _ Yo) (@reluniv_cat RC _ Yo).
@@ -591,15 +600,24 @@ Section RelUniv_Yo_Rezk.
         ).
     - apply epsinv.
     - apply etainv.
-    - apply right_adj_equiv_is_ff.
+    - apply right_adj_equiv_is_full.
+    - apply fully_faithful_implies_full_and_faithful.
+      apply right_adj_equiv_is_ff.
     - apply R_es.
-    - apply fully_faithful_implies_full_and_faithful, R_ff.
+    - apply R_full.
   Defined.
 
   Definition transfer_of_WeakRelUnivYoneda_functor_is_catiso
     : is_catiso transfer_of_WeakRelUnivYoneda_functor.
   Proof.
     apply weak_reluniv_functor_is_catiso.
+  Defined.
+
+  Definition WeakRelUnivYoneda_functor_square_commutes_strictly
+    : (transfer_of_RelUnivYoneda_functor ∙ weak_from_reluniv_functor _)
+        = (weak_from_reluniv_functor _ ∙ transfer_of_WeakRelUnivYoneda_functor).
+  Proof.
+    apply weak_relu_square_commutes_strictly.
   Defined.
 
 End RelUniv_Yo_Rezk.

--- a/TypeTheory/ALV2/RelUniv_Cat_Simple.v
+++ b/TypeTheory/ALV2/RelUniv_Cat_Simple.v
@@ -198,6 +198,9 @@ End RelUniv_Cat_Simple.
     Definition weak_reluniv_cat : category
       := gen_reluniv_cat is_universe_relative_to.
 
+
+Section WeakRelUniv_is_univalent.
+
     Definition is_weak_reluniv_ob
       : arrow_category D → hProp.
     Proof.
@@ -212,77 +215,74 @@ End RelUniv_Cat_Simple.
         apply isapropishinh.
     Defined.
 
-    Definition weak_reluniv_to_arrow
-      : weak_reluniv_cat → arrow_category D.
+    Definition weak_reluniv_subcat : category
+      := subcategory _ (full_sub_precategory is_weak_reluniv_ob).
+
+    Definition weak_reluniv_cat_subcat_weq_ob
+      : ob weak_reluniv_cat ≃ ob weak_reluniv_subcat.
     Proof.
-      intros u.
-      set (b := pr1 (pr1 (pr1 u))).
-      set (a := dirprod_pr2 (pr1 (pr1 u))).
-      set (f := pr2 (pr1 u)).
-      apply ((a,b),,f).
+      use weq_iso.
+      - intros u.
+        set (b := pr1 (pr1 (pr1 u))).
+        set (a := dirprod_pr2 (pr1 (pr1 u))).
+        set (f := pr2 (pr1 u)).
+        set (comm := pr2 u).
+        apply (((a,b),,f),,comm).
+      - intros ff.
+        set (a := pr1 (pr1 (pr1 ff))).
+        set (b := dirprod_pr2 (pr1 (pr1 ff))).
+        set (f := pr2 (pr1 ff)).
+        set (comm := pr2 ff).
+        apply (((b,a),,f),,comm).
+      - intros u. apply idpath.
+      - intros u. apply idpath.
     Defined.
 
-    Definition arrow_to_weak_reluniv
-      : (∑ f : arrow_category D, is_weak_reluniv_ob f) → weak_reluniv_cat.
-    Proof.
-      intros ff.
-      set (a := pr1 (pr1 (pr1 ff))).
-      set (b := dirprod_pr2 (pr1 (pr1 ff))).
-      set (f := pr2 (pr1 ff)).
-      set (comm := pr2 ff).
-      apply (((b,a),,f),,comm).
-    Defined.
-
-    Definition weak_reluniv_mor_to_arrow
+    Definition weak_reluniv_cat_subcat_weq_mor
                (u1 u2 : weak_reluniv_cat)
       : weak_reluniv_cat ⟦ u1, u2 ⟧
-        → arrow_category D ⟦ weak_reluniv_to_arrow u1
-                             , weak_reluniv_to_arrow u2 ⟧.
+          ≃ weak_reluniv_subcat
+            ⟦ weak_reluniv_cat_subcat_weq_ob u1,
+              weak_reluniv_cat_subcat_weq_ob u2 ⟧.
     Proof.
-      intros mor.
-      set (b_to_d := pr1 (pr1 mor)).
-      set (a_to_c := dirprod_pr2 (pr1 mor)).
-      set (comm_square := pr2 mor).
-      use tpair.
-      - use make_dirprod.
-        + apply b_to_d.
-        + apply a_to_c.
-      - apply pathsinv0, comm_square.
-    Defined.
-
-    Definition arrow_to_weak_reluniv_mor
-               (u1 u2 : weak_reluniv_cat)
-      : arrow_category D ⟦ weak_reluniv_to_arrow u1
-                           , weak_reluniv_to_arrow u2 ⟧
-        → weak_reluniv_cat ⟦ u1, u2 ⟧.
-    Proof.
-      intros mor.
-      set (b_to_d := pr1 (pr1 mor)).
-      set (a_to_c := dirprod_pr2 (pr1 mor)).
-      set (comm_square := pr2 mor).
-      use tpair.
-      - use make_dirprod.
-        + apply b_to_d.
-        + apply a_to_c.
-      - apply pathsinv0, comm_square.
+      use weq_iso.
+      - intros mor.
+        set (b_to_d := pr1 (pr1 mor)).
+        set (a_to_c := dirprod_pr2 (pr1 mor)).
+        set (comm_square := pr2 mor).
+        use (tpair _ _ tt).
+        use tpair.
+        + apply (make_dirprod b_to_d a_to_c).
+        + apply pathsinv0, comm_square.
+      - intros mor.
+        set (b_to_d := pr1 (pr1 (pr1 mor))).
+        set (a_to_c := dirprod_pr2 (pr1 (pr1 mor))).
+        set (comm_square := pr2 (pr1 mor)).
+        use tpair.
+        + use make_dirprod.
+            * apply b_to_d.
+            * apply a_to_c.
+        + apply pathsinv0, comm_square.
+      - intros mor.
+        use gen_reluniv_mor_eq.
+        + apply idpath.
+        + apply idpath.
+      - intros mor.
+        use total2_paths_f.
+        + use arrow_category_mor_eq.
+          * apply idpath.
+          * apply idpath.
+        + apply isapropunit.
     Defined.
 
     Definition weak_reluniv_cat_to_full_subcat
-      : catiso weak_reluniv_cat
-               (carrier_of_sub_precategory
-                  _ (full_sub_precategory is_weak_reluniv_ob)).
+      : catiso weak_reluniv_cat weak_reluniv_subcat.
     Proof.
       use tpair.
       - use make_functor.
         + use make_functor_data.
-          * intros u.
-            use tpair.
-            -- apply (weak_reluniv_to_arrow u).
-            -- apply (pr2 u).
-          * intros u1 u2 mor.
-            use tpair.
-            -- apply (weak_reluniv_mor_to_arrow _ _ mor).
-            -- apply tt.
+          * apply weak_reluniv_cat_subcat_weq_ob.
+          * apply weak_reluniv_cat_subcat_weq_mor.
         + use tpair.
           * intros u.
             use dirprod_paths.
@@ -298,23 +298,8 @@ End RelUniv_Cat_Simple.
             -- apply isapropunit.
       - use make_dirprod.
         + intros a b.
-          use isweq_iso.
-          * intros mor.
-            apply (arrow_to_weak_reluniv_mor a b (pr1 mor)).
-          * intros mor.
-            use gen_reluniv_mor_eq.
-            -- apply idpath.
-            -- apply idpath.
-          * intros mor.
-            use total2_paths_f.
-            -- use arrow_category_mor_eq.
-               ++ apply idpath.
-               ++ apply idpath.
-            -- apply isapropunit.
-        + use isweq_iso.
-          * apply arrow_to_weak_reluniv.
-          * intros u. apply idpath.
-          * intros u. apply idpath.
+          apply (pr2 (weak_reluniv_cat_subcat_weq_mor a b)).
+        + apply weak_reluniv_cat_subcat_weq_ob.
     Defined.
 
     Definition weak_reluniv_cat_is_univalent
@@ -328,6 +313,8 @@ End RelUniv_Cat_Simple.
                (arrow_category_is_univalent D_univ)
             ).
     Defined.
+
+End WeakRelUniv_is_univalent.
 
 End RelUniv.
 

--- a/TypeTheory/ALV2/RelUniv_Cat_Simple.v
+++ b/TypeTheory/ALV2/RelUniv_Cat_Simple.v
@@ -21,8 +21,6 @@ Other important definitions:
 - [iscontr_reluniv_mor_ϕ] — proof that ϕ component is contractible when J is fully faithful;
 - [isaprop_reluniv_mor_ϕ] — proof that ϕ component is proposition when J is faithful.
 
-TODO: document/update Comm_Squares and Functor_Squares sections.
-
 *)
 
 Require Import UniMath.Foundations.Sets.
@@ -319,14 +317,6 @@ End RelUniv_Cat_Simple.
           * intros u. apply idpath.
     Defined.
 
-    Definition catiso_univalent (C' : precategory) (D' : category)
-      : catiso D' C' → is_univalent C' → is_univalent D'.
-    Proof.
-      intros i C'_univ.
-      rewrite (catiso_to_precategory_path (homset_property _) i).
-      assumption.
-    Defined.
-      
     Definition weak_reluniv_cat_is_univalent
                (D_univ : is_univalent D)
       : is_univalent weak_reluniv_cat.

--- a/TypeTheory/Auxiliary/Auxiliary.v
+++ b/TypeTheory/Auxiliary/Auxiliary.v
@@ -21,6 +21,8 @@ Require Export UniMath.CategoryTheory.categories.HSET.Core.
 Require Export UniMath.CategoryTheory.categories.HSET.Limits.
 Require Export UniMath.CategoryTheory.categories.HSET.Univalence.
 Require Export UniMath.CategoryTheory.ArrowCategory.
+Require Export UniMath.CategoryTheory.catiso.
+Require Export UniMath.CategoryTheory.CategoryEquality.
 
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 (* Require Import TypeTheory.Auxiliary.UnicodeNotations. *)
@@ -1945,6 +1947,15 @@ Proof.
       * apply idpath.
     + apply (pr2 (arrow_category_id_weq_iso C_univ _ _)).
   - apply homset_property.
+Defined.
+
+Definition catiso_univalent (C : category) (D : precategory)
+  : catiso D C → is_univalent C → is_univalent D.
+Proof.
+  intros i C_univ.
+  set (D_eq_C := invweq (catiso_is_path_precat _ _ (homset_property _)) i).
+  use (transportb _ D_eq_C).
+  apply C_univ.
 Defined.
 
 End Unorganised.

--- a/TypeTheory/Auxiliary/Auxiliary.v
+++ b/TypeTheory/Auxiliary/Auxiliary.v
@@ -2041,6 +2041,21 @@ Proof.
         apply arrow_category_weq_is_iso.
 Defined. 
 
+Definition arrow_category_mor_eq {C : category}
+           {abf cdg : arrow_category C}
+           (f g : arrow_category C ⟦ abf, cdg ⟧)
+  : pr1 (pr1 f) = pr1 (pr1 g)
+    → dirprod_pr2 (pr1 f) = dirprod_pr2 (pr1 g)
+    → f = g.
+Proof.
+  intros p1 p2.
+  use total2_paths_f.
+  - use dirprod_paths.
+    + apply p1.
+    + apply p2.
+  - apply homset_property.
+Defined.
+
 Definition arrow_category_is_univalent {C : category}
            (C_univ : is_univalent C)
   : is_univalent (arrow_category C).
@@ -2052,11 +2067,9 @@ Proof.
       apply C_univ.
     + intros p. induction p.
       apply eq_iso. 
-      use total2_paths_f.
-      * use dirprod_paths.
-        -- apply idpath.
-        -- apply idpath.
-      * apply homset_property.
+      apply arrow_category_mor_eq.
+      * apply idpath.
+      * apply idpath.
     + apply (pr2 (arrow_category_id_weq_iso C_univ _ _)).
   - apply homset_property.
 Defined.

--- a/TypeTheory/Auxiliary/Auxiliary.v
+++ b/TypeTheory/Auxiliary/Auxiliary.v
@@ -2046,22 +2046,19 @@ Definition arrow_category_is_univalent {C : category}
   : is_univalent (arrow_category C).
 Proof.
   use make_is_univalent.
-  - intros a b.
-    use isweq_iso.
-    + apply (invweq (arrow_category_id_weq_iso C_univ _ _)).
-    + intros p. simpl.
-      Search weq.
-    
+  - intros abf cdg.
     use isweqhomot.
     + apply arrow_category_id_weq_iso.
       apply C_univ.
-    + intros p. apply eq_iso.
+    + intros p. induction p.
+      apply eq_iso. 
       use total2_paths_f.
       * use dirprod_paths.
         -- apply idpath.
-    use isweq_iso.
-    + apply (invweq (arrow_category_id_weq_iso C_univ a b)).
-    + intros p. simpl.
+        -- apply idpath.
+      * apply homset_property.
+    + apply (pr2 (arrow_category_id_weq_iso C_univ _ _)).
+  - apply homset_property.
 Defined.
 
 End Unorganised.

--- a/TypeTheory/Auxiliary/Auxiliary.v
+++ b/TypeTheory/Auxiliary/Auxiliary.v
@@ -1682,134 +1682,7 @@ Proof.
   apply maponpaths, maponpaths, idtoiso_isotoid.
 Qed.
 
-Definition transportf_dirprod_path {C : category}
-           (a b c d : C)
-           (e1 : a = c)
-           (e2 : b = d)
-           (f : C ⟦ a, b ⟧)
-  : transportf
-      (λ x : C × C, C ⟦ dirprod_pr1 x, dirprod_pr2 x ⟧)
-      (@dirprod_paths _ _ (a, b) (c, d) e1 e2) f
-    = idtoiso (!e1) ;; f ;; idtoiso e2.
-Proof.
-  use (paths_rect C a (λ x ex, transportf (λ xy : C × C, C ⟦ pr1 xy, pr2 xy ⟧) (@dirprod_paths _ _ (a, b) (x, d) ex e2) f = idtoiso (!ex) ;; f ;; idtoiso e2) _ _ e1).
-  simpl.
-  use (paths_rect C b (λ x ex, transportf (λ xy : C × C, C ⟦ pr1 xy, pr2 xy ⟧) (@dirprod_paths _ _ (a, b) (a, x) (idpath a) ex) f = identity a ;; f ;; idtoiso ex) _ _ e2).
-  simpl.
-  etrans.
-  apply (@idpath_transportf (C × C) (λ xy : C × C, C ⟦ pr1 xy, pr2 xy ⟧ ) (a, b) f).
-  apply pathsinv0.
-  etrans. apply assoc'.
-  etrans. apply id_left.
-  apply id_right.
-Defined.
-
-Definition arrow_category_iso_to_isos {C : category}
-           {abf cdg : arrow_category C}
-  : iso abf cdg →
-        ∑ (hk : iso (pr1 (pr1 abf)) (pr1 (pr1 cdg))
-                    × iso (pr2 (pr1 cdg)) (pr2 (pr1 abf))),
-    pr2 abf = pr1 hk ;; pr2 cdg ;; pr2 hk.
-Proof.
-  intros abf_cdg_iso.
-  set (e1 := iso_inv_after_iso abf_cdg_iso).
-  set (e2 := iso_after_iso_inv abf_cdg_iso).
-  use tpair.
-  + use make_dirprod.
-    * use make_iso.
-      -- apply (pr1 (pr1 (pr1 abf_cdg_iso))).
-      -- use is_iso_from_is_z_iso.
-         exists (pr1 (pr1 (inv_from_iso abf_cdg_iso))).
-         use make_dirprod.
-         ++ apply (maponpaths (λ x, pr1 (pr1 x)) e1).
-         ++ apply (maponpaths (λ x, pr1 (pr1 x)) e2).
-    * use make_iso.
-      -- apply (dirprod_pr2 (pr1 (inv_from_iso abf_cdg_iso))).
-      -- use is_iso_from_is_z_iso.
-         exists (dirprod_pr2 (pr1 (pr1 abf_cdg_iso))).
-         use make_dirprod.
-         ++ apply (maponpaths (λ x, dirprod_pr2 (pr1 x)) e2).
-         ++ apply (maponpaths (λ x, dirprod_pr2 (pr1 x)) e1).
-  + simpl.
-    apply pathsinv0.
-    etrans. apply maponpaths_2, pathsinv0.
-    apply (pr2 (pr1 abf_cdg_iso)).
-    etrans. apply assoc'.
-    etrans. apply maponpaths.
-    apply (maponpaths (λ x, dirprod_pr2 (pr1 x)) e1).
-    apply id_right.
-Defined.
-
-Axiom arrow_category_isos_to_iso
-  : ∏ (C : category)
-      (abf cdg : arrow_category C),
-  (∑ (hk : iso (pr1 (pr1 abf)) (pr1 (pr1 cdg))
-                 × iso (pr2 (pr1 cdg)) (pr2 (pr1 abf))),
-     pr2 abf = pr1 hk ;; pr2 cdg ;; pr2 hk)
-    → iso abf cdg.
-
-Definition arrow_category_isotoid {C : category}
-           (C_univ : is_univalent C)
-           (ff gg : arrow_category C)
-  : iso ff gg → ff = gg.
-Proof.
-  intros ff_gg_iso.
-  set (a_iso := pr1 (pr1 (arrow_category_iso_to_isos ff_gg_iso))).
-  set (b_iso := dirprod_pr2 (pr1 (arrow_category_iso_to_isos ff_gg_iso))).
-  set (f_iso := pr2 (arrow_category_iso_to_isos ff_gg_iso)).
-  use total2_paths_f.
-  * use dirprod_paths.
-    -- use isotoid. apply C_univ. apply a_iso.
-    -- apply pathsinv0. use isotoid. apply C_univ. use b_iso.
-  * etrans. apply transportf_dirprod_path.
-
-    etrans. apply maponpaths.
-    apply (maponpaths pr1 (idtoiso_inv _ _ _ _)).
-    etrans. apply maponpaths, maponpaths, maponpaths.
-    apply idtoiso_isotoid.
-
-    etrans. apply assoc'.
-    etrans. apply maponpaths_2.
-    apply (maponpaths pr1 (idtoiso_inv _ _ _ _)).
-    etrans. apply maponpaths_2, maponpaths, maponpaths.
-    apply idtoiso_isotoid.
-
-    etrans. apply maponpaths, maponpaths_2.
-    apply f_iso.
-
-    etrans. apply maponpaths, assoc'.
-    etrans. apply maponpaths, maponpaths.
-    apply iso_inv_after_iso.
-
-    etrans. apply assoc.
-    etrans. apply maponpaths_2, assoc.
-    etrans. apply maponpaths_2, maponpaths_2.
-    apply iso_after_iso_inv.
-
-    etrans. apply maponpaths_2.
-    apply id_left.
-    apply id_right.
-Defined. 
-
-Definition is_univalent_arrow_category {C : category}
-           (C_univ : is_univalent C)
-  : is_univalent (arrow_category C).
-Proof.
-  use make_is_univalent.
-  - intros ff gg.
-    use isweq_iso.
-    + apply arrow_category_isotoid. apply C_univ.
-    + intros e.
-      simpl.
-      Search total2_paths_f.
-      (* STUCK: no idea how to proceed *)
-Abort.
-
-(* BELOW: alternative route, inspired by a proof for slicecat
-   https://github.com/UniMath/UniMath/blob/afaba56e5002bba801abbfabdb43fb63dab977f8/UniMath/CategoryTheory/slicecat.v#L373-L380
- *)
-
-Definition transportf_dirprod_path' {C : category}
+Lemma transportf_dirprod_path' {C : category}
            {a b c d : C}
            (e : (a, b) = (c, d))
            (f : C ⟦ a, b ⟧)
@@ -1835,7 +1708,7 @@ Definition arrow_category_ids {C : category}
                × (dirprod_pr2 (pr1 abf) = dirprod_pr2 (pr1 cdg))),
     pr2 abf ;; idtoiso (dirprod_pr2 hk) = idtoiso (pr1 hk) ;; pr2 cdg.
 
-Definition arrow_category_id_to_ids {C : category}
+Lemma arrow_category_id_to_ids {C : category}
            {abf cdg : arrow_category C}
   : (abf = cdg) ≃ arrow_category_ids abf cdg.
 Proof.
@@ -1880,7 +1753,7 @@ Definition arrow_category_is_iso {C : category}
      is_iso a_to_c ×
      (pr2 abf ;; b_to_d = a_to_c ;; pr2 cdg).
 
-Definition isaprop_arrow_category_is_iso {C : category}
+Lemma isaprop_arrow_category_is_iso {C : category}
            {abf cdg : arrow_category C}
            (a_to_c : C ⟦ pr1 (pr1 abf), pr1 (pr1 cdg) ⟧)
            (b_to_d : C ⟦ dirprod_pr2 (pr1 abf), dirprod_pr2 (pr1 cdg) ⟧)


### PR DESCRIPTION
TODO:

- [x] prove that square of mappings commutes
- [x] prove that square of functors commutes up to a natural isomorphism
- [x] prove that square of functors commutes strictly (under some conditions or universally)
  - [x] show that arrow category is univalent when underlying category is univalent
  - [x] show that category of weak relative universes is univalent (when underlying category is univalent), using `is_univalent_full_subcat`
  - [x] use that together with the fact that category of functors is univalent when target is univalent, to show that square commutes strictly
- [x] cleanup code