### PR TITLE
Another proof that reluniv_functor_with_ess_surj issurjective (assuming R is essentially surjective)

### DIFF
--- a/TypeTheory/ALV2/RelUnivTransfer.v
+++ b/TypeTheory/ALV2/RelUnivTransfer.v
@@ -335,8 +335,7 @@ Section RelUniv_Transfer.
     Defined.
 
   Section SURJECTIVE.
-    Context (D_univ : is_univalent D)
-            (R_ses : split_ess_surj R)
+    Context (R_ses : split_ess_surj R)
             (D'_univ : is_univalent D')
             (invS : functor D' D)
             (eta : iso (C:=[D, D, pr2 D]) (functor_identity D) (S ∙ invS))
@@ -547,10 +546,6 @@ Section RelUniv_Transfer.
 
   End Helpers.
 
-    Axiom STUCK : ∏ X : UU, X.
-
-    Search paths.
-
     Definition inv_reluniv_with_ess_surj
       : reluniv_cat J' → reluniv_cat J.
     Proof.
@@ -567,32 +562,7 @@ Section RelUniv_Transfer.
         * apply pb_commutes_and_is_pullback.
     Defined.
 
-    Definition inv_reluniv_with_ess_surj_preserves_mor_total
-               (u' : reluniv_cat J')
-      : pr1 (reluniv_functor_with_ess_surj (inv_reluniv_with_ess_surj u'))
-        = pr1 u'.
-    Proof.
-      set (S_weq_on_mor_total
-           := isweq_left_adj_equivalence_on_mor_total
-                S D_univ D'_univ AE
-              : isweq (functor_on_mor_total S)).
-      apply (homotweqinvweq
-               (functor_on_mor_total S,,S_weq_on_mor_total)).
-    Defined.
-
-    Search (∑ (e : ?a = ?a'), _).
-    Search total2_paths_f.
-
-    Definition maponpaths_pr2_total2_paths_f
-               (A : Type) (B : A → Type)
-               (ab ab' : ∑ a : A, B a)
-               (e : ab = ab')
-      : transportf _ (maponpaths pr1 e) (pr2 ab) = pr2 ab'.
-    Proof.
-      induction e. apply idpath.
-    Defined.
-
-    Definition reluniv_functor_with_ess_surj_after_inv
+    Definition reluniv_functor_with_ess_surj_after_inv_iso
                (u' : reluniv_cat J')
       : iso u'
             (reluniv_functor_with_ess_surj (inv_reluniv_with_ess_surj u')).
@@ -627,6 +597,18 @@ Section RelUniv_Transfer.
           * apply (maponpaths (λ k, pr1 k _) (iso_inv_after_iso ε)).
     Defined.
 
+    Definition reluniv_functor_with_ess_surj_after_inv_id
+               (u' : reluniv_cat J')
+      : u' = reluniv_functor_with_ess_surj (inv_reluniv_with_ess_surj u').
+    Proof.
+      use isotoid.
+      - use reluniv_cat_is_univalent.
+        + apply C'_univ.
+        + apply ff_J'.
+        + apply D'_univ.
+      - apply reluniv_functor_with_ess_surj_after_inv_iso.
+    Defined.
+
     Definition reluniv_functor_with_ess_surj_issurjective
       : issurjective reluniv_functor_with_ess_surj.
     Proof.
@@ -634,44 +616,7 @@ Section RelUniv_Transfer.
       use hinhpr.
       use tpair.
       - apply (inv_reluniv_with_ess_surj u').
-      - use isotoid.
-        use (invmaponpathsweq (weqtotal2asstor _ _)).
-        use total2_paths_f.
-        + apply (maponpaths pr1 (inv_reluniv_with_ess_surj_preserves_mor_total u')).
-        + use total2_paths_f.
-          * etrans. use (pr1_transportf (D' × D')).
-            use maponpaths_pr2_total2_paths_f.
-          * etrans. refine (transportf_forall _ _ _).
-            apply funextsec. intros X'.
-            etrans. refine (transportf_forall _ _ _).
-            apply funextsec. intros f'.
-            use total2_paths_f.
-            -- use total2_paths_f.
-               ++ etrans. apply maponpaths. use pr1_transportf.
-                  etrans. use (pr1_transportf (D' ⟦ _, _ ⟧)).
-                  use isotoid. apply C'_univ.
-                  (* we know that Xf' = R (invR Xf'')
-                   * where Xf'' = R(invR X).(_ ;; # S (# invS f) ;; _)
-                   * and invR is the inverse on objects given
-                   * by R being (split) essentially surjective
-                   * However for some reason (because of transportf?)
-                   * pr2 (R_ses _) does not apply :(
-                   *)
-                  apply STUCK. (* Xf' *)
-               ++ use dirprod_paths.
-                  ** (* This one will probably the hardest to prove formally
-                      * since it is in C' and is constructed
-                      * by going between categories a lot.
-                      *)
-                    apply STUCK. (* pp' *)
-                  ** (* This one should be fairly easy since
-                      * it is only mapped with S and invS
-                      * with some isos prepended to it in both maps
-                      *)
-                    apply STUCK. (* Q' *)
-            -- use dirprod_paths.
-               ++ apply homset_property.
-               ++ apply isaprop_isPullback.
+      - apply pathsinv0, reluniv_functor_with_ess_surj_after_inv_id.
     Defined.
 
   End SURJECTIVE.
@@ -885,30 +830,6 @@ Section WeakRelUniv_Transfer.
     apply weak_relu_square_commutes.
   Defined.
 
-  Definition reluniv_functor_with_ess_surj_issurjective
-             (C'_univ : is_univalent C')
-             (AC : AxiomOfChoice.AxiomOfChoice)
-             (obC_isaset : isaset C)
-    : issurjective (reluniv_functor_with_ess_surj
-                      _ _ _ _ J J'
-                      R S α α_is_iso
-                      S_pb C'_univ ff_J' S_full R_es
-                   ).
-  Proof.
-    set (W := (weak_from_reluniv_functor J'
-            ,, weak_from_reluniv_functor_is_catiso J' C'_univ ff_J')
-        : catiso _ _).
-    use (Core.issurjective_postcomp_with_weq _ (catiso_ob_weq W)).
-    use (transportf (λ F, issurjective (pr11 F))
-                    (! weak_relu_square_commutes_strictly C'_univ)).
-    use issurjcomp.
-    - apply weak_from_reluniv_functor_issurjective.
-      apply AC.
-      apply obC_isaset.
-    - apply issurjectiveweq.
-      apply (catiso_ob_weq (_,,weak_reluniv_functor_is_catiso)).
-  Defined.
-
 End WeakRelUniv_Transfer.
 
 Section RelUniv_Yo_Rezk.
@@ -961,7 +882,6 @@ Section RelUniv_Yo_Rezk.
     use (reluniv_functor_with_ess_surj_issurjective
            _ _ _ _ Yo Yo
            _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-           AC obC_isaset
         ).
     - apply is_univalent_preShv.
     - apply is_univalent_preShv.

--- a/TypeTheory/ALV2/RelUnivTransfer.v
+++ b/TypeTheory/ALV2/RelUnivTransfer.v
@@ -31,7 +31,6 @@ Require Import UniMath.CategoryTheory.catiso.
 Require Import UniMath.CategoryTheory.Equivalences.Core.
 
 Set Automatic Introduction.
-Set Nested Proofs Allowed.
 
 Section RelUniv_Transfer.
 

--- a/TypeTheory/ALV2/RelUnivTransfer.v
+++ b/TypeTheory/ALV2/RelUnivTransfer.v
@@ -592,6 +592,41 @@ Section RelUniv_Transfer.
       induction e. apply idpath.
     Defined.
 
+    Definition reluniv_functor_with_ess_surj_after_inv
+               (u' : reluniv_cat J')
+      : iso u'
+            (reluniv_functor_with_ess_surj (inv_reluniv_with_ess_surj u')).
+    Proof.
+      set (εx := Constructions.pointwise_iso_from_nat_iso ε).
+      set (εx' := Constructions.pointwise_iso_from_nat_iso
+                   (iso_inv_from_iso ε)).
+      use z_iso_to_iso.
+      use make_z_iso.
+      - use tpair.
+        + use make_dirprod.
+          * cbn. apply (εx' (pr211 u')).
+          * cbn. apply (εx' (pr111 u')).
+        + unfold is_gen_reluniv_mor.
+          etrans. apply pathsinv0.
+          apply (nat_trans_ax (pr1 (iso_inv_from_iso ε))).
+          apply idpath.
+      - use tpair.
+        + use make_dirprod.
+          * cbn. apply (εx (pr211 u')).
+          * cbn. apply (εx (pr111 u')).
+        + unfold is_gen_reluniv_mor.
+          etrans. apply pathsinv0.
+          apply (nat_trans_ax (pr1 ε)).
+          apply idpath.
+      - use make_dirprod.
+        + use gen_reluniv_mor_eq.
+          * apply (maponpaths (λ k, pr1 k _) (iso_after_iso_inv ε)).
+          * apply (maponpaths (λ k, pr1 k _) (iso_after_iso_inv ε)).
+        + use gen_reluniv_mor_eq.
+          * apply (maponpaths (λ k, pr1 k _) (iso_inv_after_iso ε)).
+          * apply (maponpaths (λ k, pr1 k _) (iso_inv_after_iso ε)).
+    Defined.
+
     Definition reluniv_functor_with_ess_surj_issurjective
       : issurjective reluniv_functor_with_ess_surj.
     Proof.
@@ -599,7 +634,8 @@ Section RelUniv_Transfer.
       use hinhpr.
       use tpair.
       - apply (inv_reluniv_with_ess_surj u').
-      - use (invmaponpathsweq (weqtotal2asstor _ _)).
+      - use isotoid.
+        use (invmaponpathsweq (weqtotal2asstor _ _)).
         use total2_paths_f.
         + apply (maponpaths pr1 (inv_reluniv_with_ess_surj_preserves_mor_total u')).
         + use total2_paths_f.

--- a/TypeTheory/ALV2/RelUnivTransfer.v
+++ b/TypeTheory/ALV2/RelUnivTransfer.v
@@ -334,7 +334,7 @@ Section RelUniv_Transfer.
       - apply reluniv_functor_with_ess_surj_is_faithful, S_faithful.
     Defined.
 
-  Section SURJECTIVE.
+  Section Surjective_if_R_split_ess_surj.
     Context (R_ses : split_ess_surj R)
             (D'_univ : is_univalent D')
             (invS : functor D' D)
@@ -619,7 +619,7 @@ Section RelUniv_Transfer.
       - apply pathsinv0, reluniv_functor_with_ess_surj_after_inv_id.
     Defined.
 
-  End SURJECTIVE.
+  End Surjective_if_R_split_ess_surj.
 
   End RelUniv_Transfer_with_ess_surj.
 
@@ -830,6 +830,30 @@ Section WeakRelUniv_Transfer.
     apply weak_relu_square_commutes.
   Defined.
 
+  Definition reluniv_functor_with_ess_surj_issurjective_AC
+              (C'_univ : is_univalent C')		
+              (AC : AxiomOfChoice.AxiomOfChoice)		
+              (obC_isaset : isaset C)		
+     : issurjective (reluniv_functor_with_ess_surj		
+                       _ _ _ _ J J'		
+                       R S α α_is_iso		
+                       S_pb C'_univ ff_J' S_full R_es		
+                    ).		
+   Proof.		
+     set (W := (weak_from_reluniv_functor J'		
+             ,, weak_from_reluniv_functor_is_catiso J' C'_univ ff_J')		
+         : catiso _ _).		
+     use (Core.issurjective_postcomp_with_weq _ (catiso_ob_weq W)).		
+     use (transportf (λ F, issurjective (pr11 F))		
+                     (! weak_relu_square_commutes_strictly C'_univ)).		
+     use issurjcomp.		
+     - apply weak_from_reluniv_functor_issurjective.		
+       apply AC.		
+       apply obC_isaset.		
+     - apply issurjectiveweq.		
+       apply (catiso_ob_weq (_,,weak_reluniv_functor_is_catiso)).		
+   Defined.
+
 End WeakRelUniv_Transfer.
 
 Section RelUniv_Yo_Rezk.
@@ -879,7 +903,7 @@ Section RelUniv_Yo_Rezk.
              (obC_isaset : isaset C)
     : issurjective transfer_of_RelUnivYoneda_functor.
   Proof.
-    use (reluniv_functor_with_ess_surj_issurjective
+    use (reluniv_functor_with_ess_surj_issurjective_AC
            _ _ _ _ Yo Yo
            _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
         ).
@@ -891,6 +915,8 @@ Section RelUniv_Yo_Rezk.
     - apply fully_faithful_implies_full_and_faithful.
       apply right_adj_equiv_is_ff.
     - apply R_full.
+    - apply AC.
+    - apply obC_isaset.
   Defined.
 
   Definition transfer_of_WeakRelUnivYoneda_functor

--- a/TypeTheory/ALV2/RelUniv_Cat_Simple.v
+++ b/TypeTheory/ALV2/RelUniv_Cat_Simple.v
@@ -195,9 +195,9 @@ End RelUniv_Cat_Simple.
     Definition reluniv_cat : category
       := gen_reluniv_cat rel_universe_structure.
 
+
     Definition weak_reluniv_cat : category
       := gen_reluniv_cat is_universe_relative_to.
-
 
 Section WeakRelUniv_is_univalent.
 
@@ -424,6 +424,23 @@ Section RelUniv_Functor.
     use make_dirprod.
     - apply weak_from_reluniv_functor_ff.
     - apply (weqproperty (weq_relative_universe_weak_relative_universe _ Ccat J_ff)).
+  Defined.
+
+  Definition weak_from_reluniv_functor_catiso
+             (Ccat : is_univalent C) (J_ff : fully_faithful J)
+    : catiso (reluniv_cat J) (weak_reluniv_cat J)
+    := (weak_from_reluniv_functor
+          ,, weak_from_reluniv_functor_is_catiso Ccat J_ff).
+  
+  Definition reluniv_cat_is_univalent
+             (Ccat : is_univalent C) (J_ff : fully_faithful J)
+             (Dcat : is_univalent D)
+    : is_univalent (reluniv_cat J).
+  Proof.
+    use (catiso_univalent
+           _ _ (weak_from_reluniv_functor_catiso Ccat J_ff)).
+    apply weak_reluniv_cat_is_univalent.
+    apply Dcat.
   Defined.
 
   Definition weak_reluniv_isaset

--- a/TypeTheory/ALV2/]
+++ b/TypeTheory/ALV2/]
@@ -823,7 +823,7 @@ Section RelUniv_Yo_Rezk.
     : (transfer_of_RelUnivYoneda_functor ∙ weak_from_reluniv_functor _)
         = (weak_from_reluniv_functor _ ∙ transfer_of_WeakRelUnivYoneda_functor).
   Proof.
-    apply weak_relu_square_commutes_strictly.
+    apply weak_relu_square_commutes_identity.
   Defined.
 
 End RelUniv_Yo_Rezk.

--- a/TypeTheory/ALV2/]
+++ b/TypeTheory/ALV2/]
@@ -718,7 +718,7 @@ Section WeakRelUniv_Transfer.
         : catiso _ _).
     use (Core.issurjective_postcomp_with_weq _ (catiso_ob_weq W)).
     use (transportf (λ F, issurjective (pr11 F))
-                    (! weak_relu_square_commutes_strictly C'_univ)).
+                    (! weak_relu_square_commutes_identity C'_univ)).
     use issurjcomp.
     - apply weak_from_reluniv_functor_issurjective.
       apply AC.

--- a/TypeTheory/ALV2/]
+++ b/TypeTheory/ALV2/]
@@ -1,0 +1,829 @@
+(**
+  [TypeTheory.ALV2.RelUnivTransfer]
+
+  Part of the [TypeTheory] library (Ahrens, Lumsdaine, Voevodsky, 2015–present).
+*)
+
+(**
+Transfer constructions from [TypeTheory.ALV1.RelativeUniverses] lifted to functors.
+
+Current observation: for simple category of relative J-universe structures
+transfer constructions are lifted "trivially" and the resulting functor
+has all the properties of S functor. This might become a little more complicated
+for the more general case of "full" category of relative J-universe structures
+(where morphisms have explicit ϕ component).
+
+TODO:
+- [x] one transfer construction for "simple" (naive) category of J-universe structures
+- [ ] transfer constructions for "full" category of J-universe structures
+*)
+
+Require Import UniMath.Foundations.All.
+Require Import UniMath.MoreFoundations.All.
+Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
+
+Require Import TypeTheory.Auxiliary.Auxiliary.
+Require Import TypeTheory.ALV1.RelativeUniverses.
+Require Import TypeTheory.ALV1.Transport_along_Equivs.
+Require Import TypeTheory.ALV2.RelUniv_Cat_Simple.
+Require Import TypeTheory.ALV2.RelUniv_Cat.
+Require Import UniMath.CategoryTheory.catiso.
+Require Import UniMath.CategoryTheory.Equivalences.Core.
+
+Set Automatic Introduction.
+
+Section RelUniv_Transfer.
+
+  (*       J
+      C  -----> D
+      |         |
+    R |         | S
+      |         |
+      v         v
+      C' -----> D'
+           J'
+   *)
+  Context (C D C' D' : category).
+  Context (J  : functor C D).
+  Context (J' : functor C' D').
+  Context (R : functor C C').
+  Context (S : functor D D').
+
+  (* the square of functors above commutes
+   * up to natural isomorphism *)
+  Context (α : [C, D'] ⟦ J ∙ S, R ∙ J' ⟧).
+  Context (α_is_iso : is_iso α).
+
+  (* J and J' are fully faithful *)
+  Context (ff_J : fully_faithful J).
+  Context (ff_J' : fully_faithful J').
+
+  (* S preserves pullbacks *)
+  Context (S_pb : maps_pb_squares_to_pb_squares _ _ S).
+
+  Section RelUniv_Transfer_with_ess_split.
+
+    Context (S_sf : split_full S).
+    Context (R_es : split_ess_surj R).
+
+    Let transfer_of_reluniv u
+      := transfer_of_rel_univ_with_ess_split _ u _ _ _ _ α_is_iso S_pb R_es S_sf.
+
+    Definition reluniv_mor_J_to_J'_with_ess_split
+               (u1 u2 : relative_universe J)
+               (mor : relative_universe_mor _ u1 u2)
+      : relative_universe_mor _
+                              (transfer_of_reluniv u1)
+                              (transfer_of_reluniv u2).
+    Proof.
+      set (F_Ũ := pr11 mor).
+      set (F_U := pr21 mor).
+      use tpair.
+      - use make_dirprod.
+        + exact (# S F_Ũ).
+        + exact (# S F_U).
+      - (* NOTE: we use eqweqmap to match [weq_reluniv_mor_J_to_J'_with_ess_split] *)
+        use (eqweqmap _ (maponpaths (# S) (pr2 mor))).
+        etrans. apply maponpaths, functor_comp.
+        etrans. apply maponpaths_2, functor_comp.
+        apply idpath.
+    Defined.
+
+    Definition weq_reluniv_mor_J_to_J'_with_ess_split
+               (S_faithful : faithful S)
+               (u1 u2 : relative_universe J)
+      : relative_universe_mor _ u1 u2
+                              ≃ relative_universe_mor _
+                              (transfer_of_rel_univ_with_ess_split
+                                 _ u1 _ _ _ _ α_is_iso S_pb R_es S_sf)
+                              (transfer_of_rel_univ_with_ess_split
+                                 _ u2 _ _ _ _ α_is_iso S_pb R_es S_sf).
+    Proof.
+      set (S_ff := full_and_faithful_implies_fully_faithful _ _ _
+                                                            (full_from_split_full _ S_sf , S_faithful)).
+      set (S_weq := weq_from_fully_faithful S_ff).
+      use weqtotal2.
+      - use weqdirprodf.
+        + apply S_weq.
+        + apply S_weq.
+      - intros mor.
+        eapply weqcomp.
+        apply (maponpaths (S_weq _ _) ,, isweqmaponpaths _ _ _).
+        apply eqweqmap.
+        unfold is_gen_reluniv_mor; simpl.
+        etrans. apply maponpaths, functor_comp.
+        etrans. apply maponpaths_2, functor_comp.
+        apply idpath.
+    Defined.
+
+    Goal ∏
+         (S_faithful : faithful S)
+         (u1 u2 : relative_universe J),
+    reluniv_mor_J_to_J'_with_ess_split u1 u2
+    =
+    weq_reluniv_mor_J_to_J'_with_ess_split S_faithful u1 u2.
+    Proof.
+      intros; apply idpath.
+    Qed.
+
+    Definition reluniv_functor_data_with_ess_split
+      : functor_data (reluniv_cat J) (reluniv_cat J').
+    Proof.
+      use make_functor_data.
+      - intros u.
+        apply (transfer_of_rel_univ_with_ess_split
+                 _ u _ _ _ _ α_is_iso S_pb R_es S_sf).
+      - intros u1 u2 mor.
+        apply reluniv_mor_J_to_J'_with_ess_split.
+        apply mor.
+    Defined.
+
+    Definition reluniv_functor_idax_with_ess_split
+      : functor_idax reluniv_functor_data_with_ess_split.
+    Proof.
+      intros u.
+      use gen_reluniv_mor_eq.
+      - etrans. apply functor_id. apply idpath.
+      - etrans. apply functor_id. apply idpath.
+    Defined.
+
+    Definition reluniv_functor_compax_with_ess_split
+      : functor_compax reluniv_functor_data_with_ess_split.
+    Proof.
+      intros a b c f g.
+      use gen_reluniv_mor_eq.
+      - etrans. apply functor_comp. apply idpath.
+      - etrans. apply functor_comp. apply idpath.
+    Defined.
+
+    Definition reluniv_is_functor_with_ess_split
+      : is_functor reluniv_functor_data_with_ess_split
+      := (reluniv_functor_idax_with_ess_split ,, reluniv_functor_compax_with_ess_split).
+
+    Definition reluniv_functor_with_ess_split
+      : functor (reluniv_cat J) (reluniv_cat J')
+      := make_functor
+           reluniv_functor_data_with_ess_split
+           reluniv_is_functor_with_ess_split.
+
+    Definition reluniv_functor_with_ess_split_is_full
+               (S_faithful : faithful S)
+      : full reluniv_functor_with_ess_split.
+    Proof.
+      intros u1 u2.
+      apply issurjectiveweq.
+      use (weqproperty (weq_reluniv_mor_J_to_J'_with_ess_split _ _ _)).
+      apply S_faithful.
+    Defined.
+
+    Definition reluniv_functor_with_ess_split_is_faithful
+               (S_faithful : faithful S)
+      : faithful reluniv_functor_with_ess_split.
+    Proof.
+      intros u1 u2.
+      apply isinclweq.
+      use (weqproperty (weq_reluniv_mor_J_to_J'_with_ess_split _ _ _)).
+      apply S_faithful.
+    Defined.
+
+    Definition reluniv_functor_with_ess_split_ff
+               (S_faithful : faithful S)
+      : fully_faithful reluniv_functor_with_ess_split.
+    Proof.
+      apply full_and_faithful_implies_fully_faithful.
+      use make_dirprod.
+      - apply reluniv_functor_with_ess_split_is_full, S_faithful.
+      - apply reluniv_functor_with_ess_split_is_faithful, S_faithful.
+    Defined.
+
+  End RelUniv_Transfer_with_ess_split.
+
+  Section RelUniv_Transfer_with_ess_surj.
+
+    Context (C'_univ : is_univalent C').
+    Context (J'_ff : fully_faithful J').
+    Context (S_f : full S).
+    Context (R_es : essentially_surjective R).
+
+    Let transfer_of_reluniv u
+      := transfer_of_rel_univ_with_ess_surj _ u _ _ _ _ α_is_iso S_pb R_es C'_univ J'_ff S_f.
+
+    Definition reluniv_mor_J_to_J'_with_ess_surj
+                (u1 u2 : relative_universe J)
+                (mor : relative_universe_mor _ u1 u2)
+        : relative_universe_mor _
+            (transfer_of_reluniv u1)
+            (transfer_of_reluniv u2).
+    Proof.
+        set (F_Ũ := pr11 mor).
+        set (F_U := pr21 mor).
+        use tpair.
+        - use make_dirprod.
+          + exact (# S F_Ũ).
+          + exact (# S F_U).
+        - (* NOTE: we use eqweqmap to match [weq_reluniv_mor_J_to_J'_with_ess_split] *)
+          use (eqweqmap _ (maponpaths (# S) (pr2 mor))).
+          etrans. apply maponpaths, functor_comp.
+          etrans. apply maponpaths_2, functor_comp.
+          apply idpath.
+    Defined.
+
+    Definition weq_reluniv_mor_J_to_J'_with_ess_surj
+                (S_faithful : faithful S)
+                (u1 u2 : relative_universe J)
+        : relative_universe_mor _ u1 u2
+        ≃ relative_universe_mor _
+            (transfer_of_reluniv u1)
+            (transfer_of_reluniv u2).
+    Proof.
+      set (S_ff := full_and_faithful_implies_fully_faithful _ _ _
+                     (S_f , S_faithful)).
+      set (S_weq := weq_from_fully_faithful S_ff).
+      use weqtotal2.
+      - use weqdirprodf.
+        + apply S_weq.
+        + apply S_weq.
+      - intros mor.
+        eapply weqcomp.
+        apply (maponpaths (S_weq _ _) ,, isweqmaponpaths _ _ _).
+        apply eqweqmap.
+        unfold is_gen_reluniv_mor; simpl.
+        etrans. apply maponpaths, functor_comp.
+        etrans. apply maponpaths_2, functor_comp.
+        apply idpath.
+    Defined.
+
+    Goal ∏
+         (S_faithful : faithful S)
+         (u1 u2 : relative_universe J),
+    reluniv_mor_J_to_J'_with_ess_surj u1 u2
+    =
+    weq_reluniv_mor_J_to_J'_with_ess_surj S_faithful u1 u2.
+    Proof.
+      intros; apply idpath.
+    Qed.
+
+    Definition reluniv_functor_data_with_ess_surj
+        : functor_data (@reluniv_cat _ _ J)
+                    (@reluniv_cat _ _ J').
+    Proof.
+      use make_functor_data.
+      - apply transfer_of_reluniv.
+      - intros u1 u2 mor.
+        apply reluniv_mor_J_to_J'_with_ess_surj.
+        apply mor.
+    Defined.
+
+    Definition reluniv_functor_idax_with_ess_surj
+      : functor_idax reluniv_functor_data_with_ess_surj.
+    Proof.
+      intros u.
+      use gen_reluniv_mor_eq.
+      - etrans. apply functor_id. apply idpath.
+      - etrans. apply functor_id. apply idpath.
+    Defined.
+
+    Definition reluniv_functor_compax_with_ess_surj
+      : functor_compax reluniv_functor_data_with_ess_surj.
+    Proof.
+        intros a b c f g.
+        use gen_reluniv_mor_eq.
+        - etrans. apply functor_comp. apply idpath.
+        - etrans. apply functor_comp. apply idpath.
+    Defined.
+
+    Definition reluniv_is_functor_with_ess_surj
+      : is_functor reluniv_functor_data_with_ess_surj
+      := (reluniv_functor_idax_with_ess_surj
+            ,, reluniv_functor_compax_with_ess_surj).
+
+    Definition reluniv_functor_with_ess_surj
+      : functor (@reluniv_cat _ _ J) (@reluniv_cat _ _ J')
+      := make_functor
+           reluniv_functor_data_with_ess_surj
+           reluniv_is_functor_with_ess_surj.
+
+    Definition reluniv_functor_with_ess_surj_is_full
+               (S_faithful : faithful S)
+      : full reluniv_functor_with_ess_surj.
+    Proof.
+      intros u1 u2.
+      apply issurjectiveweq.
+      use (weqproperty (weq_reluniv_mor_J_to_J'_with_ess_surj _ _ _)).
+      apply S_faithful.
+    Defined.
+
+    Definition reluniv_functor_with_ess_surj_is_faithful
+               (S_faithful : faithful S)
+      : faithful reluniv_functor_with_ess_surj.
+    Proof.
+      intros u1 u2.
+      apply isinclweq.
+      use (weqproperty (weq_reluniv_mor_J_to_J'_with_ess_surj _ _ _)).
+      apply S_faithful.
+    Defined.
+
+    Definition reluniv_functor_with_ess_surj_ff
+               (S_faithful : faithful S)
+      : fully_faithful reluniv_functor_with_ess_surj.
+    Proof.
+      apply full_and_faithful_implies_fully_faithful.
+      use make_dirprod.
+      - apply reluniv_functor_with_ess_surj_is_full, S_faithful.
+      - apply reluniv_functor_with_ess_surj_is_faithful, S_faithful.
+    Defined.
+
+    Axiom STUCK : ∏ X : UU, X.
+
+    Definition reluniv_functor_with_ess_surj_issurjective
+               (D_univ : is_univalent D)
+               (R_ses : split_ess_surj R)
+               (D'_univ : is_univalent D')
+               (invS : functor D' D)
+               (eta : iso (C:=[D, D, pr2 D]) (functor_identity D) (S ∙ invS))
+               (eps : iso (C:=[D', D', pr2 D']) (invS ∙ S) (functor_identity D'))
+               (S_ff : fully_faithful S)
+      : issurjective reluniv_functor_with_ess_surj.
+    Proof.
+      set (E 
+           := ((S,, (invS,, (pr1 eta, pr1 eps)))
+                 ,, ((λ d,  (pr2 (Constructions.pointwise_iso_from_nat_iso eta d )))
+                     , (λ d', (pr2 (Constructions.pointwise_iso_from_nat_iso eps d')))))
+              : equivalence_of_precats D D').
+      
+      set (AE := adjointificiation E).
+      set (η' := pr1 (pr121 AE) : nat_trans (functor_identity _) (S ∙ invS)).
+      set (ε' := pr2 (pr121 AE) : nat_trans (invS ∙ S) (functor_identity _)).
+
+      Search iso.
+      set (η := functor_iso_from_pointwise_iso
+                  (λ d : D, (η' d,, pr12 (adjointificiation E) d))
+                : iso (C:=[D, D, pr2 D]) (functor_identity D) (S ∙ invS)).
+
+          : ∏ d : D, iso d (invS (S d))).
+      set (ε := (λ d' : D', (ε' d',, pr22 (adjointificiation E) d'))
+          : ∏ d' : D', iso (S (invS d')) d').
+
+      intros u'.
+      set (p' := pr1  u' : mor_total D').
+      set (Ũ' := pr21 p' : D').
+      set (U' := pr11 p' : D').
+      set (pf' := pr2 p' : D' ⟦ Ũ', U' ⟧).
+      set (α_inv := inv_from_iso (α,,α_is_iso)).
+      use hinhpr.
+      use tpair.
+      - use tpair.
+        + exact ((invS U', invS Ũ') ,, # invS pf').
+        + intros X f. unfold target in f; simpl in f.
+          set (X' := R X   : C').
+          set (f' := pr1 α_inv X ;; # S f ;; ε U'
+                  : D' ⟦ J' X' , U' ⟧).
+          set (pb' := pr2 u' X' f').
+          
+          set (Xf' := pr11 pb').
+          set (Xf := pr1 (R_ses Xf') : C).
+          set (RXf_Xf'_iso := pr2 (R_ses Xf') : iso (R Xf) Xf').
+
+          set (pp' := pr121 pb' : C' ⟦ Xf', X' ⟧).
+          set (pp 
+            := invweq (weq_from_fully_faithful ff_J _ _)
+                 (η _ ;;
+                       # invS
+                       (pr1 α Xf ;;
+                            # J' (RXf_Xf'_iso ;; pp') ;;
+                            pr1 α_inv X) ;;
+                       pr1 (inv_from_iso η) _)
+               : C ⟦ Xf, X ⟧).
+
+          set (Q' := pr221 pb' : D' ⟦ J' Xf', Ũ' ⟧).
+          set (Q 
+               := η _ ;; # invS (pr1 α Xf ;; # J' RXf_Xf'_iso ;; Q')
+                  : D ⟦ J Xf, invS Ũ' ⟧).
+
+          set (pb'_commutes := pr12 pb' : # J' pp' ;; f' = Q' ;; p').
+
+          use tpair.
+          * use tpair.
+            -- apply Xf.
+            -- use make_dirprod.
+               ++ apply pp.
+               ++ apply Q.
+          * use make_dirprod.
+            -- unfold fq, fp, pp, Q. simpl.
+               etrans. apply maponpaths_2.
+               apply (homotweqinvweq (weq_from_fully_faithful ff_J Xf X)).
+
+               etrans. apply assoc'.
+               etrans. apply assoc'.
+               apply pathsinv0.
+               etrans. apply assoc'.
+               apply maponpaths.
+
+               etrans. apply maponpaths_2, functor_comp.
+               apply pathsinv0.
+               etrans. apply maponpaths_2, functor_comp.
+               etrans. apply maponpaths_2, maponpaths_2.
+               apply maponpaths, maponpaths, functor_comp.
+               etrans. apply maponpaths_2, maponpaths_2.
+               apply maponpaths, assoc.
+               etrans. apply maponpaths_2, maponpaths_2, functor_comp.
+               etrans. apply assoc'.
+               etrans. apply assoc'.
+               apply pathsinv0.
+               etrans. apply assoc'.
+               apply maponpaths.
+
+               etrans. apply pathsinv0, functor_comp.
+               etrans. apply maponpaths, pathsinv0, pb'_commutes.
+
+               etrans. apply functor_comp.
+               apply maponpaths.
+
+               unfold f'.
+               etrans. apply functor_comp.
+               etrans. apply maponpaths_2, functor_comp.
+               etrans. apply assoc'.
+               apply maponpaths.
+
+               apply pathsinv0.
+               etrans. apply maponpaths, pathsinv0, id_right.
+               etrans. apply maponpaths, maponpaths, pathsinv0.
+               apply (maponpaths (λ F, pr1 F (invS U'))
+                                 (iso_inv_after_iso η)).
+
+               etrans. apply maponpaths, assoc.
+               etrans. apply maponpaths, maponpaths_2.
+               apply (nat_trans_ax (pr1 η)).
+
+               etrans. apply assoc.
+               etrans. apply maponpaths_2, assoc.
+               etrans. apply maponpaths_2, maponpaths_2.
+               apply (maponpaths (λ F, pr1 F (J X))
+                                 (iso_after_iso_inv η)).
+               etrans. apply maponpaths_2, id_left.
+
+               apply maponpaths.
+
+               set ( XXX :=
+                   pr2 (iso_to_nat_iso _ _ η)
+                       (invS U') (invS (S (invS U')))
+                     ).
+               unfold isweq in XXX.
+
+               (* FIXME: STUCK *)
+               Check adjointificiation.
+               Print equivalence_of_precats.
+               apply STUCK.
+
+            -- Check (isPullback_image_square
+                        _ _ invS
+                        _ _ _ pb'_commutes (pr22 pb')).
+               unfold fp, fq. simpl.
+            -- use (isPullback_image_square (pr2 pb')).
+              assert (invS_pb : maps_pb_squares_to_pb_squares D' D invS).
+               {
+                 intros a' b' c' d' f0 g h k H pbH a h0 k0 H0.
+                 apply STUCK.
+               }
+               intros e h k comm.
+               unfold fpb_ob. unfold source in k. simpl in *.
+               Check S_pb.
+               Search maps_pb_squares_to_pb_squares.
+               Print maps_pb_squares_to_pb_squares.
+               Print maps_pb_square_to_pb_square.
+               Print preserves_pullbacks_ext.
+    Defined.
+
+  End RelUniv_Transfer_with_ess_surj.
+
+End RelUniv_Transfer.
+
+Section WeakRelUniv_Transfer.
+
+  (*       J
+      C  -----> D
+      |         |
+    R |         | S
+      |         |
+      v         v
+      C' -----> D'
+           J'
+   *)
+  Context (C D C' D' : category).
+  Context (J  : functor C D).
+  Context (J' : functor C' D').
+  Context (R : functor C C').
+  Context (S : functor D D').
+
+  (* the square of functors above commutes
+   * up to natural isomorphism *)
+  Context (α : [C, D'] ⟦ J ∙ S, R ∙ J' ⟧).
+  Context (α_is_iso : is_iso α).
+
+  (* J and J' are fully faithful *)
+  Context (ff_J : fully_faithful J).
+  Context (ff_J' : fully_faithful J').
+
+  (* D and D' are univalent *)
+  Context (Dcat : is_univalent D).
+  Context (D'cat : is_univalent D').
+
+  (* S preserves pullbacks *)
+  Context (S_pb : maps_pb_squares_to_pb_squares _ _ S).
+
+  (* S is an equivalence *)
+  Context (T : functor D' D).
+  Context (η : iso (C := [D, D, pr2 D]) (functor_identity D) (S ∙ T)).
+  Context (ε : iso (C := [D', D', pr2 D']) (T ∙ S) (functor_identity D')).
+  Context (S_full : full S).
+  Context (S_faithful : faithful S).
+
+  (* R is essentially surjective and full *)
+  Context (R_es : essentially_surjective R).
+  Context (R_full : full R).
+
+  Local Definition S_ff : fully_faithful S.
+  Proof.
+    use full_and_faithful_implies_fully_faithful.
+    use make_dirprod.
+    - apply S_full.
+    - apply S_faithful.
+  Defined.
+
+  Let weq_weak_reluniv
+    := weq_weak_relative_universe_transfer
+         _ _ _ _ _
+         α_is_iso S_pb R_es S_full
+         R_full Dcat D'cat T η ε S_ff.
+
+  Definition weq_weak_reluniv_mor_J_to_J'
+             (u1 u2 : weak_relative_universe J)
+    : weak_reluniv_cat J  ⟦ u1, u2 ⟧
+    ≃ weak_reluniv_cat J' ⟦ weq_weak_reluniv u1, weq_weak_reluniv u2 ⟧.
+  Proof.
+    set (S_weq := weq_from_fully_faithful S_ff).
+    use weqtotal2.
+    - use weqdirprodf.
+      + apply S_weq.
+      + apply S_weq.
+    - intros mor.
+      eapply weqcomp.
+      apply (maponpaths (S_weq _ _) ,, isweqmaponpaths _ _ _).
+      apply eqweqmap.
+      unfold is_gen_reluniv_mor; simpl.
+      etrans. apply maponpaths, functor_comp.
+      etrans. apply maponpaths_2, functor_comp.
+      apply idpath.
+  Defined.
+
+  Definition weak_reluniv_functor_data
+    : functor_data (weak_reluniv_cat J) (weak_reluniv_cat J').
+  Proof.
+    use make_functor_data.
+    - apply weq_weak_reluniv.
+    - apply weq_weak_reluniv_mor_J_to_J'.
+  Defined.
+
+  Definition weak_reluniv_functor_idax
+    : functor_idax weak_reluniv_functor_data.
+  Proof.
+    intros u.
+    use gen_reluniv_mor_eq.
+    - etrans. apply functor_id. apply idpath.
+    - etrans. apply functor_id. apply idpath.
+  Defined.
+
+  Definition weak_reluniv_functor_compax
+    : functor_compax weak_reluniv_functor_data.
+  Proof.
+    intros a b c f g.
+    use gen_reluniv_mor_eq.
+    - etrans. apply functor_comp. apply idpath.
+    - etrans. apply functor_comp. apply idpath.
+  Defined.
+
+  Definition weak_reluniv_is_functor
+    : is_functor weak_reluniv_functor_data
+    := (weak_reluniv_functor_idax ,, weak_reluniv_functor_compax).
+
+  Definition weak_reluniv_functor
+    : functor (weak_reluniv_cat J) (weak_reluniv_cat J')
+    := make_functor
+         weak_reluniv_functor_data
+         weak_reluniv_is_functor.
+
+  Definition weak_reluniv_functor_is_catiso
+    : is_catiso weak_reluniv_functor.
+  Proof.
+    use tpair.
+    - intros u1 u2.
+      apply weq_weak_reluniv_mor_J_to_J'.
+    - apply weq_weak_relative_universe_transfer.
+  Defined.
+
+  Local Definition relu_J_to_relu_J'
+        (C'_univ : is_univalent C')
+    : functor (reluniv_cat J) (reluniv_cat J')
+    := reluniv_functor_with_ess_surj
+         _ _ _ _ _ _ _ _ _ α_is_iso
+         S_pb C'_univ ff_J' S_full R_es.
+
+  Definition weak_relu_square_commutes_on_mor
+        (C'_univ : is_univalent C')
+        (u1 u2 : reluniv_cat J)
+        (mor : reluniv_cat J ⟦ u1, u2 ⟧)
+    : pr21 (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J') u1 u2 mor
+    = pr21 (weak_from_reluniv_functor J ∙ weak_reluniv_functor) u1 u2 mor.
+  Proof.
+    use gen_reluniv_mor_eq.
+    - apply idpath.
+    - apply idpath.
+  Defined.
+
+  Definition weak_relu_square_nat_trans
+        (C'_univ : is_univalent C')
+    : nat_trans
+        (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J')
+        (weak_from_reluniv_functor J ∙ weak_reluniv_functor).
+  Proof.
+    use tpair.
+    + intros u.
+      use tpair.
+      * use tpair.
+        -- apply identity.
+        -- apply identity.
+      * unfold is_gen_reluniv_mor.
+        cbn.
+        etrans. apply id_left.
+        apply pathsinv0, id_right.
+    + intros u1 u2 mor.
+      use gen_reluniv_mor_eq.
+      * simpl.
+        etrans. apply id_right.
+        apply pathsinv0, id_left.
+      * simpl.
+        etrans. apply id_right.
+        apply pathsinv0, id_left.
+  Defined.
+
+  Definition weak_relu_square_nat_trans_is_nat_iso
+        (C'_univ : is_univalent C')
+    : is_nat_iso (weak_relu_square_nat_trans C'_univ).
+  Proof.
+    intros u1 wu1.
+    use isweq_iso.
+    - intros mor.
+      apply mor.
+    - intros mor.
+      use id_left. (* FIXME: works, but slow for some reason *)
+    - intros mor.
+      use id_left. (* FIXME: works, but slow for some reason *)
+  Defined.
+    
+  Definition weak_relu_square_commutes
+        (C'_univ : is_univalent C')
+    : nat_iso
+        (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J')
+        (weak_from_reluniv_functor J ∙ weak_reluniv_functor).
+  Proof.
+    use tpair.
+    - apply weak_relu_square_nat_trans.
+    - apply weak_relu_square_nat_trans_is_nat_iso.
+  Defined.
+
+  Definition weak_relu_square_commutes_strictly
+             (C'_univ : is_univalent C')
+    : (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J')
+        = (weak_from_reluniv_functor J ∙ weak_reluniv_functor).
+  Proof.
+    use (isotoid _ (is_univalent_functor_category _ _ _)).
+    apply weak_reluniv_cat_is_univalent.
+    apply D'cat.
+    use nat_iso_to_iso.
+    apply weak_relu_square_commutes.
+  Defined.
+
+  Definition reluniv_functor_with_ess_surj_issurjective
+             (C'_univ : is_univalent C')
+             (AC : AxiomOfChoice.AxiomOfChoice)
+             (obC_isaset : isaset C)
+    : issurjective (reluniv_functor_with_ess_surj
+                      _ _ _ _ J J'
+                      R S α α_is_iso
+                      S_pb C'_univ ff_J' S_full R_es
+                   ).
+  Proof.
+    set (W := (weak_from_reluniv_functor J'
+            ,, weak_from_reluniv_functor_is_catiso J' C'_univ ff_J')
+        : catiso _ _).
+    use (Core.issurjective_postcomp_with_weq _ (catiso_ob_weq W)).
+    use (transportf (λ F, issurjective (pr11 F))
+                    (! weak_relu_square_commutes_strictly C'_univ)).
+    use issurjcomp.
+    - apply weak_from_reluniv_functor_issurjective.
+      apply AC.
+      apply obC_isaset.
+    - apply issurjectiveweq.
+      apply (catiso_ob_weq (_,,weak_reluniv_functor_is_catiso)).
+  Defined.
+
+End WeakRelUniv_Transfer.
+
+Section RelUniv_Yo_Rezk.
+
+  Context (C : category).
+  Let RC : univalent_category := Rezk_completion C (homset_property _).
+
+  Let R := Rezk_eta C (homset_property _).
+  Let R_ff := Rezk_eta_fully_faithful C (homset_property _).
+  Let R_es := Rezk_eta_essentially_surjective C (homset_property _).
+  Let S := Transport_along_Equivs.ext R R_ff R_es.
+  Let S_pb := Transport_along_Equivs.preserves_pullbacks_ext R R_ff R_es.
+  Let α := Transport_along_Equivs.fi R R_ff R_es.
+
+  Local Definition R_full : full R.
+  Proof.
+    apply fully_faithful_implies_full_and_faithful, R_ff.
+  Defined.
+
+  Definition transfer_of_RelUnivYoneda_functor
+    : functor (@reluniv_cat C _ Yo) (@reluniv_cat RC _ Yo).
+  Proof.
+    use (reluniv_functor_with_ess_surj
+           _ _ _ _ Yo Yo
+           R S
+           α
+           (pr2 α)
+           S_pb
+           (pr2 RC)
+           (yoneda_fully_faithful _ _)
+           (right_adj_equiv_is_full _ _)
+           R_es
+        ).
+  Defined.
+
+  Definition transfer_of_RelUnivYoneda_functor_ff
+    : fully_faithful transfer_of_RelUnivYoneda_functor.
+  Proof.
+    use (reluniv_functor_with_ess_surj_ff _ _ _ _ Yo Yo).
+    use right_adj_equiv_is_ff.
+  Defined.
+
+  Let T := Transport_along_Equivs.Fop_precomp R.
+
+  Definition transfer_of_RelUnivYoneda_functor_issurjective
+             (AC : AxiomOfChoice.AxiomOfChoice)
+             (obC_isaset : isaset C)
+    : issurjective transfer_of_RelUnivYoneda_functor.
+  Proof.
+    use (reluniv_functor_with_ess_surj_issurjective
+           _ _ _ _ Yo Yo
+           _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+           AC obC_isaset
+        ).
+    - apply is_univalent_preShv.
+    - apply is_univalent_preShv.
+    - apply T.
+    - apply epsinv.
+    - apply etainv.
+    - apply fully_faithful_implies_full_and_faithful.
+      apply right_adj_equiv_is_ff.
+    - apply R_full.
+  Defined.
+
+  Definition transfer_of_WeakRelUnivYoneda_functor
+    : functor (@weak_reluniv_cat C _ Yo) (@weak_reluniv_cat RC _ Yo).
+  Proof.
+    use (weak_reluniv_functor
+           _ _ _ _ Yo Yo
+           R S
+           α
+           (pr2 α)
+           (is_univalent_preShv _)
+           (is_univalent_preShv _)
+           S_pb
+           T
+        ).
+    - apply epsinv.
+    - apply etainv.
+    - apply right_adj_equiv_is_full.
+    - apply fully_faithful_implies_full_and_faithful.
+      apply right_adj_equiv_is_ff.
+    - apply R_es.
+    - apply R_full.
+  Defined.
+
+  Definition transfer_of_WeakRelUnivYoneda_functor_is_catiso
+    : is_catiso transfer_of_WeakRelUnivYoneda_functor.
+  Proof.
+    apply weak_reluniv_functor_is_catiso.
+  Defined.
+
+  Definition WeakRelUnivYoneda_functor_square_commutes_strictly
+    : (transfer_of_RelUnivYoneda_functor ∙ weak_from_reluniv_functor _)
+        = (weak_from_reluniv_functor _ ∙ transfer_of_WeakRelUnivYoneda_functor).
+  Proof.
+    apply weak_relu_square_commutes_strictly.
+  Defined.
+
+End RelUniv_Yo_Rezk.

--- a/TypeTheory/ALV2/]
+++ b/TypeTheory/ALV2/]
@@ -819,7 +819,7 @@ Section RelUniv_Yo_Rezk.
     apply weak_reluniv_functor_is_catiso.
   Defined.
 
-  Definition WeakRelUnivYoneda_functor_square_commutes_strictly
+  Definition WeakRelUnivYoneda_functor_square_commutes_identity
     : (transfer_of_RelUnivYoneda_functor ∙ weak_from_reluniv_functor _)
         = (weak_from_reluniv_functor _ ∙ transfer_of_WeakRelUnivYoneda_functor).
   Proof.

--- a/TypeTheory/ALV2/]
+++ b/TypeTheory/ALV2/]
@@ -691,7 +691,7 @@ Section WeakRelUniv_Transfer.
     - apply weak_relu_square_nat_trans_is_nat_iso.
   Defined.
 
-  Definition weak_relu_square_commutes_strictly
+  Definition weak_relu_square_commutes_identity
              (C'_univ : is_univalent C')
     : (relu_J_to_relu_J' C'_univ ∙ weak_from_reluniv_functor J')
         = (weak_from_reluniv_functor J ∙ weak_reluniv_functor).


### PR DESCRIPTION
My hypothesis is that we do not need any extra assumptions like AC or univalent C for the functor between RelUniv(J) and RelUniv(J') to be surjective.

Current WIP proof starts with some stronger assumptions which should be relaxed:
- [ ] R is split essentially surjective ➞ R is essentially surjective
- [ ] S is an equivalence ➞ S is full and reflects pullbacks (however, this might be insufficient);

Now I have an mapping on objects to go from RelUniv(J') to RelUniv(J) which I should document properly. Proving that it is a right inverse directly is cumbersome, so @peterlefanulumsdaine suggested another approach:
- [x] show an isomorphism instead of identity first;
- [x] show that RelUniv(J') is univalent (under some conditions)
- [ ] use univalence to get identity and
- [ ] complete proof of surjectivity

Finally, I plan to
- [ ] clean up the code :)