### PR TITLE
Type categories are equivalent to (full and faithful) comprehension categories

### DIFF
--- a/TypeTheory/ALV2/.package/files
+++ b/TypeTheory/ALV2/.package/files
@@ -12,3 +12,4 @@ RelUniv_Cat_Iso.v
 RelUniv_Cat_Yo_CwF_Iso.v
 RelUnivTransfer.v
 TypeCat_ComprehensionCat.v
+FullyFaithfulDispFunctor.v

--- a/TypeTheory/ALV2/FullyFaithfulDispFunctor.v
+++ b/TypeTheory/ALV2/FullyFaithfulDispFunctor.v
@@ -1,0 +1,662 @@
+(*
+  [TypeTheory.ALV2.FullyFaithfulDispFunctor]
+
+  Part of the [TypeTheory] library (Ahrens, Lumsdaine, Voevodsky, 2015–present).
+*)
+
+(**
+
+Fully faithful displayed functors over identity functor on C
+with fixed target displayed categories are completely determined
+my their action on objects.
+
+Specifically we have an equivalence [ff_disp_functor_weq] between
+[ff_disp_functor] (an alias for [ff_disp_functor_on_objects])
+and [ff_disp_functor_explicit] (which is a combination of
+a source displayed category over C and a fully faithful functor
+over identity functor on C from said category into D').
+
+Main definitions:
+
+- [ff_disp_functor] (same as [ff_disp_functor_on_objects]) —
+  definition of fully faithful functor without (contractible) morphisms;
+- [ff_disp_functor_explicit] — combination of a source displayed category
+  over C and a fully faithful displayed functor (over identity functor on C)
+  into D';
+- [ff_disp_functor_weq] — equivalence of the two definitions;
+
+Accessors for [ff_disp_functor]:
+
+- [source_disp_cat_from_ff_disp_functor] — source displayed category;
+- [disp_functor_from_ff_disp_functor] — displayed functor (also acts as coercion);
+- [disp_functor_from_ff_disp_functor_is_ff] — proof that extracted functor is fully faithful;
+
+*)
+
+Require Import UniMath.MoreFoundations.PartA.
+Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
+
+Require Import TypeTheory.Auxiliary.Auxiliary.
+Require Import UniMath.CategoryTheory.DisplayedCats.Core.
+
+Section Auxiliary.
+
+  (* TODO: move upstream? *)
+  Lemma weqtotaltoforall3 {X : UU}
+        (P1 : X → UU)
+        (P2 : ∏ x : X, P1 x → UU)
+        (P3 : ∏ (x : X) (y : P1 x), P2 x y → UU)
+    : (∑ (p1 : ∏ x : X, P1 x) (p2 : ∏ x : X, P2 x (p1 x)), ∏ x : X, P3 x (p1 x) (p2 x))
+        ≃ (∏ x : X, ∑ (p1 : P1 x) (p2 : P2 x p1), P3 x p1 p2).
+  Proof.
+    eapply weqcomp.
+    apply (weqtotal2asstol
+             (λ p1, ∏ x : X, P2 x (p1 x))
+             (λ p12, ∏ x : X, P3 x (pr1 p12 x) (pr2 p12 x))
+          ).
+    eapply weqcomp.
+    use weqtotal2. 3: apply weqtotaltoforall.
+    - exact (λ p12, ∏ x : X, P3 x (pr1 (p12 x)) (pr2 (p12 x))).
+    - intros x. apply idweq.
+
+    - eapply weqcomp.
+      apply (weqtotaltoforall
+               (λ x : X, ∑ y : P1 x, P2 x y)
+               (λ (x : X) p12, P3 x (pr1 p12) (pr2 p12))
+            ).
+      apply weqonsecfibers.
+      intros x.
+      apply weqtotal2asstor.
+  Defined.
+
+  (* TODO: move upstream? *)
+  Lemma iscontr_total2
+        {X : UU} {P : X → UU}
+    : iscontr X → (∏ x : X, iscontr (P x)) → iscontr (∑ (x : X), P x).
+  Proof.
+    intros X_contr P_contr.
+    use tpair.
+    - exists (pr1 X_contr). apply P_contr.
+    - intros xp.
+      use total2_paths_f.
+      + apply X_contr.
+      + apply P_contr.
+  Defined.
+
+  (* TODO: move upstream? *)
+  Lemma idpath_transportb
+        {X : UU} (P : X → UU)
+        (x : X) (p : P x)
+    : transportb P (idpath x) p = p.
+  Proof.
+    apply idpath.
+  Defined.
+
+  (* TODO: move upstream? *)
+  Lemma homot_invweq_transportb_weq
+        (Z : UU)
+        (z z' : Z)
+        (X Y : Z → UU)
+        (e : z = z')
+        (w : ∏ z : Z, X z ≃ Y z)
+        (x : X z')
+    : invmap (w z) (transportb Y e (w z' x)) = transportb X e x.
+  Proof.
+    induction e.
+    etrans. apply maponpaths, idpath_transportb.
+    apply homotinvweqweq.
+  Defined.
+
+End Auxiliary.
+
+Section FullyFaithfulDispFunctor.
+
+  (* Fully faithful displayed functor (over identity functor on C) into D'
+   * is completely determined by its action on objects:
+   *
+   * - type family of displayed objects (for the source displayed category) over objects in C
+   * - mapping of said displayed objects to displayed objects in D' over C.
+   * *)
+  Definition ff_disp_functor_on_objects {C : category}
+             (D' : disp_cat C)
+    : UU
+    := ∑ (ob_disp : C → UU)
+       (* Fob *), ∏ (Γ : C), ob_disp Γ → D' Γ.
+
+  Section FullyFaithfulFunctorOnMorphisms.
+
+    Context {C : category} {D' : disp_cat C}.
+    Context (D : ff_disp_functor_on_objects D').
+
+    Definition ff_disp_functor_on_morphisms_sop : UU
+      := ∑ (mord : ∏ Γ Γ', (pr1 D Γ) → (pr1 D Γ') → (Γ --> Γ') → UU)
+           (functor_mord : ∏ Γ Γ' (A : pr1 D Γ) (A' : pr1 D Γ') (f : Γ --> Γ')
+                           , (mord _ _ A A' f) -> (pr2 D _ A -->[ f ] pr2 D _ A'))
+         , ∏ Γ Γ' (A : pr1 D Γ) (A' : pr1 D Γ') (f : Γ --> Γ')
+         , isweq (functor_mord Γ Γ' A A' f).
+
+    Definition ff_disp_functor_on_morphisms_pos : UU
+      := ∏ Γ Γ' (A : pr1 D Γ) (A' : pr1 D Γ') (f : Γ --> Γ'),
+         ∑ (mord : UU), mord ≃ (pr2 D _ A -->[ f ] pr2 D _ A').
+
+    Definition ff_disp_functor_on_morphisms_sop_pos_weq
+      : ff_disp_functor_on_morphisms_sop ≃ ff_disp_functor_on_morphisms_pos.
+    Proof.
+      eapply weqcomp.
+      apply (weqtotaltoforall3
+               (λ Γ, ∏ Γ', (pr1 D Γ) → (pr1 D Γ') → (Γ --> Γ') → UU)
+               (λ Γ mord, ∏ Γ' (A : pr1 D Γ) (A' : pr1 D Γ') (f : Γ --> Γ')
+                , (mord _ A A' f) -> (pr2 D _ A -->[ f ] pr2 D _ A'))
+               (λ Γ mord functor_mord, 
+                ∏ Γ' (A : pr1 D Γ) (A' : pr1 D Γ') (f : Γ --> Γ')
+                , isweq (functor_mord Γ' A A' f))).
+      apply weqonsecfibers. intros Γ.
+
+      eapply weqcomp.
+      apply (weqtotaltoforall3
+               (λ Γ', (pr1 D Γ) → (pr1 D Γ') → (Γ --> Γ') → UU)
+               (λ Γ' mord, ∏ (A : pr1 D Γ) (A' : pr1 D Γ') (f : Γ --> Γ')
+                , (mord A A' f) -> (pr2 D _ A -->[ f ] pr2 D _ A'))
+               (λ Γ' mord functor_mord, 
+                ∏ (A : pr1 D Γ) (A' : pr1 D Γ') (f : Γ --> Γ')
+                , isweq (functor_mord A A' f))).
+      apply weqonsecfibers. intros Γ'.
+
+      eapply weqcomp.
+      apply (weqtotaltoforall3
+               (λ A, (pr1 D Γ') → (Γ --> Γ') → UU)
+               (λ A mord, ∏ (A' : pr1 D Γ') (f : Γ --> Γ')
+                , (mord A' f) -> (pr2 D _ A -->[ f ] pr2 D _ A'))
+               (λ A mord functor_mord, 
+                ∏ (A' : pr1 D Γ') (f : Γ --> Γ')
+                , isweq (functor_mord A' f))).
+      apply weqonsecfibers. intros A.
+
+      eapply weqcomp.
+      apply (weqtotaltoforall3
+               (λ A', (Γ --> Γ') → UU)
+               (λ A' mord, ∏ (f : Γ --> Γ')
+                , (mord f) -> (pr2 D _ A -->[ f ] pr2 D _ A'))
+               (λ A' mord functor_mord, 
+                ∏ (f : Γ --> Γ')
+                , isweq (functor_mord f))).
+      apply weqonsecfibers. intros A'.
+
+      eapply weqcomp.
+      apply (weqtotaltoforall3
+               (λ f, UU)
+               (λ f mord, mord -> (pr2 D _ A -->[ f ] pr2 D _ A'))
+               (λ f mord functor_mord, isweq functor_mord)).
+      apply idweq.
+    Defined.
+
+    Definition ff_disp_functor_on_morphisms_pos_iscontr
+      : iscontr ff_disp_functor_on_morphisms_pos.
+    Proof.
+      apply impred_iscontr. intros Γ.
+      apply impred_iscontr. intros Γ'.
+      apply impred_iscontr. intros A.
+      apply impred_iscontr. intros A'.
+      apply impred_iscontr. intros f.
+      use (@iscontrweqf (∑ mord : UU, mord = pr2 D Γ A -->[f] pr2 D Γ' A')).
+      - use (weqtotal2 (idweq _)). intros mord. apply univalenceweq.
+      - apply iscontrcoconustot.
+    Defined.
+
+    Definition ff_disp_functor_on_morphisms_pos_isaprop
+      : isaprop ff_disp_functor_on_morphisms_pos.
+    Proof.
+      apply isapropifcontr, ff_disp_functor_on_morphisms_pos_iscontr.
+    Defined.
+
+    Definition ff_disp_functor_on_morphisms_id_pos
+               (mor_weq : ff_disp_functor_on_morphisms_pos)
+      : UU
+      := ∏ (Γ : C) (A : pr1 D Γ),
+         ∑ (mor_id : pr1 (mor_weq Γ Γ A A (identity Γ))),
+         pr1 (pr2 (mor_weq Γ Γ A A (identity Γ))) mor_id
+         = transportb (mor_disp (pr2 D Γ A) (pr2 D Γ A))
+                      (functor_id (functor_identity C) Γ) (id_disp (pr2 D Γ A)).
+
+    Definition ff_disp_functor_on_morphisms_id_pos_iscontr
+               (mor_weq : ff_disp_functor_on_morphisms_pos)
+               (mor_isaset : ∏ Γ Γ' f (A : pr1 D Γ) (A' : pr1 D Γ'), isaset (pr1 (mor_weq _ _ A A' f)))
+      : iscontr (ff_disp_functor_on_morphisms_id_pos mor_weq).
+    Proof.
+      apply impred_iscontr. intros Γ.
+      apply impred_iscontr. intros A.
+      set (mord := pr1 (mor_weq Γ Γ A A (identity Γ))).
+      set (mord_weq := pr2 (mor_weq Γ Γ A A (identity Γ))).
+      use (@iscontrweqf (∑ mor_id : mord, mor_id = invweq mord_weq
+                                                          (transportb (mor_disp (pr2 D Γ A) (pr2 D Γ A))
+                                                                      (functor_id (functor_identity C) Γ) (id_disp (pr2 D Γ A))))).
+      - use (weqtotal2 (idweq _)). intros mor_id. simpl.
+        use weq_iso.
+        + intros p. apply (maponpaths mord_weq p @ homotweqinvweq mord_weq _).
+        + intros p. apply (! homotinvweqweq mord_weq _ @ maponpaths (invmap mord_weq) p).
+        + intros p. apply mor_isaset.
+        + intros p. apply (@homsets_disp _ D').
+      - apply iscontrcoconustot.
+    Defined.
+
+    Definition ff_disp_functor_on_morphisms_comp_pos
+               (mor_weq : ff_disp_functor_on_morphisms_pos)
+      : UU
+      := ∏ (Γ Γ' Γ'' : C)
+           (A : pr1 D Γ) (A' : pr1 D Γ') (A'' : pr1 D Γ'')
+           (f : Γ --> Γ') (g : Γ' --> Γ'')
+           (ff : pr1 (mor_weq Γ Γ' A A' f))
+           (gg : pr1 (mor_weq Γ' Γ'' A' A'' g)),
+         ∑ (mor_comp : pr1 (mor_weq Γ Γ'' A A'' (f ;; g))),
+         pr2 (mor_weq Γ Γ'' A A'' (f ;; g)) mor_comp
+         = transportb _ (functor_comp (functor_identity C) f g)
+                      (comp_disp (pr2 (mor_weq _ _ _ _ _) ff) (pr2 (mor_weq _ _ _ _ _) gg)).
+
+    Definition ff_disp_functor_on_morphisms_comp_pos_iscontr
+               (mor_weq : ff_disp_functor_on_morphisms_pos)
+               (mor_isaset : ∏ Γ Γ' f (A : pr1 D Γ) (A' : pr1 D Γ'), isaset (pr1 (mor_weq _ _ A A' f)))
+      : iscontr (ff_disp_functor_on_morphisms_comp_pos mor_weq).
+    Proof.
+      apply impred_iscontr. intros Γ.
+      apply impred_iscontr. intros Γ'.
+      apply impred_iscontr. intros Γ''.
+      apply impred_iscontr. intros A.
+      apply impred_iscontr. intros A'.
+      apply impred_iscontr. intros A''.
+      apply impred_iscontr. intros f.
+      apply impred_iscontr. intros g.
+      apply impred_iscontr. intros ff.
+      apply impred_iscontr. intros gg.
+      set (mord := pr1 (mor_weq Γ Γ'' A A'' (f ;; g))).
+      set (mord_weq := pr2 (mor_weq Γ Γ'' A A'' (f ;; g))).
+      use (@iscontrweqf (∑ mor_comp : mord,
+                                      mor_comp
+                                      = invweq mord_weq (transportb _ (functor_comp (functor_identity C) f g)
+                                                                    (comp_disp (pr2 (mor_weq _ _ _ _ _) ff) (pr2 (mor_weq _ _ _ _ _) gg))))).
+      - use (weqtotal2 (idweq _)). intros mor_id. simpl.
+        use weq_iso.
+        + intros p. apply (maponpaths mord_weq p @ homotweqinvweq mord_weq _).
+        + intros p. apply (! homotinvweqweq mord_weq _ @ maponpaths (invmap mord_weq) p).
+        + intros p. apply mor_isaset.
+        + intros p. apply (@homsets_disp _ D').
+      - apply iscontrcoconustot.
+    Defined.
+
+    Definition ff_disp_functor_source_mor_isaset
+               (mor_weq : ff_disp_functor_on_morphisms_pos)
+      : ∏ Γ Γ' f (A : pr1 D Γ) (A' : pr1 D Γ'), isaset (pr1 (mor_weq _ _ A A' f)).
+    Proof.
+      intros Γ Γ' f A A'.
+      set (w := pr2 (mor_weq Γ Γ' A A' f)).
+      use (isofhlevelweqf 2 (invweq w)).
+      apply (@homsets_disp _ D').
+    Defined.
+
+    Definition ff_disp_functor_source_mor_isaset_iscontr
+               (mor_weq : ff_disp_functor_on_morphisms_pos)
+      : iscontr (∏ Γ Γ' f (A : pr1 D Γ) (A' : pr1 D Γ'), isaset (pr1 (mor_weq _ _ A A' f))).
+    Proof.
+      apply iscontraprop1.
+      - apply impred_isaprop. intros Γ.
+        apply impred_isaprop. intros Γ'.
+        apply impred_isaprop. intros A.
+        apply impred_isaprop. intros A'.
+        apply impred_isaprop. intros f.
+        apply isapropisaset.
+      - apply ff_disp_functor_source_mor_isaset.
+    Defined.
+
+    Definition ff_disp_functor_on_morphisms_idcomp_pos : UU
+      := ∑ (mor_weq : ff_disp_functor_on_morphisms_pos)
+           (mor_isaset : ∏ Γ Γ' f (A : pr1 D Γ) (A' : pr1 D Γ'), isaset (pr1 (mor_weq _ _ A A' f)))
+           (mor_id : ff_disp_functor_on_morphisms_id_pos mor_weq)
+         , ff_disp_functor_on_morphisms_comp_pos mor_weq.
+
+    Definition ff_disp_functor_on_morphisms_idcomp_pos_iscontr
+      : iscontr ff_disp_functor_on_morphisms_idcomp_pos.
+    Proof.
+      apply iscontr_total2.
+      - apply ff_disp_functor_on_morphisms_pos_iscontr.
+      - intros mor_weq. apply iscontr_total2.
+        + apply ff_disp_functor_source_mor_isaset_iscontr.
+        + intros mor_isaset.
+          apply iscontr_total2.
+          * apply ff_disp_functor_on_morphisms_id_pos_iscontr.
+            apply mor_isaset.
+          * intros ?.
+            apply ff_disp_functor_on_morphisms_comp_pos_iscontr.
+            apply mor_isaset.
+    Defined.
+
+    Definition ff_disp_functor_on_morphisms_idcomp_sop
+      := ∑ (mor_disp : ∏ {x y : C}, pr1 D x -> pr1 D y -> (x --> y) -> UU)
+           (id_disp' : ∏ {x : C} (xx : pr1 D x), mor_disp xx xx (identity x))
+           (comp_disp' : ∏ {x y z : C} {f : x --> y} {g : y --> z}
+                           {xx : pr1 D x} {yy : pr1 D y} {zz : pr1 D z},
+                         mor_disp xx yy f -> mor_disp yy zz g -> mor_disp xx zz (f ;; g))
+           (homsets_disp : ∏ {x y} {f : x --> y} {xx} {yy}, isaset (mor_disp xx yy f))
+           (Fmor : ∏ x y (xx : pr1 D x) (yy : pr1 D y) (f : x --> y),
+                   (mor_disp xx yy f) -> (pr2 D _ xx -->[ f ] pr2 D _ yy))
+           (Fid : ∏ x (xx : pr1 D x),
+                  Fmor _ _ _ _ _ (id_disp' xx) = transportb _ (functor_id (functor_identity C) x) (id_disp (pr2 D _ xx)))
+           (Fcomp :  ∏ x y z (xx : pr1 D x) yy zz (f : x --> y) (g : y --> z)
+                       (ff : mor_disp xx yy f) (gg : mor_disp yy zz g),
+                     Fmor _ _ _ _ _ (comp_disp' ff gg)
+                     = transportb _ (functor_comp (functor_identity _) f g) (comp_disp (Fmor _ _ _ _ _ ff) (Fmor _ _ _ _ _ gg)))
+         , ∏ x y (xx : pr1 D x) (yy : pr1 D y) (f : x --> y),
+         isweq (fun ff : mor_disp xx yy f => Fmor _ _ _ _ _ ff).
+
+    Definition ff_disp_functor_on_morphisms_idcomp_sop_pos_weq
+      : ff_disp_functor_on_morphisms_idcomp_sop ≃ ff_disp_functor_on_morphisms_idcomp_pos.
+    Proof.
+      use weq_iso.
+
+      - intros sop.
+        set (mor_disp := pr1 sop).
+        set (id_disp' := pr1 (pr2 sop)).
+        set (comp_disp' := pr1 (pr2 (pr2 sop))).
+        set (homsets_disp' := pr1 (pr2 (pr2 (pr2 sop)))).
+        set (Fmor := pr1 (pr2 (pr2 (pr2 (pr2 sop))))).
+        set (Fid := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 sop)))))).
+        set (Fcomp := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+        set (Fff := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+
+        exists (λ x y xx yy f, mor_disp x y xx yy f ,, Fmor x y xx yy f,, Fff x y xx yy f).
+        exists homsets_disp'.
+        exists (λ x xx, (id_disp' x xx ,, Fid x xx)).
+        exact (λ x y z xx yy zz f g ff gg, (comp_disp' x y z f g xx yy zz ff gg ,, Fcomp x y z xx yy zz f g ff gg)).
+
+      - intros pos.
+        set (mor_disp := λ x y xx yy f, pr1 (pr1 pos x y xx yy f)).
+        set (Fmor := λ x y xx yy f, pr1 (pr2 (pr1 pos x y xx yy f))).
+        set (Fff := λ x y xx yy f, pr2 (pr2 (pr1 pos x y xx yy f))).
+        set (homsets_disp' := pr1 (pr2 pos)).
+        set (id_disp' := λ x xx, pr1 (pr1 (pr2 (pr2 pos)) x xx)).
+        set (Fid := λ x xx, pr2 (pr1 (pr2 (pr2 pos)) x xx)).
+        set (comp_disp' := λ x y z f g xx yy zz ff gg, pr1 (pr2 (pr2 (pr2 pos)) x y z xx yy zz f g ff gg)).
+        set (Fcomp := λ x y z xx yy zz f g ff gg, pr2 (pr2 (pr2 (pr2 pos)) x y z xx yy zz f g ff gg)).
+
+        exists mor_disp.
+        exists id_disp'.
+        exists comp_disp'.
+        exists homsets_disp'.
+        exists Fmor.
+        exists Fid.
+        exists Fcomp.
+        exact Fff.
+      - intros ?. apply idpath.
+      - intros ?. apply idpath.
+    Defined.
+
+    Definition source_disp_cat_data_of_ff_disp_functor_on_morphisms_idcomp_sop
+      : ff_disp_functor_on_morphisms_idcomp_sop → disp_cat_data C.
+    Proof.
+      intros sop.
+      set (mor_disp := pr1 sop).
+      set (id_disp' := pr1 (pr2 sop)).
+      set (comp_disp' := pr1 (pr2 (pr2 sop))).
+
+      use tpair.
+      - exists (pr1 D). apply mor_disp.
+      - exact (id_disp' , comp_disp').
+    Defined.
+
+    Definition ff_disp_functor_mor_sop : UU
+      := ∑ (mor_idcomp : ff_disp_functor_on_morphisms_idcomp_sop),
+         disp_cat_axioms _ (source_disp_cat_data_of_ff_disp_functor_on_morphisms_idcomp_sop
+                              mor_idcomp).
+    
+    Definition ff_disp_functor_mor_sop_iscontr
+      : iscontr ff_disp_functor_mor_sop.
+    Proof.
+      apply iscontr_total2.
+      - apply (iscontrweqb ff_disp_functor_on_morphisms_idcomp_sop_pos_weq).
+        apply ff_disp_functor_on_morphisms_idcomp_pos_iscontr.
+      - intros sop.
+        apply iscontr_total2.
+
+        + apply impred_iscontr. intros Γ.
+          apply impred_iscontr. intros Γ'.
+          apply impred_iscontr. intros f.
+          apply impred_iscontr. intros A.
+          apply impred_iscontr. intros A'.
+          apply impred_iscontr. intros ff.
+          apply iscontraprop1. apply (pr1 (pr2 (pr2 (pr2 sop)))).
+          set (id_disp' := pr1 (pr2 sop)).
+          set (comp_disp' := pr1 (pr2 (pr2 sop))).
+          set (Fmor := pr1 (pr2 (pr2 (pr2 (pr2 sop))))).
+          set (Fid := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 sop)))))).
+          set (Fcomp := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+          set (Fff := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+          set (w := λ g, (Fmor _ _ A A' g,, Fff _ _ _ _ _)).
+          etrans. apply pathsinv0. apply (homotinvweqweq (w _)).
+          etrans. apply maponpaths. apply Fcomp.
+          etrans. apply maponpaths, maponpaths, maponpaths_2. apply Fid.
+          etrans. apply maponpaths, maponpaths. apply id_left_disp.
+          etrans. apply maponpaths. apply transport_b_b. simpl.
+          apply homot_invweq_transportb_weq.
+          
+        + intros ?.
+          apply iscontr_total2.
+
+          * apply impred_iscontr. intros Γ.
+            apply impred_iscontr. intros Γ'.
+            apply impred_iscontr. intros f.
+            apply impred_iscontr. intros A.
+            apply impred_iscontr. intros A'.
+            apply impred_iscontr. intros ff.
+            apply iscontraprop1. apply (pr1 (pr2 (pr2 (pr2 sop)))).
+            set (id_disp' := pr1 (pr2 sop)).
+            set (comp_disp' := pr1 (pr2 (pr2 sop))).
+            set (Fmor := pr1 (pr2 (pr2 (pr2 (pr2 sop))))).
+            set (Fid := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 sop)))))).
+            set (Fcomp := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+            set (Fff := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+            set (w := λ g, (Fmor _ _ A A' g,, Fff _ _ _ _ _)).
+            etrans. apply pathsinv0. apply (homotinvweqweq (w _)).
+            etrans. apply maponpaths. apply Fcomp.
+            etrans. apply maponpaths, maponpaths, maponpaths. apply Fid.
+            etrans. apply maponpaths, maponpaths. apply id_right_disp.
+            etrans. apply maponpaths. apply transport_b_b. simpl.
+            apply homot_invweq_transportb_weq.
+
+          * intros ?. apply iscontr_total2.
+
+            -- apply impred_iscontr. intros Γ.
+               apply impred_iscontr. intros Γ'.
+               apply impred_iscontr. intros Γ''.
+               apply impred_iscontr. intros Γ'''.
+               apply impred_iscontr. intros f.
+               apply impred_iscontr. intros g.
+               apply impred_iscontr. intros h.
+               apply impred_iscontr. intros A.
+               apply impred_iscontr. intros A'.
+               apply impred_iscontr. intros A''.
+               apply impred_iscontr. intros A'''.
+               apply impred_iscontr. intros ff.
+               apply impred_iscontr. intros gg.
+               apply impred_iscontr. intros hh.
+               apply iscontraprop1. apply (pr1 (pr2 (pr2 (pr2 sop)))).
+               set (id_disp' := pr1 (pr2 sop)).
+               set (comp_disp' := pr1 (pr2 (pr2 sop))).
+               set (Fmor := pr1 (pr2 (pr2 (pr2 (pr2 sop))))).
+               set (Fid := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 sop)))))).
+               set (Fcomp := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+               set (Fff := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+               set (w := λ g, (Fmor _ _ A A''' g,, Fff _ _ _ _ _)).
+               etrans. apply pathsinv0. apply (homotinvweqweq (w (f ;; (g ;; h)))).
+               etrans. apply maponpaths. apply Fcomp.
+               etrans. apply maponpaths, maponpaths, maponpaths. apply Fcomp.
+               etrans. apply maponpaths, maponpaths. apply assoc_disp.
+               etrans. apply maponpaths. apply transport_b_b.
+               (* WORK IN PROGRESS *)
+               etrans. apply maponpaths, maponpaths, maponpaths_2, pathsinv0, Fcomp.
+               etrans. apply maponpaths, maponpaths, pathsinv0, Fcomp.
+               apply homot_invweq_transportb_weq.
+            -- intros ?.
+               set (homsets_disp' := pr1 (pr2 (pr2 (pr2 sop)))).
+               apply iscontraprop1.
+               ++ apply impred_isaprop. intros Γ.
+                  apply impred_isaprop. intros Γ'.
+                  apply impred_isaprop. intros f.
+                  apply impred_isaprop. intros A.
+                  apply impred_isaprop. intros A'.
+                  apply isapropisaset.
+               ++ apply homsets_disp'.
+    Defined.
+
+  End FullyFaithfulFunctorOnMorphisms.
+
+  Section FullyFaithfulFunctorWithMorphisms.
+
+    (* Fully faithful displayed functor (over identity functor on C) into D'
+     * (equipped with contractible action on morphisms). *)
+    Definition ff_disp_functor_with_morphisms
+               {C : category} (D' : disp_cat C)
+    : UU
+      := ∑ (D : ff_disp_functor_on_objects D'), ff_disp_functor_mor_sop D.
+
+    (* Source displayed category over C
+     * extracted from a fully faithful displayed functor (over identity functor on C) *)
+    Definition source_disp_cat_from_ff_disp_functor_with_morphisms
+               {C : category} {D' : disp_cat C}
+               (Fsop : ff_disp_functor_with_morphisms D')
+      : disp_cat C.
+    Proof.
+      set (sop := pr1 (pr2 Fsop)).
+
+      set (ob_disp := pr1 (pr1 Fsop)).
+      set (axioms_d := pr2 (pr2 Fsop)).
+
+      set (mor_disp := pr1 sop).
+      set (id_disp' := pr1 (pr2 sop)).
+      set (comp_disp' := pr1 (pr2 (pr2 sop))).
+
+      exact (((ob_disp ,, mor_disp) ,, (id_disp' , comp_disp')) ,, axioms_d).
+    Defined.
+
+    Definition disp_functor_from_ff_disp_functor_with_morphisms
+               {C : category} {D' : disp_cat C}
+               (Fsop : ff_disp_functor_with_morphisms D')
+      : disp_functor (functor_identity C) (source_disp_cat_from_ff_disp_functor_with_morphisms Fsop) D'.
+    Proof.
+      set (sop := pr1 (pr2 Fsop)).
+
+      set (Fob := pr2 (pr1 Fsop)).
+      set (Fmor := pr1 (pr2 (pr2 (pr2 (pr2 sop))))).
+      set (Fid := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 sop)))))).
+      set (Fcomp := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+
+      exact ((Fob,,Fmor),,(Fid,Fcomp)).
+    Defined.
+
+    Coercion disp_functor_from_ff_disp_functor_with_morphisms
+      : ff_disp_functor_with_morphisms >-> disp_functor.
+
+    Definition disp_functor_from_ff_disp_functor_with_morphisms_is_ff
+               {C : category} {D' : disp_cat C}
+               (Fsop : ff_disp_functor_with_morphisms D')
+      : disp_functor_ff (disp_functor_from_ff_disp_functor_with_morphisms Fsop).
+    Proof.
+      set (sop := pr1 (pr2 Fsop)).
+      set (Fff := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+      exact Fff.
+    Defined.
+
+    Definition ff_disp_functor_with_morphisms_eq
+               {C : category} (D' : disp_cat C)
+               (X Y : ff_disp_functor_with_morphisms D')
+               (e : pr1 X = pr1 Y)
+      : X = Y.
+    Proof.
+      use total2_paths_f.
+      - apply e.
+      - apply isapropifcontr.
+        apply ff_disp_functor_mor_sop_iscontr.
+    Defined.
+
+    Definition ff_disp_functor_explicit
+               {C : category} (D' : disp_cat C)
+      : UU
+      := ∑ (D : disp_cat C) (F : disp_functor (functor_identity _) D D'), disp_functor_ff F.
+    
+    Definition ff_disp_functor_with_morphisms_weq
+               {C : category} {D' : disp_cat C}
+      : ff_disp_functor_with_morphisms D' ≃ ff_disp_functor_explicit D'.
+    Proof.
+      use weq_iso.
+
+      - intros Fsop.
+        exists (source_disp_cat_from_ff_disp_functor_with_morphisms Fsop).
+        exists (disp_functor_from_ff_disp_functor_with_morphisms Fsop).
+        apply disp_functor_from_ff_disp_functor_with_morphisms_is_ff.
+
+      - intros F.
+        
+        set (ob_disp := pr1 (pr1 (pr1 (pr1 F)))).
+        set (mor_disp := pr2 (pr1 (pr1 (pr1 F)))).
+        set (id_disp' := pr1 (pr2 (pr1 (pr1 F)))).
+        set (comp_disp' := pr2 (pr2 (pr1 (pr1 F)))).
+        set (axioms_d := pr2 (pr1 F)).
+        set (homsets_disp' := pr2 (pr2 (pr2 axioms_d))).
+
+        set (Fob := pr1 (pr1 (pr1 (pr2 F)))).
+        set (Fmor := pr2 (pr1 (pr1 (pr2 F)))).
+        set (Fid := pr1 (pr2 (pr1 (pr2 F)))).
+        set (Fcomp := pr2 (pr2 (pr1 (pr2 F)))).
+        set (Fff := pr2 (pr2 F)).
+
+        exists (ob_disp ,, Fob).
+        exists (mor_disp ,, id_disp' ,, comp_disp' ,, homsets_disp' ,, Fmor ,, Fid ,, Fcomp ,, Fff).
+        exact axioms_d.
+
+      - intros ?. apply ff_disp_functor_with_morphisms_eq. apply idpath.
+      - intros ?. apply idpath.
+    Defined.
+
+    Definition ff_disp_functor_on_objects_ff_disp_functor_with_morphisms_weq
+               {C : category} {D' : disp_cat C}
+      : ff_disp_functor_on_objects D' ≃ ff_disp_functor_with_morphisms D'.
+    Proof.
+      apply invweq, weqpr1.
+      intros D.
+      apply ff_disp_functor_mor_sop_iscontr.
+    Defined.
+
+  End FullyFaithfulFunctorWithMorphisms.
+
+  (* Fully faithful displayed functor (over identity functor on C) into D'. *)
+  Definition ff_disp_functor
+             {C : category} (D' : disp_cat C)
+    : UU
+    := ff_disp_functor_on_objects D'.
+
+  Definition ff_disp_functor_weq
+             {C : category} {D' : disp_cat C}
+    : ff_disp_functor D' ≃ ff_disp_functor_explicit D'.
+  Proof.
+    eapply weqcomp. apply ff_disp_functor_on_objects_ff_disp_functor_with_morphisms_weq.
+    apply ff_disp_functor_with_morphisms_weq.
+  Defined.
+
+  Definition source_disp_cat_from_ff_disp_functor
+             {C : category} {D' : disp_cat C}
+             (F : ff_disp_functor D')
+    : disp_cat C
+    := pr1 (ff_disp_functor_weq F).
+
+  Definition disp_functor_from_ff_disp_functor
+             {C : category} {D' : disp_cat C}
+             (F : ff_disp_functor D')
+    : disp_functor (functor_identity C) (source_disp_cat_from_ff_disp_functor F) D'
+    := pr1 (pr2 (ff_disp_functor_weq F)).
+
+  Coercion disp_functor_from_ff_disp_functor : ff_disp_functor >-> disp_functor.
+
+  Definition disp_functor_from_ff_disp_functor_is_ff
+             {C : category} {D' : disp_cat C}
+             (F : ff_disp_functor D')
+    : disp_functor_ff F
+    := pr2 (pr2 (ff_disp_functor_weq F)).
+
+End FullyFaithfulDispFunctor.

--- a/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
+++ b/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
@@ -449,6 +449,19 @@ Section Auxiliary.
     apply homotinvweqweq.
   Defined.
 
+  Lemma homot_invweq_transportb
+        (Z : UU)
+        (z z' : Z)
+        (X Y : Z → UU)
+        (e : z = z')
+        (w : ∏ z : Z, X z ≃ Y z)
+        (y : Y z')
+    : invmap (w z) (transportb Y e y) = transportb X e (invmap (w z') y).
+  Proof.
+    induction e.
+    apply idpath.
+  Defined.
+
   Definition disp_ff_functor_sop_iscontr
              {C : category} {D' : disp_cat C}
              (D : disp_ff_functor_to_on_objects D')
@@ -529,13 +542,26 @@ Section Auxiliary.
              set (Fcomp := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
              set (Fff := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
              set (w := λ g, (Fmor _ _ A A''' g,, Fff _ _ _ _ _)).
-             etrans. apply pathsinv0. apply (homotinvweqweq (w _)).
+             etrans. apply pathsinv0. apply (homotinvweqweq (w (f ;; (g ;; h)))).
              etrans. apply maponpaths. apply Fcomp.
              etrans. apply maponpaths, maponpaths, maponpaths. apply Fcomp.
              etrans. apply maponpaths, maponpaths. apply assoc_disp.
-             etrans. apply maponpaths. apply transport_b_b. simpl.
+             etrans. apply maponpaths. apply transport_b_b.
              (* WORK IN PROGRESS *)
-  Abort.
+             etrans. apply maponpaths, maponpaths, maponpaths_2, pathsinv0, Fcomp.
+             etrans. apply maponpaths, maponpaths, pathsinv0, Fcomp.
+             apply homot_invweq_transportb_weq.
+          -- intros ?.
+             set (homsets_disp' := pr1 (pr2 (pr2 (pr2 sop)))).
+             apply iscontraprop1.
+             ++ apply impred_isaprop. intros Γ.
+                apply impred_isaprop. intros Γ'.
+                apply impred_isaprop. intros f.
+                apply impred_isaprop. intros A.
+                apply impred_isaprop. intros A'.
+                apply isapropisaset.
+             ++ apply homsets_disp'.
+  Defined.
 
   (* Types for parts of a fully faithful functor that rely on morphisms *)
   Section disp_ff_functor_to_on_morphisms.

--- a/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
+++ b/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
@@ -486,6 +486,9 @@ End TypeCat_Disp_Functor.
 (* TODO: move upstream *)
 Definition comprehension_cat := ∑ (C : category), (comprehension_cat_structure C).
 
+Coercion category_of_comprehension_cat (C : comprehension_cat) := pr1 C.
+Coercion structure_of_comprehension_cat (C : comprehension_cat) := pr2 C.
+
 Section ComprehensionCat_TypeCat.
   Context {C : category}.
   Context (CC : comprehension_cat_structure C).
@@ -641,5 +644,36 @@ Section TypeCat_ComprehensionCat.
     exists (pr1 CC).
     apply (typecat_structure_from_comprehension_cat (pr2 CC)).
   Defined.
+    
+  Definition fully_faithful_comprehension_cat_structure
+             {C : category} (CC : comprehension_cat_structure C)
+    := disp_functor_ff (pr1 (pr2 (pr2 CC))).
+
+  Definition typecat_comprehension_cat_structure_weq
+             {C : category}
+    : typecat_structure C ≃ ∑ CC : comprehension_cat_structure C, fully_faithful_comprehension_cat_structure CC.
+  Proof.
+    use weq_iso.
+    - intros TC.
+      exact (typecat_to_comprehension_cat_structure TC ,, typecat_disp_functor_ff TC).
+    - intros CC. apply (typecat_structure_from_comprehension_cat (pr1 CC)).
+    - intros TC.
+      repeat use total2_paths_f.
+      + apply idpath.
+      + apply idpath.
+      + apply idpath.
+      + apply idpath.
+      + apply idpath.
+      + apply idpath.
+      + apply funextsec. intros Γ.
+        apply funextsec. intros A.
+        apply funextsec. intros Γ'.
+        apply funextsec. intros f.
+        apply isaprop_isPullback.
+    - intros ff_CC.
+      repeat use total2_paths_f.
+      + apply idpath.
+      + (* STUCK: need to think, this might be impossible *) (* apply idpath. *)
+  Abort.
 
 End TypeCat_ComprehensionCat.

--- a/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
+++ b/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
@@ -1278,6 +1278,18 @@ Section TypeCat_ComprehensionCat.
     - intros ?. apply idpath.
   Defined.
 
+  Definition typecat_obj_ext_structure_ff_disp_functor_to_codomain_weq
+             (C : category)
+    : typecat_obj_ext_structure C ≃
+      ∑ (D : disp_cat C)
+      (F : disp_functor (functor_identity _) D (disp_codomain C))
+      , disp_functor_ff F.
+  Proof.
+    eapply weqcomp. apply typecat_obj_ext_structure_disp_ff_functor_to_codomain_weq.
+    eapply weqcomp. apply disp_ff_functor_sop_disp_ff_functor_to_on_objects_weq.
+    apply disp_ff_functor_sop_disp_functor_ff_weq.
+  Defined.
+
   Definition ff_comprehension_cat_structure (C : category) : UU
     := ∑ (F : disp_ff_functor_sop (disp_codomain C)),
        cleaving (source_disp_cat_of_disp_ff_functor_sop F)

--- a/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
+++ b/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
@@ -69,12 +69,12 @@ Section Auxiliary.
     := ∑ (obd : C → UU)
        , ∏ (Γ : C), obd Γ → D' Γ.
 
-  Definition disp_ff_functor_to_on_morphisms
+  Definition disp_ff_functor_to_on_morphisms'
              {C : category} {D' : disp_cat C} 
              (D : disp_ff_functor_to_on_objects D')
+             (mord : ∏ (Γ Γ' : C), (pr1 D Γ) → (pr1 D Γ') → (Γ --> Γ') → UU)
     : UU
-    := ∑ (mord : ∏ (Γ Γ' : C), (pr1 D Γ) → (pr1 D Γ') → (Γ --> Γ') → UU)
-         (id_comp_d : disp_cat_id_comp C (_ ,, mord))
+    := ∑ (id_comp_d : disp_cat_id_comp C (_ ,, mord))
          (axioms_d : disp_cat_axioms C (_,, id_comp_d))
          (functor_mord :
             ∏ x y (xx : ((_,,axioms_d) : disp_cat C) x) (yy : pr1 D y) (f : x --> y),
@@ -86,6 +86,13 @@ Section Auxiliary.
        , disp_functor_ff ((_ ,, functor_axioms_d)
                           : disp_functor (functor_identity C)
                                          (_ ,, axioms_d) D').
+
+  Definition disp_ff_functor_to_on_morphisms
+             {C : category} {D' : disp_cat C} 
+             (D : disp_ff_functor_to_on_objects D')
+    : UU
+    := ∑ (mord : ∏ (Γ Γ' : C), (pr1 D Γ) → (pr1 D Γ') → (Γ --> Γ') → UU)
+       , disp_ff_functor_to_on_morphisms' D mord.
 
   Definition disp_ff_functor_to
              {C : category} (D' : disp_cat C)
@@ -118,6 +125,41 @@ Section Auxiliary.
     : disp_functor_ff (disp_functor_of_disp_ff_functor D)
     := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 D))))).
 
+  Definition disp_ff_functor_mor_eq
+             {C : category} {D' : disp_cat C}
+             (D : disp_ff_functor_to_on_objects D')
+             (m1 m2 : ∏ (Γ Γ' : C), (pr1 D Γ) → (pr1 D Γ') → (Γ --> Γ') → UU)
+             (e_mor : m1 = m2)
+             (X : disp_ff_functor_to_on_morphisms' D m1)
+             (Y : disp_ff_functor_to_on_morphisms' D m2)
+    : transportf _ e_mor X = Y.
+  Proof.
+    induction e_mor.
+    etrans. apply idpath_transportf.
+    use total2_paths_f.
+    - use dirprod_paths.
+      + apply funextsec. intros Γ.
+        apply funextsec. intros A.
+
+        set (id_disp_X := pr1 (pr1 X) Γ A).
+        set (id_disp_Y := pr1 (pr1 Y) Γ A).
+
+        (* STUCK *)
+
+        (*
+        apply funextsec. intros Γ.
+        apply funextsec. intros A.
+        set (id_disp_1 := pr1 id_comp_d1).
+        set (id_disp_2 := pr1 id_comp_d2).
+        set (e1 := pr1 axioms_d1 Γ Γ _ A A (id_disp_2 Γ A)).
+        set (e2 := pr1 (dirprod_pr2 axioms_d2) Γ Γ _ A A (id_disp_1 Γ A)).
+        unfold id_disp, id_disp_1, id_disp_2 in *.
+        simpl in *.
+        Check (!e1 @ e2).
+         *)
+  Abort.
+             
+
   Lemma isaprop_disp_source_functor_on_morphisms
         {C : category} {D' : disp_cat C} 
         (D : disp_ff_functor_to_on_objects D')
@@ -139,8 +181,23 @@ Section Auxiliary.
         * use dirprod_paths.
           -- apply funextsec. intros Γ.
              apply funextsec. intros A.
+
              set (Fid_axiom_X := pr1 (pr2 (disp_functor_of_disp_ff_functor (D,,X))) Γ A).
              set (Fid_axiom_Y := pr1 (pr2 (disp_functor_of_disp_ff_functor (D,,Y))) Γ A).
+
+             set (id_disp_X := pr1 (pr1 (pr2 X))).
+             set (id_disp_Y := pr1 (pr1 (pr2 Y))).
+
+             (*
+
+             Check (pr1 (pr1 (pr2 (pr2 X))) Γ Γ _ A A (id_disp_Y Γ A)).
+             set (Did_axiom_X := 
+
+             simpl in *.
+             Check Fid_axiom_Y.
+             Check Fid_axiom_X @ !Fid_axiom_Y.
+             Search weq.
+              *)
              (* TODO: work in progress *)
              (*
              maponpaths (Fid_axiom_X @ !Fid_axiom_Y).

--- a/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
+++ b/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
@@ -226,6 +226,53 @@ Section Auxiliary.
     - apply iscontrcoconustot.
   Defined.
 
+  Definition disp_ff_functor_on_morphisms_comp_pos
+             {C : category} {D' : disp_cat C}
+             (D : disp_ff_functor_to_on_objects D')
+             (mor_weq : disp_ff_functor_on_morphisms_pos D)
+    : UU
+    := ∏ (Γ Γ' Γ'' : C)
+         (A : pr1 D Γ) (A' : pr1 D Γ') (A'' : pr1 D Γ'')
+         (f : Γ --> Γ') (g : Γ' --> Γ'')
+         (ff : pr1 (mor_weq Γ Γ' A A' f))
+         (gg : pr1 (mor_weq Γ' Γ'' A' A'' g)),
+       ∑ (mor_comp : pr1 (mor_weq Γ Γ'' A A'' (f ;; g))),
+       pr2 (mor_weq Γ Γ'' A A'' (f ;; g)) mor_comp
+       = transportb _ (functor_comp (functor_identity C) f g)
+                    (comp_disp (pr2 (mor_weq _ _ _ _ _) ff) (pr2 (mor_weq _ _ _ _ _) gg)).
+
+  Definition disp_ff_functor_on_morphisms_comp_pos_iscontr
+             {C : category} {D' : disp_cat C}
+             (D : disp_ff_functor_to_on_objects D')
+             (mor_weq : disp_ff_functor_on_morphisms_pos D)
+             (mor_isaset : ∏ Γ Γ' f (A : pr1 D Γ) (A' : pr1 D Γ'), isaset (pr1 (mor_weq _ _ A A' f)))
+    : iscontr (disp_ff_functor_on_morphisms_comp_pos D mor_weq).
+  Proof.
+    apply impred_iscontr. intros Γ.
+    apply impred_iscontr. intros Γ'.
+    apply impred_iscontr. intros Γ''.
+    apply impred_iscontr. intros A.
+    apply impred_iscontr. intros A'.
+    apply impred_iscontr. intros A''.
+    apply impred_iscontr. intros f.
+    apply impred_iscontr. intros g.
+    apply impred_iscontr. intros ff.
+    apply impred_iscontr. intros gg.
+    set (mord := pr1 (mor_weq Γ Γ'' A A'' (f ;; g))).
+    set (mord_weq := pr2 (mor_weq Γ Γ'' A A'' (f ;; g))).
+    use (@iscontrweqf (∑ mor_comp : mord,
+       mor_comp
+       = invweq mord_weq (transportb _ (functor_comp (functor_identity C) f g)
+                    (comp_disp (pr2 (mor_weq _ _ _ _ _) ff) (pr2 (mor_weq _ _ _ _ _) gg))))).
+    - use (weqtotal2 (idweq _)). intros mor_id. simpl.
+      use weq_iso.
+      + intros p. apply (maponpaths mord_weq p @ homotweqinvweq mord_weq _).
+      + intros p. apply (! homotinvweqweq mord_weq _ @ maponpaths (invmap mord_weq) p).
+      + intros p. apply mor_isaset.
+      + intros p. apply (@homsets_disp _ D').
+    - apply iscontrcoconustot.
+  Defined.
+
   (* Types for parts of a fully faithful functor that rely on morphisms *)
   Section disp_ff_functor_to_on_morphisms.
 

--- a/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
+++ b/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
@@ -111,8 +111,6 @@ Section Auxiliary.
     := ∑ (obd : C → UU)
        , ∏ (Γ : C), obd Γ → D' Γ.
 
-  Check weqtotaltoforall.
-
   Definition disp_ff_functor_on_morphisms_sop
              {C : category} {D' : disp_cat C}
              (D : disp_ff_functor_to_on_objects D')
@@ -340,6 +338,70 @@ Section Auxiliary.
         * intros ?.
           apply disp_ff_functor_on_morphisms_comp_pos_iscontr.
           apply mor_isaset.
+  Defined.
+
+  Definition disp_ff_functor_on_morphisms_idcomp_sop
+             {C : category} {D' : disp_cat C}
+             (D : disp_ff_functor_to_on_objects D')
+    := ∑ (mor_disp : ∏ {x y : C}, (x --> y) -> pr1 D x -> pr1 D y -> UU)
+         (id_disp' : ∏ {x : C} (xx : pr1 D x), mor_disp (identity x) xx xx)
+         (comp_disp' : ∏ {x y z : C} {f : x --> y} {g : y --> z}
+                        {xx : pr1 D x} {yy : pr1 D y} {zz : pr1 D z},
+                      mor_disp f xx yy -> mor_disp g yy zz -> mor_disp (f ;; g) xx zz)
+         (homsets_disp : ∏ {x y} {f : x --> y} {xx} {yy}, isaset (mor_disp f xx yy))
+         (Fmor : ∏ x y (xx : pr1 D x) (yy : pr1 D y) (f : x --> y),
+                 (mor_disp f xx yy) -> (pr2 D _ xx -->[ f ] pr2 D _ yy))
+         (Fid : ∏ x (xx : pr1 D x),
+                Fmor _ _ _ _ _ (id_disp' xx) = transportb _ (functor_id (functor_identity C) x) (id_disp (pr2 D _ xx)))
+         (Fcomp :  ∏ x y z (xx : pr1 D x) yy zz (f : x --> y) (g : y --> z)
+                     (ff : mor_disp f xx yy) (gg : mor_disp g yy zz),
+                   Fmor _ _ _ _ _ (comp_disp' ff gg)
+                   = transportb _ (functor_comp (functor_identity _) f g) (comp_disp (Fmor _ _ _ _ _ ff) (Fmor _ _ _ _ _ gg)))
+       , ∏ x y (xx : pr1 D x) (yy : pr1 D y) (f : x --> y),
+       isweq (fun ff : mor_disp f xx yy => Fmor _ _ _ _ _ ff).
+
+  Definition disp_ff_functor_on_morphisms_idcomp_sop_pos_weq
+             {C : category} {D' : disp_cat C}
+             (D : disp_ff_functor_to_on_objects D')
+    : disp_ff_functor_on_morphisms_idcomp_sop D ≃ disp_ff_functor_on_morphisms_idcomp_pos D.
+  Proof.
+    use weq_iso.
+
+    - intros sop.
+      set (mor_disp := pr1 sop).
+      set (id_disp' := pr1 (pr2 sop)).
+      set (comp_disp' := pr1 (pr2 (pr2 sop))).
+      set (homsets_disp' := pr1 (pr2 (pr2 (pr2 sop)))).
+      set (Fmor := pr1 (pr2 (pr2 (pr2 (pr2 sop))))).
+      set (Fid := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 sop)))))).
+      set (Fcomp := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+      set (Fff := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+
+      exists (λ x y xx yy f, mor_disp x y f xx yy ,, Fmor x y xx yy f,, Fff x y xx yy f).
+      exists homsets_disp'.
+      exists (λ x xx, (id_disp' x xx ,, Fid x xx)).
+      exact (λ x y z xx yy zz f g ff gg, (comp_disp' x y z f g xx yy zz ff gg ,, Fcomp x y z xx yy zz f g ff gg)).
+
+    - intros pos.
+      set (mor_disp := λ x y f xx yy, pr1 (pr1 pos x y xx yy f)).
+      set (Fmor := λ x y xx yy f, pr1 (pr2 (pr1 pos x y xx yy f))).
+      set (Fff := λ x y xx yy f, pr2 (pr2 (pr1 pos x y xx yy f))).
+      set (homsets_disp' := pr1 (pr2 pos)).
+      set (id_disp' := λ x xx, pr1 (pr1 (pr2 (pr2 pos)) x xx)).
+      set (Fid := λ x xx, pr2 (pr1 (pr2 (pr2 pos)) x xx)).
+      set (comp_disp' := λ x y z f g xx yy zz ff gg, pr1 (pr2 (pr2 (pr2 pos)) x y z xx yy zz f g ff gg)).
+      set (Fcomp := λ x y z xx yy zz f g ff gg, pr2 (pr2 (pr2 (pr2 pos)) x y z xx yy zz f g ff gg)).
+
+      exists mor_disp.
+      exists id_disp'.
+      exists comp_disp'.
+      exists homsets_disp'.
+      exists Fmor.
+      exists Fid.
+      exists Fcomp.
+      exact Fff.
+    - intros ?. apply idpath.
+    - intros ?. apply idpath.
   Defined.
 
   (* Types for parts of a fully faithful functor that rely on morphisms *)
@@ -1023,11 +1085,6 @@ Section TypeCat_ComprehensionCat.
   Definition fully_faithful_comprehension_cat_structure
              {C : category} (CC : comprehension_cat_structure C)
     := disp_functor_ff (pr1 (pr2 (pr2 CC))).
-
-  Print disp_cat_ob_mor.
-
-  Print cleaving.
-  Check cartesian_lift.
 
   Definition typecat_obj_ext_structure_disp_ff_functor_to_codomain_weq
              (C : category)

--- a/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
+++ b/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
@@ -1290,6 +1290,39 @@ Section TypeCat_ComprehensionCat.
     apply disp_ff_functor_sop_disp_functor_ff_weq.
   Defined.
 
+  Definition typecat_structure' (C : category) : UU
+    := ∑ (TC : typecat_obj_ext_structure C)
+         (reind : ∏ Γ (A : TC Γ) Γ' (f : Γ' --> Γ), TC Γ')
+         (q : ∏ Γ (A : TC Γ) Γ' (f : Γ' --> Γ), (obj_ext_typecat Γ' (reind _ A _ f)) --> obj_ext_typecat Γ A )
+         (dpr_q : ∏ Γ (A : TC Γ) Γ' (f : Γ' --> Γ), 
+                  (q _ A _ f) ;; (dpr_typecat_obj_ext A) = (dpr_typecat_obj_ext (reind _ A _ f)) ;; f),
+       ∏ Γ (A : TC Γ) Γ' (f : Γ' --> Γ),
+       isPullback _ _ _ _ (!dpr_q _ A _ f).
+
+  Definition typecat_structure_typecat_structure'_weq
+             (C : category)
+    : typecat_structure C ≃ typecat_structure' C.
+  Proof.
+    eapply weqcomp. apply weqtotal2asstor.
+    apply invweq.
+    eapply weqcomp. apply weqtotal2asstor.
+    apply (weqtotal2 (idweq _)). intros Ty.
+
+    eapply weqcomp. apply weqtotal2asstor.
+    apply invweq. eapply weqcomp. apply weqtotal2asstor.
+    apply (weqtotal2 (idweq _)). intros ext.
+
+    eapply weqcomp. unfold typecat_structure2. simpl.
+    apply (@WeakEquivalences.weqtotal2comm
+             _ _
+             (λ reind dpr,
+              ∑ (q : ∏ Γ (A : Ty Γ) Γ' (f : Γ' --> Γ), (ext Γ' (reind _ A _ f)) --> ext Γ A )
+                (dpr_q : ∏ Γ (A : Ty Γ) Γ' (f : Γ' --> Γ), 
+                         (q _ A _ f) ;; (dpr _ A) = (dpr _ (reind _ A _ f)) ;; f),
+              _)).
+    apply idweq.
+  Defined.
+
   Definition ff_comprehension_cat_structure (C : category) : UU
     := ∑ (F : disp_ff_functor_sop (disp_codomain C)),
        cleaving (source_disp_cat_of_disp_ff_functor_sop F)

--- a/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
+++ b/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
@@ -62,15 +62,7 @@ Section Auxiliary.
     apply idpath.
   Defined.
 
-  Definition disp_ff_functor_to_on_objects
-             {C : category}
-             (D' : disp_cat C)
-    : UU
-    := ∑ (obd : C → UU)
-       , ∏ (Γ : C), obd Γ → D' Γ.
-
-  Check weqtotaltoforall.
-
+  (* TODO: move upstream? *)
   Lemma weqtotaltoforall3 {X : UU}
         (P1 : X → UU)
         (P2 : ∏ x : X, P1 x → UU)
@@ -97,6 +89,15 @@ Section Auxiliary.
       intros x.
       apply weqtotal2asstor.
   Defined.
+
+  Definition disp_ff_functor_to_on_objects
+             {C : category}
+             (D' : disp_cat C)
+    : UU
+    := ∑ (obd : C → UU)
+       , ∏ (Γ : C), obd Γ → D' Γ.
+
+  Check weqtotaltoforall.
 
   Definition disp_ff_functor_on_morphisms_sop
              {C : category} {D' : disp_cat C}
@@ -189,6 +190,40 @@ Section Auxiliary.
     : isaprop (disp_ff_functor_on_morphisms_pos D).
   Proof.
     apply isapropifcontr, disp_ff_functor_on_morphisms_pos_iscontr.
+  Defined.
+
+  Definition disp_ff_functor_on_morphisms_id_pos
+             {C : category} {D' : disp_cat C}
+             (D : disp_ff_functor_to_on_objects D')
+             (mor_weq : disp_ff_functor_on_morphisms_pos D)
+    : UU
+    := ∏ (Γ : C) (A : pr1 D Γ),
+       ∑ (mor_id : pr1 (mor_weq Γ Γ A A (identity Γ))),
+       pr1 (pr2 (mor_weq Γ Γ A A (identity Γ))) mor_id
+       = transportb (mor_disp (pr2 D Γ A) (pr2 D Γ A))
+                    (functor_id (functor_identity C) Γ) (id_disp (pr2 D Γ A)).
+
+  Definition disp_ff_functor_on_morphisms_id_pos_iscontr
+             {C : category} {D' : disp_cat C}
+             (D : disp_ff_functor_to_on_objects D')
+             (mor_weq : disp_ff_functor_on_morphisms_pos D)
+             (mor_isaset : ∏ Γ Γ' f (A : pr1 D Γ) (A' : pr1 D Γ'), isaset (pr1 (mor_weq _ _ A A' f)))
+    : iscontr (disp_ff_functor_on_morphisms_id_pos D mor_weq).
+  Proof.
+    apply impred_iscontr. intros Γ.
+    apply impred_iscontr. intros A.
+    set (mord := pr1 (mor_weq Γ Γ A A (identity Γ))).
+    set (mord_weq := pr2 (mor_weq Γ Γ A A (identity Γ))).
+    use (@iscontrweqf (∑ mor_id : mord, mor_id = invweq mord_weq
+                                    (transportb (mor_disp (pr2 D Γ A) (pr2 D Γ A))
+                                                (functor_id (functor_identity C) Γ) (id_disp (pr2 D Γ A))))).
+    - use (weqtotal2 (idweq _)). intros mor_id. simpl.
+      use weq_iso.
+      + intros p. apply (maponpaths mord_weq p @ homotweqinvweq mord_weq _).
+      + intros p. apply (! homotinvweqweq mord_weq _ @ maponpaths (invmap mord_weq) p).
+      + intros p. apply mor_isaset.
+      + intros p. apply (@homsets_disp _ D').
+    - apply iscontrcoconustot.
   Defined.
 
   (* Types for parts of a fully faithful functor that rely on morphisms *)

--- a/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
+++ b/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
@@ -104,6 +104,30 @@ Section Auxiliary.
       + apply P_contr.
   Defined.
 
+  (* TODO: move upstream? *)
+  Lemma idpath_transportb
+        {X : UU} (P : X → UU)
+        (x : X) (p : P x)
+    : transportb P (idpath x) p = p.
+  Proof.
+    apply idpath.
+  Defined.
+
+  (* TODO: move upstream? *)
+  Lemma homot_invweq_transportb_weq
+        (Z : UU)
+        (z z' : Z)
+        (X Y : Z → UU)
+        (e : z = z')
+        (w : ∏ z : Z, X z ≃ Y z)
+        (x : X z')
+    : invmap (w z) (transportb Y e (w z' x)) = transportb X e x.
+  Proof.
+    induction e.
+    etrans. apply maponpaths, idpath_transportb.
+    apply homotinvweqweq.
+  Defined.
+
   Definition disp_ff_functor_to_on_objects
              {C : category}
              (D' : disp_cat C)
@@ -419,7 +443,7 @@ Section Auxiliary.
     - exact (id_disp' , comp_disp').
   Defined.
 
-  Definition disp_ff_functor_sop
+  Definition disp_ff_functor_mor_sop
              {C : category} {D' : disp_cat C}
              (D : disp_ff_functor_to_on_objects D')
     : UU
@@ -427,45 +451,10 @@ Section Auxiliary.
       disp_cat_axioms _ (source_disp_cat_data_of_disp_ff_functor_on_morphisms_idcomp_sop
                            D mor_idcomp).
         
-  Lemma idpath_transportb
-        {X : UU} (P : X → UU)
-        (x : X) (p : P x)
-    : transportb P (idpath x) p = p.
-  Proof.
-    apply idpath.
-  Defined.
-
-  Lemma homot_invweq_transportb_weq
-        (Z : UU)
-        (z z' : Z)
-        (X Y : Z → UU)
-        (e : z = z')
-        (w : ∏ z : Z, X z ≃ Y z)
-        (x : X z')
-    : invmap (w z) (transportb Y e (w z' x)) = transportb X e x.
-  Proof.
-    induction e.
-    etrans. apply maponpaths, idpath_transportb.
-    apply homotinvweqweq.
-  Defined.
-
-  Lemma homot_invweq_transportb
-        (Z : UU)
-        (z z' : Z)
-        (X Y : Z → UU)
-        (e : z = z')
-        (w : ∏ z : Z, X z ≃ Y z)
-        (y : Y z')
-    : invmap (w z) (transportb Y e y) = transportb X e (invmap (w z') y).
-  Proof.
-    induction e.
-    apply idpath.
-  Defined.
-
-  Definition disp_ff_functor_sop_iscontr
+  Definition disp_ff_functor_mor_sop_iscontr
              {C : category} {D' : disp_cat C}
              (D : disp_ff_functor_to_on_objects D')
-    : iscontr (disp_ff_functor_sop D).
+    : iscontr (disp_ff_functor_mor_sop D).
   Proof.
     apply iscontr_total2.
     - apply (iscontrweqb (disp_ff_functor_on_morphisms_idcomp_sop_pos_weq _)).
@@ -561,6 +550,74 @@ Section Auxiliary.
                 apply impred_isaprop. intros A'.
                 apply isapropisaset.
              ++ apply homsets_disp'.
+  Defined.
+
+  Definition disp_ff_functor_sop
+             {C : category} (D' : disp_cat C)
+    : UU
+    := ∑ (D : disp_ff_functor_to_on_objects D'),
+       disp_ff_functor_mor_sop D.
+
+  Definition disp_ff_functor_sop_eq
+             {C : category} (D' : disp_cat C)
+             (X Y : disp_ff_functor_sop D')
+             (e : pr1 X = pr1 Y)
+    : X = Y.
+  Proof.
+    use total2_paths_f.
+    - apply e.
+    - apply isapropifcontr.
+      apply disp_ff_functor_mor_sop_iscontr.
+  Defined.
+             
+  Definition disp_ff_functor_sop_disp_functor_ff_weq
+             {C : category} {D' : disp_cat C}
+    : disp_ff_functor_sop D' ≃
+      ∑ (D : disp_cat C) (F : disp_functor (functor_identity _) D D'), disp_functor_ff F.
+  Proof.
+    use weq_iso.
+
+    - intros Fsop.
+      set (sop := pr1 (pr2 Fsop)).
+
+      set (ob_disp := pr1 (pr1 Fsop)).
+      set (Fob := pr2 (pr1 Fsop)).
+      set (axioms_d := pr2 (pr2 Fsop)).
+
+      set (mor_disp := pr1 sop).
+      set (id_disp' := pr1 (pr2 sop)).
+      set (comp_disp' := pr1 (pr2 (pr2 sop))).
+      set (homsets_disp' := pr1 (pr2 (pr2 (pr2 sop)))).
+      set (Fmor := pr1 (pr2 (pr2 (pr2 (pr2 sop))))).
+      set (Fid := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 sop)))))).
+      set (Fcomp := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+      set (Fff := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+
+      exists (((ob_disp ,, mor_disp) ,, (id_disp' , comp_disp')) ,, axioms_d).
+      exists ((Fob,,Fmor),,(Fid,Fcomp)).
+      exact Fff.
+
+    - intros F.
+      
+      set (ob_disp := pr1 (pr1 (pr1 (pr1 F)))).
+      set (mor_disp := pr2 (pr1 (pr1 (pr1 F)))).
+      set (id_disp' := pr1 (pr2 (pr1 (pr1 F)))).
+      set (comp_disp' := pr2 (pr2 (pr1 (pr1 F)))).
+      set (axioms_d := pr2 (pr1 F)).
+      set (homsets_disp' := pr2 (pr2 (pr2 axioms_d))).
+
+      set (Fob := pr1 (pr1 (pr1 (pr2 F)))).
+      set (Fmor := pr2 (pr1 (pr1 (pr2 F)))).
+      set (Fid := pr1 (pr2 (pr1 (pr2 F)))).
+      set (Fcomp := pr2 (pr2 (pr1 (pr2 F)))).
+      set (Fff := pr2 (pr2 F)).
+
+      exists (ob_disp ,, Fob).
+      exists (mor_disp ,, id_disp' ,, comp_disp' ,, homsets_disp' ,, Fmor ,, Fid ,, Fcomp ,, Fff).
+      exact axioms_d.
+
+    - intros ?. apply disp_ff_functor_sop_eq. apply idpath.
+    - intros ?. apply idpath.
   Defined.
 
   (* Types for parts of a fully faithful functor that rely on morphisms *)

--- a/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
+++ b/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
@@ -558,6 +558,50 @@ Section Auxiliary.
     := ∑ (D : disp_ff_functor_to_on_objects D'),
        disp_ff_functor_mor_sop D.
 
+  Definition source_disp_cat_of_disp_ff_functor_sop
+             {C : category} {D' : disp_cat C}
+             (Fsop : disp_ff_functor_sop D')
+    : disp_cat C.
+  Proof.
+    set (sop := pr1 (pr2 Fsop)).
+
+    set (ob_disp := pr1 (pr1 Fsop)).
+    set (axioms_d := pr2 (pr2 Fsop)).
+
+    set (mor_disp := pr1 sop).
+    set (id_disp' := pr1 (pr2 sop)).
+    set (comp_disp' := pr1 (pr2 (pr2 sop))).
+
+    exact (((ob_disp ,, mor_disp) ,, (id_disp' , comp_disp')) ,, axioms_d).
+  Defined.
+
+  Definition disp_functor_of_disp_ff_functor_sop
+             {C : category} {D' : disp_cat C}
+             (Fsop : disp_ff_functor_sop D')
+    : disp_functor (functor_identity C) (source_disp_cat_of_disp_ff_functor_sop Fsop) D'.
+  Proof.
+    set (sop := pr1 (pr2 Fsop)).
+
+    set (Fob := pr2 (pr1 Fsop)).
+    set (Fmor := pr1 (pr2 (pr2 (pr2 (pr2 sop))))).
+    set (Fid := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 sop)))))).
+    set (Fcomp := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+
+    exact ((Fob,,Fmor),,(Fid,Fcomp)).
+  Defined.
+
+  Coercion disp_functor_of_disp_ff_functor_sop : disp_ff_functor_sop >-> disp_functor.
+
+  Definition disp_functor_of_disp_ff_functor_sop_is_ff
+             {C : category} {D' : disp_cat C}
+             (Fsop : disp_ff_functor_sop D')
+    : disp_functor_ff (disp_functor_of_disp_ff_functor_sop Fsop).
+  Proof.
+    set (sop := pr1 (pr2 Fsop)).
+    set (Fff := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
+    exact Fff.
+  Defined.
+
   Definition disp_ff_functor_sop_eq
              {C : category} (D' : disp_cat C)
              (X Y : disp_ff_functor_sop D')
@@ -578,24 +622,9 @@ Section Auxiliary.
     use weq_iso.
 
     - intros Fsop.
-      set (sop := pr1 (pr2 Fsop)).
-
-      set (ob_disp := pr1 (pr1 Fsop)).
-      set (Fob := pr2 (pr1 Fsop)).
-      set (axioms_d := pr2 (pr2 Fsop)).
-
-      set (mor_disp := pr1 sop).
-      set (id_disp' := pr1 (pr2 sop)).
-      set (comp_disp' := pr1 (pr2 (pr2 sop))).
-      set (homsets_disp' := pr1 (pr2 (pr2 (pr2 sop)))).
-      set (Fmor := pr1 (pr2 (pr2 (pr2 (pr2 sop))))).
-      set (Fid := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 sop)))))).
-      set (Fcomp := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
-      set (Fff := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
-
-      exists (((ob_disp ,, mor_disp) ,, (id_disp' , comp_disp')) ,, axioms_d).
-      exists ((Fob,,Fmor),,(Fid,Fcomp)).
-      exact Fff.
+      exists (source_disp_cat_of_disp_ff_functor_sop Fsop).
+      exists (disp_functor_of_disp_ff_functor_sop Fsop).
+      apply disp_functor_of_disp_ff_functor_sop_is_ff.
 
     - intros F.
       
@@ -620,100 +649,14 @@ Section Auxiliary.
     - intros ?. apply idpath.
   Defined.
 
-  (* Types for parts of a fully faithful functor that rely on morphisms *)
-  Section disp_ff_functor_to_on_morphisms.
-
-    Context {C : category} {D' : disp_cat C}.
-    Context (D : disp_ff_functor_to_on_objects D').
-
-    Definition disp_ff_functor_source_mor : UU
-      := ∏ (Γ Γ' : C), (pr1 D Γ) → (pr1 D Γ') → (Γ --> Γ') → UU.
-
-    Definition disp_ff_functor_source_id_comp
-               (mord : disp_ff_functor_source_mor) : UU
-      := disp_cat_id_comp C (pr1 D,, mord).
-
-    Definition disp_ff_functor_source_axioms
-               (mord : disp_ff_functor_source_mor)
-               (id_comp_d : disp_ff_functor_source_id_comp mord)
-      : UU
-      := disp_cat_axioms C ((pr1 D ,, mord) ,, id_comp_d).
-
-    Definition disp_ff_functor_on_morphisms
-               (mord : disp_ff_functor_source_mor)
-      : UU
-      := ∏ x y (xx : pr1 D x) (yy : pr1 D y) (f : x --> y)
-         , (mord _ _ xx yy f) -> (pr2 D _ xx -->[ f ] pr2 D _ yy).
-          
-    Definition disp_ff_functor_axioms
-               (mord : disp_ff_functor_source_mor)
-               (id_comp_d : disp_ff_functor_source_id_comp mord)
-               (axioms_d : disp_ff_functor_source_axioms mord id_comp_d)
-               (functor_mord : disp_ff_functor_on_morphisms mord)
-      : UU
-      := @disp_functor_axioms
-           C C (functor_identity _)
-           (((pr1 D ,, mord) ,, id_comp_d) ,, axioms_d) D'
-           (pr2 D ,, functor_mord).
-               
-    Definition disp_ff_functor_ff
-               (mord : disp_ff_functor_source_mor)
-               (functor_mord : disp_ff_functor_on_morphisms mord)
-      : UU
-      := ∏ Γ Γ' (A : pr1 D Γ) (A' : pr1 D Γ') (f : Γ --> Γ')
-         , isweq (functor_mord Γ Γ' A A' f).
-
-    Definition disp_ff_functor_to_on_morphisms'
-               (mord : disp_ff_functor_source_mor)
-      : UU
-      := ∑ (id_comp_d : disp_ff_functor_source_id_comp mord)
-           (axioms_d : disp_ff_functor_source_axioms mord id_comp_d)
-           (functor_mord : disp_ff_functor_on_morphisms mord)
-           (functor_axioms_d : disp_ff_functor_axioms mord id_comp_d axioms_d functor_mord)
-         , disp_ff_functor_ff mord functor_mord.
-
-    Definition disp_ff_functor_to_on_morphisms
-      : UU
-      := ∑ (mord : disp_ff_functor_source_mor)
-         , disp_ff_functor_to_on_morphisms' mord.
-
-  End disp_ff_functor_to_on_morphisms.
-
-  Definition disp_ff_functor_to
-             {C : category} (D' : disp_cat C)
-    : UU
-    := ∑ (D : disp_ff_functor_to_on_objects D'), disp_ff_functor_to_on_morphisms D.
-
-  (* Accessors for parts of a fully faithful functor that rely on morphisms *)
-  Section disp_ff_functor_accessors.
-
-    Definition source_disp_cat_of_disp_ff_functor
-                {C : category} {D' : disp_cat C}
-                (D : disp_ff_functor_to D')
-        : disp_cat C.
-    Proof.
-        set (axioms_d := pr1 (pr2 (pr2 (pr2 D)))).
-        exact (((pr1 (pr1 D),, _),, _) ,, axioms_d).
-    Defined.
-
-    Definition disp_functor_of_disp_ff_functor
-                {C : category} {D' : disp_cat C}
-                (D : disp_ff_functor_to D')
-        : disp_functor (functor_identity _) (source_disp_cat_of_disp_ff_functor D) D'.
-    Proof.
-        set (functor_axioms_d := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 D)))))).
-        exact ((pr2 (pr1 D) ,, _) ,, functor_axioms_d).
-    Defined.
-
-    Coercion disp_functor_of_disp_ff_functor : disp_ff_functor_to >-> disp_functor.
-
-    Definition disp_ff_functor_is_ff
-                {C : category} {D' : disp_cat C}
-                (D : disp_ff_functor_to D')
-        : disp_functor_ff (disp_functor_of_disp_ff_functor D)
-        := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 D))))).
-
-  End disp_ff_functor_accessors.
+  Definition disp_ff_functor_sop_disp_ff_functor_to_on_objects_weq
+             {C : category} {D' : disp_cat C}
+    : disp_ff_functor_to_on_objects D' ≃ disp_ff_functor_sop D'.
+  Proof.
+    apply invweq, weqpr1.
+    intros D.
+    apply disp_ff_functor_mor_sop_iscontr.
+  Defined.
 
 End Auxiliary.
 
@@ -1304,14 +1247,25 @@ Section TypeCat_ComprehensionCat.
 
   Definition typecat_obj_ext_structure_disp_ff_functor_to_codomain_weq
              (C : category)
-    : typecat_obj_ext_structure C ≃ disp_ff_functor_to (disp_codomain C).
+    : typecat_obj_ext_structure C ≃ disp_ff_functor_to_on_objects (disp_codomain C).
   Proof.
-    (* TODO *)
+    use weq_iso.
+    - intros tc.
+      exists (pr1 (pr1 tc)).
+      intros Γ A.
+      exists (Γ ◂ A).
+      apply (pr2 tc).
+    - intros F.
+      use tpair.
+      + exists (pr1 F).
+        use tpair.
+        * intros Γ A.
+          exact (pr1 (pr2 F Γ A)).
   Abort.
 
   Definition ff_comprehension_cat_structure (C : category) : UU
-    := ∑ (F : disp_ff_functor_to (disp_codomain C)),
-       cleaving (source_disp_cat_of_disp_ff_functor F)
+    := ∑ (F : disp_ff_functor_sop (disp_codomain C)),
+       cleaving (source_disp_cat_of_disp_ff_functor_sop F)
        × is_cartesian_disp_functor F. 
 
   Definition typecat_ff_comprehension_cat_structure_weq (C : category)

--- a/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
+++ b/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
@@ -110,6 +110,8 @@ Section Auxiliary.
     exact (_ ,, functor_axioms_d).
   Defined.
 
+  Coercion disp_functor_of_disp_ff_functor : disp_ff_functor_to >-> disp_functor.
+
   Definition disp_ff_functor_is_ff
              {C : category} {D' : disp_cat C}
              (D : disp_ff_functor_to D')
@@ -740,235 +742,31 @@ Section TypeCat_ComprehensionCat.
   Print cleaving.
   Check cartesian_lift.
 
+  Definition typecat_obj_ext_structure_disp_ff_functor_to_codomain_weq
+             (C : category)
+    : typecat_obj_ext_structure C ≃ disp_ff_functor_to (disp_codomain C).
+  Proof.
+    (* TODO *)
+  Abort.
+
   Definition ff_comprehension_cat_structure (C : category) : UU
-    := ∑ (obd : C → UU)
-         (functor_on_obd : ∏ (Γ : C), obd Γ → disp_codomain C Γ)
-         (cleaving_on_obd : ∏ (Γ Γ' : C) (f : Γ' --> Γ) (A : obd Γ),
-                            ∑ (A' : obd Γ')
-                              (ff : functor_on_obd _ A' -->[f] functor_on_obd _ A),
-                            is_cartesian ff)
-       , unit.
+    := ∑ (F : disp_ff_functor_to (disp_codomain C)),
+       cleaving (source_disp_cat_of_disp_ff_functor F)
+       × is_cartesian_disp_functor F. 
 
-  Definition ff_comprehension_cat_structure_has_morphisms (C : category)
-             (ff_CC : ff_comprehension_cat_structure C)
-    : UU
-    := ∑ (mord : ∏ (Γ Γ' : C), (pr1 ff_CC Γ) → (pr1 ff_CC Γ') → (Γ --> Γ') → UU)
-         (id_comp_d : disp_cat_id_comp C (_ ,, mord))
-         (axioms_d : disp_cat_axioms C (_,, id_comp_d))
-         (functor_mord :
-            ∏ x y (xx : ((_,,axioms_d) : disp_cat C) x) (yy : pr1 ff_CC y) (f : x --> y),
-            (xx -->[f] yy) -> (pr1 (pr2 ff_CC) _ xx -->[ f ] pr1 (pr2 ff_CC) _ yy))
-         (functor_axioms_d : @disp_functor_axioms
-                               C C (functor_identity _)
-                               (_,,axioms_d) (disp_codomain C)
-                               (pr1 (pr2 ff_CC) ,, functor_mord))
-         (ff : disp_functor_ff ((_ ,, functor_axioms_d)
-                                : disp_functor (functor_identity C)
-                                               (_ ,, axioms_d) (disp_codomain C)))
-       , unit.
-
-  Definition isaprop_ff_comprehension_cat_structure_has_morphisms {C : category}
-             (ff_CC : ff_comprehension_cat_structure C)
-    : isaprop (ff_comprehension_cat_structure_has_morphisms C ff_CC).
+  Definition typecat_ff_comprehension_cat_structure_weq (C : category)
+    : typecat_structure C ≃ ff_comprehension_cat_structure C.
   Proof.
-    intros X Y.
-    use tpair.
-    - use total2_paths_f.
-      + 
-  Defined.
+    (* TODO *)
+  Abort.
 
-  Definition ff_comprehension_cat_structure_disp_cat {C : category}
-    : ff_comprehension_cat_structure C → disp_cat C.
+  Definition ff_comprehension_cat : UU
+    := ∑ (C : category), ff_comprehension_cat_structure C.
+
+  Definition typecat_ff_comprehension_cat_weq (C : category)
+    : typecat ≃ ff_comprehension_cat.
   Proof.
-    intros ff_CC.
-    set (obd := pr1 ff_CC).
-    set (functor_on_obd := pr1 (pr2 ff_CC)).
-    set (cleaving_on_obd := pr1 (pr2 (pr2 ff_CC))).
-    use tpair.
-    - use tpair.
-      + exists obd.
-        intros Γ Δ A B f.
-        exact (functor_on_obd _ A -->[f] functor_on_obd _ B).
-      + use tpair.
-        * intros Γ A.
-          apply id_disp.
-        * intros Γ Γ' Γ'' A A' A'' f g.
-          apply comp_disp.
-    - repeat use make_dirprod.
-      + intros ? ? ? ? ? ?. apply id_left_disp.
-      + intros ? ? ? ? ? ?. apply id_right_disp.
-      + intros ? ? ? ? ? ? ? ? ? ? ? ? ? ?. apply assoc_disp.
-      + intros ? ? ? ? ? ?. apply homsets_disp.
-  Defined.
-
-  Definition ff_comprehension_cat_structure_disp_functor {C : category}
-             (ff_CC : ff_comprehension_cat_structure C)
-    : disp_functor (functor_identity _)
-                   (ff_comprehension_cat_structure_disp_cat ff_CC)
-                   (disp_codomain C).
-  Proof.
-    set (obd := pr1 ff_CC).
-    set (functor_on_obd := pr1 (pr2 ff_CC)).
-    set (cleaving_on_obd := pr1 (pr2 (pr2 ff_CC))).
-    repeat use tpair.
-    - exact functor_on_obd.
-    - intros ? ? ? ? ?. apply idfun.
-    - intros ? ?. apply idpath.
-    - intros ? ? ? ? ? ? ? ? ? ?. apply idpath.
-  Defined.
-
-  Definition ff_comprehension_cat_structure_disp_functor_is_ff {C : category}
-             (ff_CC : ff_comprehension_cat_structure C)
-    : disp_functor_ff (ff_comprehension_cat_structure_disp_functor ff_CC).
-  Proof.
-    set (obd := pr1 ff_CC).
-    set (functor_on_obd := pr1 (pr2 ff_CC)).
-    set (cleaving_on_obd := pr1 (pr2 (pr2 ff_CC))).
-    unfold disp_functor_ff.
-    intros Γ Γ' A A' f.
-    use isweq_iso.
-    - apply idfun.
-    - intros k. apply idpath.
-    - intros k. apply idpath.
-  Defined.
-
-  Definition ff_comprehension_cat_structure_cleaving {C : category}
-             (ff_CC : ff_comprehension_cat_structure C)
-    : cleaving (ff_comprehension_cat_structure_disp_cat ff_CC).
-  Proof.
-    intros Γ Γ' f A.
-    set (obd := pr1 ff_CC).
-    set (functor_on_obd := pr1 (pr2 ff_CC)).
-    set (cleaving_on_obd := pr1 (pr2 (pr2 ff_CC))).
-    set (ff := cleaving_on_obd Γ Γ' f A).
-    use tpair.
-    - apply (pr1 ff).
-    - use tpair.
-      + apply (pr1 (pr2 ff)).
-      + intros Δ g B k.
-        use iscontrweqf.
-        3: {
-          use (pr2 (pr2 ff)).
-          - exact Δ.
-          - exact g.
-          - exact (functor_on_obd Δ B).
-          - exact k.
-        }
-        apply idweq.
-  Defined.
-
-  Definition ff_comprehension_cat_structure_disp_functor_is_cartesian {C : category}
-             (ff_CC : ff_comprehension_cat_structure C)
-    : is_cartesian_disp_functor (ff_comprehension_cat_structure_disp_functor ff_CC).
-  Proof.
-    use cartesian_functor_from_cleaving.
-    - apply (ff_comprehension_cat_structure_cleaving ff_CC).
-    - intros Γ Γ' f A.
-      set (cleaving_on_obd := pr1 (pr2 (pr2 ff_CC))).
-      set (ff := cleaving_on_obd Γ Γ' f A).
-      apply (pr2 (pr2 ff)).
-  Defined.
-
-  Definition ff_comprehension_cat_structure_to_comprehension_cat_structure
-             {C : category}
-    : ff_comprehension_cat_structure C
-      → ∑ (CC : comprehension_cat_structure C),
-      fully_faithful_comprehension_cat_structure CC.
-  Proof.
-    intros ff_CC.
-    use tpair.
-    - use tpair.
-      + apply (ff_comprehension_cat_structure_disp_cat ff_CC).
-      + use tpair.
-        * apply (ff_comprehension_cat_structure_cleaving ff_CC).
-        * use tpair.
-          -- apply (ff_comprehension_cat_structure_disp_functor ff_CC).
-          -- apply (ff_comprehension_cat_structure_disp_functor_is_cartesian ff_CC).
-    - apply (ff_comprehension_cat_structure_disp_functor_is_ff ff_CC).
-  Defined.
-
-  Definition ff_comprehension_cat_structure_from_comprehension_cat_structure
-             {C : category}
-    : (∑ (CC : comprehension_cat_structure C),
-       fully_faithful_comprehension_cat_structure CC)
-        → ff_comprehension_cat_structure C.
-  Proof.
-    intros CC.
-    use tpair.
-    - apply (ob_disp (pr1 (pr1 CC))).
-    - use tpair.
-      + intros Γ A. apply (disp_functor_on_objects (pr1 (pr2 (pr2 (pr1 CC)))) A).
-      + use tpair.
-        * intros Γ Γ' f A.
-          set (ff := pr1 (pr2 (pr1 CC)) Γ Γ' f A).
-          exists (pr1 ff).
-          use tpair.
-          -- use (disp_functor_on_morphisms (pr1 (pr2 (pr2 (pr1 CC))))).
-             apply (pr1 (pr2 ff)).
-          -- use (pr2 (pr2 (pr2 (pr1 CC)))).
-             apply (pr2 (pr2 ff)).
-        * apply tt.
-  Defined.
-
-
-  Definition ff_comprehension_cat_structure_weq (C : category)
-    : ff_comprehension_cat_structure C
-      ≃ ∑ (CC : comprehension_cat_structure C),
-      fully_faithful_comprehension_cat_structure CC.
-  Proof.
-    Search weq.
-    use weq_iso.
-    - apply ff_comprehension_cat_structure_to_comprehension_cat_structure.
-    - apply ff_comprehension_cat_structure_from_comprehension_cat_structure.
-    - intros ff_CC.
-      repeat use total2_paths_f.
-      + apply idpath.
-      + apply idpath.
-      + apply funextsec. intros ?.
-        apply funextsec. intros ?.
-        apply funextsec. intros ?.
-        apply funextsec. intros ?.
-        use total2_paths_f.
-        * apply idpath.
-        * use total2_paths_f.
-          -- apply idpath.
-          -- apply isaprop_is_cartesian.
-      + apply isapropunit.
-    - intros CC.
-      repeat use total2_paths_f.
-      + apply idpath.
-      + apply idpath.
-  Defined.
-
-  Definition ff_comprehension_cat_structure_weq
-             {C : category}
-    : ∑ CC : comprehension_cat_structure C, fully_faithful_comprehension_cat_structure CC.
-
-  Definition typecat_comprehension_cat_structure_weq
-             {C : category}
-    : typecat_structure C ≃ ∑ CC : comprehension_cat_structure C, fully_faithful_comprehension_cat_structure CC.
-  Proof.
-    use weq_iso.
-    - intros TC.
-      exact (typecat_to_comprehension_cat_structure TC ,, typecat_disp_functor_ff TC).
-    - intros CC. apply (typecat_structure_from_comprehension_cat (pr1 CC)).
-    - intros TC.
-      repeat use total2_paths_f.
-      + apply idpath.
-      + apply idpath.
-      + apply idpath.
-      + apply idpath.
-      + apply idpath.
-      + apply idpath.
-      + apply funextsec. intros Γ.
-        apply funextsec. intros A.
-        apply funextsec. intros Γ'.
-        apply funextsec. intros f.
-        apply isaprop_isPullback.
-    - intros ff_CC.
-      repeat use total2_paths_f.
-      + apply idpath.
-      + (* STUCK: need to think, this might be impossible *) (* apply idpath. *)
+    (* TODO *)
   Abort.
 
 End TypeCat_ComprehensionCat.

--- a/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
+++ b/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
@@ -62,6 +62,92 @@ Section Auxiliary.
     apply idpath.
   Defined.
 
+  Definition disp_ff_functor_to_on_objects
+             {C : category}
+             (D' : disp_cat C)
+    : UU
+    := ∑ (obd : C → UU)
+       , ∏ (Γ : C), obd Γ → D' Γ.
+
+  Definition disp_ff_functor_to_on_morphisms
+             {C : category} {D' : disp_cat C} 
+             (D : disp_ff_functor_to_on_objects D')
+    : UU
+    := ∑ (mord : ∏ (Γ Γ' : C), (pr1 D Γ) → (pr1 D Γ') → (Γ --> Γ') → UU)
+         (id_comp_d : disp_cat_id_comp C (_ ,, mord))
+         (axioms_d : disp_cat_axioms C (_,, id_comp_d))
+         (functor_mord :
+            ∏ x y (xx : ((_,,axioms_d) : disp_cat C) x) (yy : pr1 D y) (f : x --> y),
+            (xx -->[f] yy) -> (pr2 D _ xx -->[ f ] pr2 D _ yy))
+         (functor_axioms_d : @disp_functor_axioms
+                               C C (functor_identity _)
+                               (_,,axioms_d) D'
+                               (pr2 D ,, functor_mord))
+       , disp_functor_ff ((_ ,, functor_axioms_d)
+                          : disp_functor (functor_identity C)
+                                         (_ ,, axioms_d) D').
+
+  Definition disp_ff_functor_to
+             {C : category} (D' : disp_cat C)
+    : UU
+    := ∑ (D : disp_ff_functor_to_on_objects D'), disp_ff_functor_to_on_morphisms D.
+
+  Definition source_disp_cat_of_disp_ff_functor
+             {C : category} {D' : disp_cat C}
+             (D : disp_ff_functor_to D')
+    : disp_cat C.
+  Proof.
+    set (axioms_d := pr1 (pr2 (pr2 (pr2 D)))).
+    exact (_ ,, axioms_d).
+  Defined.
+
+  Definition disp_functor_of_disp_ff_functor
+             {C : category} {D' : disp_cat C}
+             (D : disp_ff_functor_to D')
+    : disp_functor (functor_identity _) (source_disp_cat_of_disp_ff_functor D) D'.
+  Proof.
+    set (functor_axioms_d := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 D)))))).
+    exact (_ ,, functor_axioms_d).
+  Defined.
+
+  Definition disp_ff_functor_is_ff
+             {C : category} {D' : disp_cat C}
+             (D : disp_ff_functor_to D')
+    : disp_functor_ff (disp_functor_of_disp_ff_functor D)
+    := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 D))))).
+
+  Lemma isaprop_disp_source_functor_on_morphisms
+        {C : category} {D' : disp_cat C} 
+        (D : disp_ff_functor_to_on_objects D')
+    : isaprop (disp_ff_functor_to_on_morphisms D).
+  Proof.
+    intros X Y.
+    use tpair.
+    - use total2_paths_f.
+      + apply funextsec. intros Γ.
+        apply funextsec. intros Γ'.
+        apply funextsec. intros A.
+        apply funextsec. intros B.
+        apply funextsec. intros f.
+        set (wX := (_ ,, disp_ff_functor_is_ff (D,,X) Γ Γ' A B f)).
+        set (wY := (_ ,, disp_ff_functor_is_ff (D,,Y) Γ Γ' A B f)).
+        apply univalenceweq. (* FIXME: is this correct application? *)
+        apply (weqcomp wX (invweq wY)).
+      + use total2_paths_f.
+        * use dirprod_paths.
+          -- apply funextsec. intros Γ.
+             apply funextsec. intros A.
+             set (Fid_axiom_X := pr1 (pr2 (disp_functor_of_disp_ff_functor (D,,X))) Γ A).
+             set (Fid_axiom_Y := pr1 (pr2 (disp_functor_of_disp_ff_functor (D,,Y))) Γ A).
+             (* TODO: work in progress *)
+             (*
+             maponpaths (Fid_axiom_X @ !Fid_axiom_Y).
+             set (wX := (_ ,, disp_ff_functor_is_ff (D,,X) Γ Γ A A (identity _))).
+             set (wY := (_ ,, disp_ff_functor_is_ff (D,,Y) Γ Γ A A (identity _))).
+             apply univalenceweq.
+              *)
+  Abort.
+
 End Auxiliary.
 
 Section TypeCat_ObjExt.
@@ -648,6 +734,215 @@ Section TypeCat_ComprehensionCat.
   Definition fully_faithful_comprehension_cat_structure
              {C : category} (CC : comprehension_cat_structure C)
     := disp_functor_ff (pr1 (pr2 (pr2 CC))).
+
+  Print disp_cat_ob_mor.
+
+  Print cleaving.
+  Check cartesian_lift.
+
+  Definition ff_comprehension_cat_structure (C : category) : UU
+    := ∑ (obd : C → UU)
+         (functor_on_obd : ∏ (Γ : C), obd Γ → disp_codomain C Γ)
+         (cleaving_on_obd : ∏ (Γ Γ' : C) (f : Γ' --> Γ) (A : obd Γ),
+                            ∑ (A' : obd Γ')
+                              (ff : functor_on_obd _ A' -->[f] functor_on_obd _ A),
+                            is_cartesian ff)
+       , unit.
+
+  Definition ff_comprehension_cat_structure_has_morphisms (C : category)
+             (ff_CC : ff_comprehension_cat_structure C)
+    : UU
+    := ∑ (mord : ∏ (Γ Γ' : C), (pr1 ff_CC Γ) → (pr1 ff_CC Γ') → (Γ --> Γ') → UU)
+         (id_comp_d : disp_cat_id_comp C (_ ,, mord))
+         (axioms_d : disp_cat_axioms C (_,, id_comp_d))
+         (functor_mord :
+            ∏ x y (xx : ((_,,axioms_d) : disp_cat C) x) (yy : pr1 ff_CC y) (f : x --> y),
+            (xx -->[f] yy) -> (pr1 (pr2 ff_CC) _ xx -->[ f ] pr1 (pr2 ff_CC) _ yy))
+         (functor_axioms_d : @disp_functor_axioms
+                               C C (functor_identity _)
+                               (_,,axioms_d) (disp_codomain C)
+                               (pr1 (pr2 ff_CC) ,, functor_mord))
+         (ff : disp_functor_ff ((_ ,, functor_axioms_d)
+                                : disp_functor (functor_identity C)
+                                               (_ ,, axioms_d) (disp_codomain C)))
+       , unit.
+
+  Definition isaprop_ff_comprehension_cat_structure_has_morphisms {C : category}
+             (ff_CC : ff_comprehension_cat_structure C)
+    : isaprop (ff_comprehension_cat_structure_has_morphisms C ff_CC).
+  Proof.
+    intros X Y.
+    use tpair.
+    - use total2_paths_f.
+      + 
+  Defined.
+
+  Definition ff_comprehension_cat_structure_disp_cat {C : category}
+    : ff_comprehension_cat_structure C → disp_cat C.
+  Proof.
+    intros ff_CC.
+    set (obd := pr1 ff_CC).
+    set (functor_on_obd := pr1 (pr2 ff_CC)).
+    set (cleaving_on_obd := pr1 (pr2 (pr2 ff_CC))).
+    use tpair.
+    - use tpair.
+      + exists obd.
+        intros Γ Δ A B f.
+        exact (functor_on_obd _ A -->[f] functor_on_obd _ B).
+      + use tpair.
+        * intros Γ A.
+          apply id_disp.
+        * intros Γ Γ' Γ'' A A' A'' f g.
+          apply comp_disp.
+    - repeat use make_dirprod.
+      + intros ? ? ? ? ? ?. apply id_left_disp.
+      + intros ? ? ? ? ? ?. apply id_right_disp.
+      + intros ? ? ? ? ? ? ? ? ? ? ? ? ? ?. apply assoc_disp.
+      + intros ? ? ? ? ? ?. apply homsets_disp.
+  Defined.
+
+  Definition ff_comprehension_cat_structure_disp_functor {C : category}
+             (ff_CC : ff_comprehension_cat_structure C)
+    : disp_functor (functor_identity _)
+                   (ff_comprehension_cat_structure_disp_cat ff_CC)
+                   (disp_codomain C).
+  Proof.
+    set (obd := pr1 ff_CC).
+    set (functor_on_obd := pr1 (pr2 ff_CC)).
+    set (cleaving_on_obd := pr1 (pr2 (pr2 ff_CC))).
+    repeat use tpair.
+    - exact functor_on_obd.
+    - intros ? ? ? ? ?. apply idfun.
+    - intros ? ?. apply idpath.
+    - intros ? ? ? ? ? ? ? ? ? ?. apply idpath.
+  Defined.
+
+  Definition ff_comprehension_cat_structure_disp_functor_is_ff {C : category}
+             (ff_CC : ff_comprehension_cat_structure C)
+    : disp_functor_ff (ff_comprehension_cat_structure_disp_functor ff_CC).
+  Proof.
+    set (obd := pr1 ff_CC).
+    set (functor_on_obd := pr1 (pr2 ff_CC)).
+    set (cleaving_on_obd := pr1 (pr2 (pr2 ff_CC))).
+    unfold disp_functor_ff.
+    intros Γ Γ' A A' f.
+    use isweq_iso.
+    - apply idfun.
+    - intros k. apply idpath.
+    - intros k. apply idpath.
+  Defined.
+
+  Definition ff_comprehension_cat_structure_cleaving {C : category}
+             (ff_CC : ff_comprehension_cat_structure C)
+    : cleaving (ff_comprehension_cat_structure_disp_cat ff_CC).
+  Proof.
+    intros Γ Γ' f A.
+    set (obd := pr1 ff_CC).
+    set (functor_on_obd := pr1 (pr2 ff_CC)).
+    set (cleaving_on_obd := pr1 (pr2 (pr2 ff_CC))).
+    set (ff := cleaving_on_obd Γ Γ' f A).
+    use tpair.
+    - apply (pr1 ff).
+    - use tpair.
+      + apply (pr1 (pr2 ff)).
+      + intros Δ g B k.
+        use iscontrweqf.
+        3: {
+          use (pr2 (pr2 ff)).
+          - exact Δ.
+          - exact g.
+          - exact (functor_on_obd Δ B).
+          - exact k.
+        }
+        apply idweq.
+  Defined.
+
+  Definition ff_comprehension_cat_structure_disp_functor_is_cartesian {C : category}
+             (ff_CC : ff_comprehension_cat_structure C)
+    : is_cartesian_disp_functor (ff_comprehension_cat_structure_disp_functor ff_CC).
+  Proof.
+    use cartesian_functor_from_cleaving.
+    - apply (ff_comprehension_cat_structure_cleaving ff_CC).
+    - intros Γ Γ' f A.
+      set (cleaving_on_obd := pr1 (pr2 (pr2 ff_CC))).
+      set (ff := cleaving_on_obd Γ Γ' f A).
+      apply (pr2 (pr2 ff)).
+  Defined.
+
+  Definition ff_comprehension_cat_structure_to_comprehension_cat_structure
+             {C : category}
+    : ff_comprehension_cat_structure C
+      → ∑ (CC : comprehension_cat_structure C),
+      fully_faithful_comprehension_cat_structure CC.
+  Proof.
+    intros ff_CC.
+    use tpair.
+    - use tpair.
+      + apply (ff_comprehension_cat_structure_disp_cat ff_CC).
+      + use tpair.
+        * apply (ff_comprehension_cat_structure_cleaving ff_CC).
+        * use tpair.
+          -- apply (ff_comprehension_cat_structure_disp_functor ff_CC).
+          -- apply (ff_comprehension_cat_structure_disp_functor_is_cartesian ff_CC).
+    - apply (ff_comprehension_cat_structure_disp_functor_is_ff ff_CC).
+  Defined.
+
+  Definition ff_comprehension_cat_structure_from_comprehension_cat_structure
+             {C : category}
+    : (∑ (CC : comprehension_cat_structure C),
+       fully_faithful_comprehension_cat_structure CC)
+        → ff_comprehension_cat_structure C.
+  Proof.
+    intros CC.
+    use tpair.
+    - apply (ob_disp (pr1 (pr1 CC))).
+    - use tpair.
+      + intros Γ A. apply (disp_functor_on_objects (pr1 (pr2 (pr2 (pr1 CC)))) A).
+      + use tpair.
+        * intros Γ Γ' f A.
+          set (ff := pr1 (pr2 (pr1 CC)) Γ Γ' f A).
+          exists (pr1 ff).
+          use tpair.
+          -- use (disp_functor_on_morphisms (pr1 (pr2 (pr2 (pr1 CC))))).
+             apply (pr1 (pr2 ff)).
+          -- use (pr2 (pr2 (pr2 (pr1 CC)))).
+             apply (pr2 (pr2 ff)).
+        * apply tt.
+  Defined.
+
+
+  Definition ff_comprehension_cat_structure_weq (C : category)
+    : ff_comprehension_cat_structure C
+      ≃ ∑ (CC : comprehension_cat_structure C),
+      fully_faithful_comprehension_cat_structure CC.
+  Proof.
+    Search weq.
+    use weq_iso.
+    - apply ff_comprehension_cat_structure_to_comprehension_cat_structure.
+    - apply ff_comprehension_cat_structure_from_comprehension_cat_structure.
+    - intros ff_CC.
+      repeat use total2_paths_f.
+      + apply idpath.
+      + apply idpath.
+      + apply funextsec. intros ?.
+        apply funextsec. intros ?.
+        apply funextsec. intros ?.
+        apply funextsec. intros ?.
+        use total2_paths_f.
+        * apply idpath.
+        * use total2_paths_f.
+          -- apply idpath.
+          -- apply isaprop_is_cartesian.
+      + apply isapropunit.
+    - intros CC.
+      repeat use total2_paths_f.
+      + apply idpath.
+      + apply idpath.
+  Defined.
+
+  Definition ff_comprehension_cat_structure_weq
+             {C : category}
+    : ∑ CC : comprehension_cat_structure C, fully_faithful_comprehension_cat_structure CC.
 
   Definition typecat_comprehension_cat_structure_weq
              {C : category}

--- a/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
+++ b/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
@@ -28,6 +28,8 @@ Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.ALV1.TypeCat.
+Require Import TypeTheory.ALV2.FullyFaithfulDispFunctor.
+
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 Require Import UniMath.CategoryTheory.DisplayedCats.Auxiliary.
 Require Import UniMath.CategoryTheory.DisplayedCats.Fibrations.
@@ -60,602 +62,6 @@ Section Auxiliary.
   Proof.
     induction e.
     apply idpath.
-  Defined.
-
-  (* TODO: move upstream? *)
-  Lemma weqtotaltoforall3 {X : UU}
-        (P1 : X → UU)
-        (P2 : ∏ x : X, P1 x → UU)
-        (P3 : ∏ (x : X) (y : P1 x), P2 x y → UU)
-    : (∑ (p1 : ∏ x : X, P1 x) (p2 : ∏ x : X, P2 x (p1 x)), ∏ x : X, P3 x (p1 x) (p2 x))
-        ≃ (∏ x : X, ∑ (p1 : P1 x) (p2 : P2 x p1), P3 x p1 p2).
-  Proof.
-    eapply weqcomp.
-    apply (weqtotal2asstol
-             (λ p1, ∏ x : X, P2 x (p1 x))
-             (λ p12, ∏ x : X, P3 x (pr1 p12 x) (pr2 p12 x))
-          ).
-    eapply weqcomp.
-    use weqtotal2. 3: apply weqtotaltoforall.
-    - exact (λ p12, ∏ x : X, P3 x (pr1 (p12 x)) (pr2 (p12 x))).
-    - intros x. apply idweq.
-
-    - eapply weqcomp.
-      apply (weqtotaltoforall
-               (λ x : X, ∑ y : P1 x, P2 x y)
-               (λ (x : X) p12, P3 x (pr1 p12) (pr2 p12))
-            ).
-      apply weqonsecfibers.
-      intros x.
-      apply weqtotal2asstor.
-  Defined.
-
-  (* TODO: move upstream? *)
-  Lemma iscontr_total2
-        {X : UU} {P : X → UU}
-    : iscontr X → (∏ x : X, iscontr (P x)) → iscontr (∑ (x : X), P x).
-  Proof.
-    intros X_contr P_contr.
-    use tpair.
-    - exists (pr1 X_contr). apply P_contr.
-    - intros xp.
-      use total2_paths_f.
-      + apply X_contr.
-      + apply P_contr.
-  Defined.
-
-  (* TODO: move upstream? *)
-  Lemma idpath_transportb
-        {X : UU} (P : X → UU)
-        (x : X) (p : P x)
-    : transportb P (idpath x) p = p.
-  Proof.
-    apply idpath.
-  Defined.
-
-  (* TODO: move upstream? *)
-  Lemma homot_invweq_transportb_weq
-        (Z : UU)
-        (z z' : Z)
-        (X Y : Z → UU)
-        (e : z = z')
-        (w : ∏ z : Z, X z ≃ Y z)
-        (x : X z')
-    : invmap (w z) (transportb Y e (w z' x)) = transportb X e x.
-  Proof.
-    induction e.
-    etrans. apply maponpaths, idpath_transportb.
-    apply homotinvweqweq.
-  Defined.
-
-  Definition disp_ff_functor_to_on_objects
-             {C : category}
-             (D' : disp_cat C)
-    : UU
-    := ∑ (obd : C → UU)
-       , ∏ (Γ : C), obd Γ → D' Γ.
-
-  Definition disp_ff_functor_on_morphisms_sop
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-    : UU
-    := ∑ (mord : ∏ Γ Γ', (pr1 D Γ) → (pr1 D Γ') → (Γ --> Γ') → UU)
-         (functor_mord : ∏ Γ Γ' (A : pr1 D Γ) (A' : pr1 D Γ') (f : Γ --> Γ')
-                         , (mord _ _ A A' f) -> (pr2 D _ A -->[ f ] pr2 D _ A'))
-       , ∏ Γ Γ' (A : pr1 D Γ) (A' : pr1 D Γ') (f : Γ --> Γ')
-       , isweq (functor_mord Γ Γ' A A' f).
-
-  Definition disp_ff_functor_on_morphisms_pos
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-    : UU
-    := ∏ Γ Γ' (A : pr1 D Γ) (A' : pr1 D Γ') (f : Γ --> Γ'),
-      ∑ (mord : UU), mord ≃ (pr2 D _ A -->[ f ] pr2 D _ A').
-
-  Definition disp_ff_functor_on_morphisms_sop_pos_weq
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-    : disp_ff_functor_on_morphisms_sop D ≃ disp_ff_functor_on_morphisms_pos D.
-  Proof.
-    eapply weqcomp.
-    apply (weqtotaltoforall3
-             (λ Γ, ∏ Γ', (pr1 D Γ) → (pr1 D Γ') → (Γ --> Γ') → UU)
-             (λ Γ mord, ∏ Γ' (A : pr1 D Γ) (A' : pr1 D Γ') (f : Γ --> Γ')
-              , (mord _ A A' f) -> (pr2 D _ A -->[ f ] pr2 D _ A'))
-             (λ Γ mord functor_mord, 
-              ∏ Γ' (A : pr1 D Γ) (A' : pr1 D Γ') (f : Γ --> Γ')
-              , isweq (functor_mord Γ' A A' f))).
-    apply weqonsecfibers. intros Γ.
-
-    eapply weqcomp.
-    apply (weqtotaltoforall3
-             (λ Γ', (pr1 D Γ) → (pr1 D Γ') → (Γ --> Γ') → UU)
-             (λ Γ' mord, ∏ (A : pr1 D Γ) (A' : pr1 D Γ') (f : Γ --> Γ')
-              , (mord A A' f) -> (pr2 D _ A -->[ f ] pr2 D _ A'))
-             (λ Γ' mord functor_mord, 
-              ∏ (A : pr1 D Γ) (A' : pr1 D Γ') (f : Γ --> Γ')
-              , isweq (functor_mord A A' f))).
-    apply weqonsecfibers. intros Γ'.
-
-    eapply weqcomp.
-    apply (weqtotaltoforall3
-             (λ A, (pr1 D Γ') → (Γ --> Γ') → UU)
-             (λ A mord, ∏ (A' : pr1 D Γ') (f : Γ --> Γ')
-              , (mord A' f) -> (pr2 D _ A -->[ f ] pr2 D _ A'))
-             (λ A mord functor_mord, 
-              ∏ (A' : pr1 D Γ') (f : Γ --> Γ')
-              , isweq (functor_mord A' f))).
-    apply weqonsecfibers. intros A.
-
-    eapply weqcomp.
-    apply (weqtotaltoforall3
-             (λ A', (Γ --> Γ') → UU)
-             (λ A' mord, ∏ (f : Γ --> Γ')
-              , (mord f) -> (pr2 D _ A -->[ f ] pr2 D _ A'))
-             (λ A' mord functor_mord, 
-              ∏ (f : Γ --> Γ')
-              , isweq (functor_mord f))).
-    apply weqonsecfibers. intros A'.
-
-    eapply weqcomp.
-    apply (weqtotaltoforall3
-             (λ f, UU)
-             (λ f mord, mord -> (pr2 D _ A -->[ f ] pr2 D _ A'))
-             (λ f mord functor_mord, isweq functor_mord)).
-    apply idweq.
-  Defined.
-
-  Definition disp_ff_functor_on_morphisms_pos_iscontr
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-    : iscontr (disp_ff_functor_on_morphisms_pos D).
-  Proof.
-    apply impred_iscontr. intros Γ.
-    apply impred_iscontr. intros Γ'.
-    apply impred_iscontr. intros A.
-    apply impred_iscontr. intros A'.
-    apply impred_iscontr. intros f.
-    use (@iscontrweqf (∑ mord : UU, mord = pr2 D Γ A -->[f] pr2 D Γ' A')).
-    - use (weqtotal2 (idweq _)). intros mord. apply univalenceweq.
-    - apply iscontrcoconustot.
-  Defined.
-
-  Definition disp_ff_functor_on_morphisms_pos_isaprop
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-    : isaprop (disp_ff_functor_on_morphisms_pos D).
-  Proof.
-    apply isapropifcontr, disp_ff_functor_on_morphisms_pos_iscontr.
-  Defined.
-
-  Definition disp_ff_functor_on_morphisms_id_pos
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-             (mor_weq : disp_ff_functor_on_morphisms_pos D)
-    : UU
-    := ∏ (Γ : C) (A : pr1 D Γ),
-       ∑ (mor_id : pr1 (mor_weq Γ Γ A A (identity Γ))),
-       pr1 (pr2 (mor_weq Γ Γ A A (identity Γ))) mor_id
-       = transportb (mor_disp (pr2 D Γ A) (pr2 D Γ A))
-                    (functor_id (functor_identity C) Γ) (id_disp (pr2 D Γ A)).
-
-  Definition disp_ff_functor_on_morphisms_id_pos_iscontr
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-             (mor_weq : disp_ff_functor_on_morphisms_pos D)
-             (mor_isaset : ∏ Γ Γ' f (A : pr1 D Γ) (A' : pr1 D Γ'), isaset (pr1 (mor_weq _ _ A A' f)))
-    : iscontr (disp_ff_functor_on_morphisms_id_pos D mor_weq).
-  Proof.
-    apply impred_iscontr. intros Γ.
-    apply impred_iscontr. intros A.
-    set (mord := pr1 (mor_weq Γ Γ A A (identity Γ))).
-    set (mord_weq := pr2 (mor_weq Γ Γ A A (identity Γ))).
-    use (@iscontrweqf (∑ mor_id : mord, mor_id = invweq mord_weq
-                                    (transportb (mor_disp (pr2 D Γ A) (pr2 D Γ A))
-                                                (functor_id (functor_identity C) Γ) (id_disp (pr2 D Γ A))))).
-    - use (weqtotal2 (idweq _)). intros mor_id. simpl.
-      use weq_iso.
-      + intros p. apply (maponpaths mord_weq p @ homotweqinvweq mord_weq _).
-      + intros p. apply (! homotinvweqweq mord_weq _ @ maponpaths (invmap mord_weq) p).
-      + intros p. apply mor_isaset.
-      + intros p. apply (@homsets_disp _ D').
-    - apply iscontrcoconustot.
-  Defined.
-
-  Definition disp_ff_functor_on_morphisms_comp_pos
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-             (mor_weq : disp_ff_functor_on_morphisms_pos D)
-    : UU
-    := ∏ (Γ Γ' Γ'' : C)
-         (A : pr1 D Γ) (A' : pr1 D Γ') (A'' : pr1 D Γ'')
-         (f : Γ --> Γ') (g : Γ' --> Γ'')
-         (ff : pr1 (mor_weq Γ Γ' A A' f))
-         (gg : pr1 (mor_weq Γ' Γ'' A' A'' g)),
-       ∑ (mor_comp : pr1 (mor_weq Γ Γ'' A A'' (f ;; g))),
-       pr2 (mor_weq Γ Γ'' A A'' (f ;; g)) mor_comp
-       = transportb _ (functor_comp (functor_identity C) f g)
-                    (comp_disp (pr2 (mor_weq _ _ _ _ _) ff) (pr2 (mor_weq _ _ _ _ _) gg)).
-
-  Definition disp_ff_functor_on_morphisms_comp_pos_iscontr
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-             (mor_weq : disp_ff_functor_on_morphisms_pos D)
-             (mor_isaset : ∏ Γ Γ' f (A : pr1 D Γ) (A' : pr1 D Γ'), isaset (pr1 (mor_weq _ _ A A' f)))
-    : iscontr (disp_ff_functor_on_morphisms_comp_pos D mor_weq).
-  Proof.
-    apply impred_iscontr. intros Γ.
-    apply impred_iscontr. intros Γ'.
-    apply impred_iscontr. intros Γ''.
-    apply impred_iscontr. intros A.
-    apply impred_iscontr. intros A'.
-    apply impred_iscontr. intros A''.
-    apply impred_iscontr. intros f.
-    apply impred_iscontr. intros g.
-    apply impred_iscontr. intros ff.
-    apply impred_iscontr. intros gg.
-    set (mord := pr1 (mor_weq Γ Γ'' A A'' (f ;; g))).
-    set (mord_weq := pr2 (mor_weq Γ Γ'' A A'' (f ;; g))).
-    use (@iscontrweqf (∑ mor_comp : mord,
-       mor_comp
-       = invweq mord_weq (transportb _ (functor_comp (functor_identity C) f g)
-                    (comp_disp (pr2 (mor_weq _ _ _ _ _) ff) (pr2 (mor_weq _ _ _ _ _) gg))))).
-    - use (weqtotal2 (idweq _)). intros mor_id. simpl.
-      use weq_iso.
-      + intros p. apply (maponpaths mord_weq p @ homotweqinvweq mord_weq _).
-      + intros p. apply (! homotinvweqweq mord_weq _ @ maponpaths (invmap mord_weq) p).
-      + intros p. apply mor_isaset.
-      + intros p. apply (@homsets_disp _ D').
-    - apply iscontrcoconustot.
-  Defined.
-
-  Definition disp_ff_functor_source_mor_isaset
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-             (mor_weq : disp_ff_functor_on_morphisms_pos D)
-    : ∏ Γ Γ' f (A : pr1 D Γ) (A' : pr1 D Γ'), isaset (pr1 (mor_weq _ _ A A' f)).
-  Proof.
-    intros Γ Γ' f A A'.
-    set (w := pr2 (mor_weq Γ Γ' A A' f)).
-    use (isofhlevelweqf 2 (invweq w)).
-    apply (@homsets_disp _ D').
-  Defined.
-
-  Definition disp_ff_functor_source_mor_isaset_iscontr
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-             (mor_weq : disp_ff_functor_on_morphisms_pos D)
-    : iscontr (∏ Γ Γ' f (A : pr1 D Γ) (A' : pr1 D Γ'), isaset (pr1 (mor_weq _ _ A A' f))).
-  Proof.
-    apply iscontraprop1.
-    - apply impred_isaprop. intros Γ.
-      apply impred_isaprop. intros Γ'.
-      apply impred_isaprop. intros A.
-      apply impred_isaprop. intros A'.
-      apply impred_isaprop. intros f.
-      apply isapropisaset.
-    - apply disp_ff_functor_source_mor_isaset.
-  Defined.
-
-  Definition disp_ff_functor_on_morphisms_idcomp_pos
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-    : UU
-    := ∑ (mor_weq : disp_ff_functor_on_morphisms_pos D)
-         (mor_isaset : ∏ Γ Γ' f (A : pr1 D Γ) (A' : pr1 D Γ'), isaset (pr1 (mor_weq _ _ A A' f)))
-         (mor_id : disp_ff_functor_on_morphisms_id_pos D mor_weq)
-       , disp_ff_functor_on_morphisms_comp_pos D mor_weq.
-
-  Definition disp_ff_functor_on_morphisms_idcomp_pos_iscontr
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-    : iscontr (disp_ff_functor_on_morphisms_idcomp_pos D).
-  Proof.
-    apply iscontr_total2.
-    - apply disp_ff_functor_on_morphisms_pos_iscontr.
-    - intros mor_weq. apply iscontr_total2.
-      + apply disp_ff_functor_source_mor_isaset_iscontr.
-      + intros mor_isaset.
-        apply iscontr_total2.
-        * apply disp_ff_functor_on_morphisms_id_pos_iscontr.
-          apply mor_isaset.
-        * intros ?.
-          apply disp_ff_functor_on_morphisms_comp_pos_iscontr.
-          apply mor_isaset.
-  Defined.
-
-  Definition disp_ff_functor_on_morphisms_idcomp_sop
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-    := ∑ (mor_disp : ∏ {x y : C}, pr1 D x -> pr1 D y -> (x --> y) -> UU)
-         (id_disp' : ∏ {x : C} (xx : pr1 D x), mor_disp xx xx (identity x))
-         (comp_disp' : ∏ {x y z : C} {f : x --> y} {g : y --> z}
-                        {xx : pr1 D x} {yy : pr1 D y} {zz : pr1 D z},
-                      mor_disp xx yy f -> mor_disp yy zz g -> mor_disp xx zz (f ;; g))
-         (homsets_disp : ∏ {x y} {f : x --> y} {xx} {yy}, isaset (mor_disp xx yy f))
-         (Fmor : ∏ x y (xx : pr1 D x) (yy : pr1 D y) (f : x --> y),
-                 (mor_disp xx yy f) -> (pr2 D _ xx -->[ f ] pr2 D _ yy))
-         (Fid : ∏ x (xx : pr1 D x),
-                Fmor _ _ _ _ _ (id_disp' xx) = transportb _ (functor_id (functor_identity C) x) (id_disp (pr2 D _ xx)))
-         (Fcomp :  ∏ x y z (xx : pr1 D x) yy zz (f : x --> y) (g : y --> z)
-                     (ff : mor_disp xx yy f) (gg : mor_disp yy zz g),
-                   Fmor _ _ _ _ _ (comp_disp' ff gg)
-                   = transportb _ (functor_comp (functor_identity _) f g) (comp_disp (Fmor _ _ _ _ _ ff) (Fmor _ _ _ _ _ gg)))
-       , ∏ x y (xx : pr1 D x) (yy : pr1 D y) (f : x --> y),
-       isweq (fun ff : mor_disp xx yy f => Fmor _ _ _ _ _ ff).
-
-  Definition disp_ff_functor_on_morphisms_idcomp_sop_pos_weq
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-    : disp_ff_functor_on_morphisms_idcomp_sop D ≃ disp_ff_functor_on_morphisms_idcomp_pos D.
-  Proof.
-    use weq_iso.
-
-    - intros sop.
-      set (mor_disp := pr1 sop).
-      set (id_disp' := pr1 (pr2 sop)).
-      set (comp_disp' := pr1 (pr2 (pr2 sop))).
-      set (homsets_disp' := pr1 (pr2 (pr2 (pr2 sop)))).
-      set (Fmor := pr1 (pr2 (pr2 (pr2 (pr2 sop))))).
-      set (Fid := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 sop)))))).
-      set (Fcomp := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
-      set (Fff := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
-
-      exists (λ x y xx yy f, mor_disp x y xx yy f ,, Fmor x y xx yy f,, Fff x y xx yy f).
-      exists homsets_disp'.
-      exists (λ x xx, (id_disp' x xx ,, Fid x xx)).
-      exact (λ x y z xx yy zz f g ff gg, (comp_disp' x y z f g xx yy zz ff gg ,, Fcomp x y z xx yy zz f g ff gg)).
-
-    - intros pos.
-      set (mor_disp := λ x y xx yy f, pr1 (pr1 pos x y xx yy f)).
-      set (Fmor := λ x y xx yy f, pr1 (pr2 (pr1 pos x y xx yy f))).
-      set (Fff := λ x y xx yy f, pr2 (pr2 (pr1 pos x y xx yy f))).
-      set (homsets_disp' := pr1 (pr2 pos)).
-      set (id_disp' := λ x xx, pr1 (pr1 (pr2 (pr2 pos)) x xx)).
-      set (Fid := λ x xx, pr2 (pr1 (pr2 (pr2 pos)) x xx)).
-      set (comp_disp' := λ x y z f g xx yy zz ff gg, pr1 (pr2 (pr2 (pr2 pos)) x y z xx yy zz f g ff gg)).
-      set (Fcomp := λ x y z xx yy zz f g ff gg, pr2 (pr2 (pr2 (pr2 pos)) x y z xx yy zz f g ff gg)).
-
-      exists mor_disp.
-      exists id_disp'.
-      exists comp_disp'.
-      exists homsets_disp'.
-      exists Fmor.
-      exists Fid.
-      exists Fcomp.
-      exact Fff.
-    - intros ?. apply idpath.
-    - intros ?. apply idpath.
-  Defined.
-
-  Definition source_disp_cat_data_of_disp_ff_functor_on_morphisms_idcomp_sop
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-    : disp_ff_functor_on_morphisms_idcomp_sop D → disp_cat_data C.
-  Proof.
-    intros sop.
-    set (mor_disp := pr1 sop).
-    set (id_disp' := pr1 (pr2 sop)).
-    set (comp_disp' := pr1 (pr2 (pr2 sop))).
-
-    use tpair.
-    - exists (pr1 D). apply mor_disp.
-    - exact (id_disp' , comp_disp').
-  Defined.
-
-  Definition disp_ff_functor_mor_sop
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-    : UU
-    := ∑ (mor_idcomp : disp_ff_functor_on_morphisms_idcomp_sop D),
-      disp_cat_axioms _ (source_disp_cat_data_of_disp_ff_functor_on_morphisms_idcomp_sop
-                           D mor_idcomp).
-        
-  Definition disp_ff_functor_mor_sop_iscontr
-             {C : category} {D' : disp_cat C}
-             (D : disp_ff_functor_to_on_objects D')
-    : iscontr (disp_ff_functor_mor_sop D).
-  Proof.
-    apply iscontr_total2.
-    - apply (iscontrweqb (disp_ff_functor_on_morphisms_idcomp_sop_pos_weq _)).
-      apply disp_ff_functor_on_morphisms_idcomp_pos_iscontr.
-    - intros sop.
-      apply iscontr_total2.
-
-      + apply impred_iscontr. intros Γ.
-        apply impred_iscontr. intros Γ'.
-        apply impred_iscontr. intros f.
-        apply impred_iscontr. intros A.
-        apply impred_iscontr. intros A'.
-        apply impred_iscontr. intros ff.
-        apply iscontraprop1. apply (pr1 (pr2 (pr2 (pr2 sop)))).
-        set (id_disp' := pr1 (pr2 sop)).
-        set (comp_disp' := pr1 (pr2 (pr2 sop))).
-        set (Fmor := pr1 (pr2 (pr2 (pr2 (pr2 sop))))).
-        set (Fid := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 sop)))))).
-        set (Fcomp := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
-        set (Fff := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
-        set (w := λ g, (Fmor _ _ A A' g,, Fff _ _ _ _ _)).
-        etrans. apply pathsinv0. apply (homotinvweqweq (w _)).
-        etrans. apply maponpaths. apply Fcomp.
-        etrans. apply maponpaths, maponpaths, maponpaths_2. apply Fid.
-        etrans. apply maponpaths, maponpaths. apply id_left_disp.
-        etrans. apply maponpaths. apply transport_b_b. simpl.
-        apply homot_invweq_transportb_weq.
-        
-      + intros ?.
-        apply iscontr_total2.
-
-        * apply impred_iscontr. intros Γ.
-          apply impred_iscontr. intros Γ'.
-          apply impred_iscontr. intros f.
-          apply impred_iscontr. intros A.
-          apply impred_iscontr. intros A'.
-          apply impred_iscontr. intros ff.
-          apply iscontraprop1. apply (pr1 (pr2 (pr2 (pr2 sop)))).
-          set (id_disp' := pr1 (pr2 sop)).
-          set (comp_disp' := pr1 (pr2 (pr2 sop))).
-          set (Fmor := pr1 (pr2 (pr2 (pr2 (pr2 sop))))).
-          set (Fid := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 sop)))))).
-          set (Fcomp := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
-          set (Fff := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
-          set (w := λ g, (Fmor _ _ A A' g,, Fff _ _ _ _ _)).
-          etrans. apply pathsinv0. apply (homotinvweqweq (w _)).
-          etrans. apply maponpaths. apply Fcomp.
-          etrans. apply maponpaths, maponpaths, maponpaths. apply Fid.
-          etrans. apply maponpaths, maponpaths. apply id_right_disp.
-          etrans. apply maponpaths. apply transport_b_b. simpl.
-          apply homot_invweq_transportb_weq.
-
-        * intros ?. apply iscontr_total2.
-
-          -- apply impred_iscontr. intros Γ.
-             apply impred_iscontr. intros Γ'.
-             apply impred_iscontr. intros Γ''.
-             apply impred_iscontr. intros Γ'''.
-             apply impred_iscontr. intros f.
-             apply impred_iscontr. intros g.
-             apply impred_iscontr. intros h.
-             apply impred_iscontr. intros A.
-             apply impred_iscontr. intros A'.
-             apply impred_iscontr. intros A''.
-             apply impred_iscontr. intros A'''.
-             apply impred_iscontr. intros ff.
-             apply impred_iscontr. intros gg.
-             apply impred_iscontr. intros hh.
-             apply iscontraprop1. apply (pr1 (pr2 (pr2 (pr2 sop)))).
-             set (id_disp' := pr1 (pr2 sop)).
-             set (comp_disp' := pr1 (pr2 (pr2 sop))).
-             set (Fmor := pr1 (pr2 (pr2 (pr2 (pr2 sop))))).
-             set (Fid := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 sop)))))).
-             set (Fcomp := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
-             set (Fff := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
-             set (w := λ g, (Fmor _ _ A A''' g,, Fff _ _ _ _ _)).
-             etrans. apply pathsinv0. apply (homotinvweqweq (w (f ;; (g ;; h)))).
-             etrans. apply maponpaths. apply Fcomp.
-             etrans. apply maponpaths, maponpaths, maponpaths. apply Fcomp.
-             etrans. apply maponpaths, maponpaths. apply assoc_disp.
-             etrans. apply maponpaths. apply transport_b_b.
-             (* WORK IN PROGRESS *)
-             etrans. apply maponpaths, maponpaths, maponpaths_2, pathsinv0, Fcomp.
-             etrans. apply maponpaths, maponpaths, pathsinv0, Fcomp.
-             apply homot_invweq_transportb_weq.
-          -- intros ?.
-             set (homsets_disp' := pr1 (pr2 (pr2 (pr2 sop)))).
-             apply iscontraprop1.
-             ++ apply impred_isaprop. intros Γ.
-                apply impred_isaprop. intros Γ'.
-                apply impred_isaprop. intros f.
-                apply impred_isaprop. intros A.
-                apply impred_isaprop. intros A'.
-                apply isapropisaset.
-             ++ apply homsets_disp'.
-  Defined.
-
-  Definition disp_ff_functor_sop
-             {C : category} (D' : disp_cat C)
-    : UU
-    := ∑ (D : disp_ff_functor_to_on_objects D'),
-       disp_ff_functor_mor_sop D.
-
-  Definition source_disp_cat_of_disp_ff_functor_sop
-             {C : category} {D' : disp_cat C}
-             (Fsop : disp_ff_functor_sop D')
-    : disp_cat C.
-  Proof.
-    set (sop := pr1 (pr2 Fsop)).
-
-    set (ob_disp := pr1 (pr1 Fsop)).
-    set (axioms_d := pr2 (pr2 Fsop)).
-
-    set (mor_disp := pr1 sop).
-    set (id_disp' := pr1 (pr2 sop)).
-    set (comp_disp' := pr1 (pr2 (pr2 sop))).
-
-    exact (((ob_disp ,, mor_disp) ,, (id_disp' , comp_disp')) ,, axioms_d).
-  Defined.
-
-  Definition disp_functor_of_disp_ff_functor_sop
-             {C : category} {D' : disp_cat C}
-             (Fsop : disp_ff_functor_sop D')
-    : disp_functor (functor_identity C) (source_disp_cat_of_disp_ff_functor_sop Fsop) D'.
-  Proof.
-    set (sop := pr1 (pr2 Fsop)).
-
-    set (Fob := pr2 (pr1 Fsop)).
-    set (Fmor := pr1 (pr2 (pr2 (pr2 (pr2 sop))))).
-    set (Fid := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 sop)))))).
-    set (Fcomp := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
-
-    exact ((Fob,,Fmor),,(Fid,Fcomp)).
-  Defined.
-
-  Coercion disp_functor_of_disp_ff_functor_sop : disp_ff_functor_sop >-> disp_functor.
-
-  Definition disp_functor_of_disp_ff_functor_sop_is_ff
-             {C : category} {D' : disp_cat C}
-             (Fsop : disp_ff_functor_sop D')
-    : disp_functor_ff (disp_functor_of_disp_ff_functor_sop Fsop).
-  Proof.
-    set (sop := pr1 (pr2 Fsop)).
-    set (Fff := pr2 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 sop))))))).
-    exact Fff.
-  Defined.
-
-  Definition disp_ff_functor_sop_eq
-             {C : category} (D' : disp_cat C)
-             (X Y : disp_ff_functor_sop D')
-             (e : pr1 X = pr1 Y)
-    : X = Y.
-  Proof.
-    use total2_paths_f.
-    - apply e.
-    - apply isapropifcontr.
-      apply disp_ff_functor_mor_sop_iscontr.
-  Defined.
-             
-  Definition disp_ff_functor_sop_disp_functor_ff_weq
-             {C : category} {D' : disp_cat C}
-    : disp_ff_functor_sop D' ≃
-      ∑ (D : disp_cat C) (F : disp_functor (functor_identity _) D D'), disp_functor_ff F.
-  Proof.
-    use weq_iso.
-
-    - intros Fsop.
-      exists (source_disp_cat_of_disp_ff_functor_sop Fsop).
-      exists (disp_functor_of_disp_ff_functor_sop Fsop).
-      apply disp_functor_of_disp_ff_functor_sop_is_ff.
-
-    - intros F.
-      
-      set (ob_disp := pr1 (pr1 (pr1 (pr1 F)))).
-      set (mor_disp := pr2 (pr1 (pr1 (pr1 F)))).
-      set (id_disp' := pr1 (pr2 (pr1 (pr1 F)))).
-      set (comp_disp' := pr2 (pr2 (pr1 (pr1 F)))).
-      set (axioms_d := pr2 (pr1 F)).
-      set (homsets_disp' := pr2 (pr2 (pr2 axioms_d))).
-
-      set (Fob := pr1 (pr1 (pr1 (pr2 F)))).
-      set (Fmor := pr2 (pr1 (pr1 (pr2 F)))).
-      set (Fid := pr1 (pr2 (pr1 (pr2 F)))).
-      set (Fcomp := pr2 (pr2 (pr1 (pr2 F)))).
-      set (Fff := pr2 (pr2 F)).
-
-      exists (ob_disp ,, Fob).
-      exists (mor_disp ,, id_disp' ,, comp_disp' ,, homsets_disp' ,, Fmor ,, Fid ,, Fcomp ,, Fff).
-      exact axioms_d.
-
-    - intros ?. apply disp_ff_functor_sop_eq. apply idpath.
-    - intros ?. apply idpath.
-  Defined.
-
-  Definition disp_ff_functor_sop_disp_ff_functor_to_on_objects_weq
-             {C : category} {D' : disp_cat C}
-    : disp_ff_functor_to_on_objects D' ≃ disp_ff_functor_sop D'.
-  Proof.
-    apply invweq, weqpr1.
-    intros D.
-    apply disp_ff_functor_mor_sop_iscontr.
   Defined.
 
 End Auxiliary.
@@ -1259,7 +665,7 @@ Section TypeCat_ComprehensionCat.
 
   Definition typecat_obj_ext_structure_disp_ff_functor_to_codomain_weq
              (C : category)
-    : typecat_obj_ext_structure C ≃ disp_ff_functor_to_on_objects (disp_codomain C).
+    : typecat_obj_ext_structure C ≃ ff_disp_functor (disp_codomain C).
   Proof.
     use weq_iso.
     - intros tc.
@@ -1280,24 +686,25 @@ Section TypeCat_ComprehensionCat.
 
   Definition typecat_obj_ext_structure_ff_disp_functor_to_codomain_weq
              (C : category)
-    : typecat_obj_ext_structure C ≃
-      ∑ (D : disp_cat C)
-      (F : disp_functor (functor_identity _) D (disp_codomain C))
-      , disp_functor_ff F.
+    : typecat_obj_ext_structure C ≃ ff_disp_functor_explicit (disp_codomain C).
   Proof.
     eapply weqcomp. apply typecat_obj_ext_structure_disp_ff_functor_to_codomain_weq.
-    eapply weqcomp. apply disp_ff_functor_sop_disp_ff_functor_to_on_objects_weq.
-    apply disp_ff_functor_sop_disp_functor_ff_weq.
+    apply ff_disp_functor_weq.
   Defined.
 
-  Definition typecat_structure' (C : category) : UU
-    := ∑ (TC : typecat_obj_ext_structure C)
-         (reind : ∏ Γ (A : TC Γ) Γ' (f : Γ' --> Γ), TC Γ')
+  Definition typecat_structure2' {C : category}
+             (TC : typecat_obj_ext_structure C)
+    : UU
+    := ∑ (reind : ∏ Γ (A : TC Γ) Γ' (f : Γ' --> Γ), TC Γ')
          (q : ∏ Γ (A : TC Γ) Γ' (f : Γ' --> Γ), (obj_ext_typecat Γ' (reind _ A _ f)) --> obj_ext_typecat Γ A )
          (dpr_q : ∏ Γ (A : TC Γ) Γ' (f : Γ' --> Γ), 
                   (q _ A _ f) ;; (dpr_typecat_obj_ext A) = (dpr_typecat_obj_ext (reind _ A _ f)) ;; f),
        ∏ Γ (A : TC Γ) Γ' (f : Γ' --> Γ),
        isPullback _ _ _ _ (!dpr_q _ A _ f).
+
+  Definition typecat_structure' (C : category) : UU
+    := ∑ (TC : typecat_obj_ext_structure C),
+         typecat_structure2' TC.
 
   Definition typecat_structure_typecat_structure'_weq
              (C : category)
@@ -1324,9 +731,27 @@ Section TypeCat_ComprehensionCat.
   Defined.
 
   Definition ff_comprehension_cat_structure (C : category) : UU
-    := ∑ (F : disp_ff_functor_sop (disp_codomain C)),
-       cleaving (source_disp_cat_of_disp_ff_functor_sop F)
-       × is_cartesian_disp_functor F. 
+    := ∑ (F : ∑ (D : disp_cat C)
+                (F : disp_functor (functor_identity _) D (disp_codomain C))
+              , disp_functor_ff F),
+       cleaving (pr1 F) × is_cartesian_disp_functor (pr1 (pr2 F)). 
+
+  Definition typecat_structure2'_cleaving_weq
+             {C : category} (TC : typecat_obj_ext_structure C)
+    : typecat_structure2' TC ≃
+        (cleaving (pr1 (typecat_obj_ext_structure_ff_disp_functor_to_codomain_weq _ TC))
+        × is_cartesian_disp_functor (pr1 (pr2 (typecat_obj_ext_structure_ff_disp_functor_to_codomain_weq _ TC)))).
+  Proof.
+  Abort.
+
+  Definition typecat_structure'_ff_comprehension_cat_structure_weq
+             (C : category)
+    : typecat_structure' C ≃ ff_comprehension_cat_structure C.
+  Proof.
+    use weqtotal2.
+    - apply typecat_obj_ext_structure_ff_disp_functor_to_codomain_weq.
+    - intros TC. simpl.
+  Abort.
 
   Definition typecat_ff_comprehension_cat_structure_weq (C : category)
     : typecat_structure C ≃ ff_comprehension_cat_structure C.

--- a/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
+++ b/TypeTheory/ALV2/TypeCat_ComprehensionCat.v
@@ -90,6 +90,20 @@ Section Auxiliary.
       apply weqtotal2asstor.
   Defined.
 
+  (* TODO: move upstream? *)
+  Lemma iscontr_total2
+        {X : UU} {P : X → UU}
+    : iscontr X → (∏ x : X, iscontr (P x)) → iscontr (∑ (x : X), P x).
+  Proof.
+    intros X_contr P_contr.
+    use tpair.
+    - exists (pr1 X_contr). apply P_contr.
+    - intros xp.
+      use total2_paths_f.
+      + apply X_contr.
+      + apply P_contr.
+  Defined.
+
   Definition disp_ff_functor_to_on_objects
              {C : category}
              (D' : disp_cat C)
@@ -271,6 +285,61 @@ Section Auxiliary.
       + intros p. apply mor_isaset.
       + intros p. apply (@homsets_disp _ D').
     - apply iscontrcoconustot.
+  Defined.
+
+  Definition disp_ff_functor_source_mor_isaset
+             {C : category} {D' : disp_cat C}
+             (D : disp_ff_functor_to_on_objects D')
+             (mor_weq : disp_ff_functor_on_morphisms_pos D)
+    : ∏ Γ Γ' f (A : pr1 D Γ) (A' : pr1 D Γ'), isaset (pr1 (mor_weq _ _ A A' f)).
+  Proof.
+    intros Γ Γ' f A A'.
+    set (w := pr2 (mor_weq Γ Γ' A A' f)).
+    use (isofhlevelweqf 2 (invweq w)).
+    apply (@homsets_disp _ D').
+  Defined.
+
+  Definition disp_ff_functor_source_mor_isaset_iscontr
+             {C : category} {D' : disp_cat C}
+             (D : disp_ff_functor_to_on_objects D')
+             (mor_weq : disp_ff_functor_on_morphisms_pos D)
+    : iscontr (∏ Γ Γ' f (A : pr1 D Γ) (A' : pr1 D Γ'), isaset (pr1 (mor_weq _ _ A A' f))).
+  Proof.
+    apply iscontraprop1.
+    - apply impred_isaprop. intros Γ.
+      apply impred_isaprop. intros Γ'.
+      apply impred_isaprop. intros A.
+      apply impred_isaprop. intros A'.
+      apply impred_isaprop. intros f.
+      apply isapropisaset.
+    - apply disp_ff_functor_source_mor_isaset.
+  Defined.
+
+  Definition disp_ff_functor_on_morphisms_idcomp_pos
+             {C : category} {D' : disp_cat C}
+             (D : disp_ff_functor_to_on_objects D')
+    : UU
+    := ∑ (mor_weq : disp_ff_functor_on_morphisms_pos D)
+         (mor_isaset : ∏ Γ Γ' f (A : pr1 D Γ) (A' : pr1 D Γ'), isaset (pr1 (mor_weq _ _ A A' f)))
+         (mor_id : disp_ff_functor_on_morphisms_id_pos D mor_weq)
+       , disp_ff_functor_on_morphisms_comp_pos D mor_weq.
+
+  Definition disp_ff_functor_on_morphisms_idcomp_pos_iscontr
+             {C : category} {D' : disp_cat C}
+             (D : disp_ff_functor_to_on_objects D')
+    : iscontr (disp_ff_functor_on_morphisms_idcomp_pos D).
+  Proof.
+    apply iscontr_total2.
+    - apply disp_ff_functor_on_morphisms_pos_iscontr.
+    - intros mor_weq. apply iscontr_total2.
+      + apply disp_ff_functor_source_mor_isaset_iscontr.
+      + intros mor_isaset.
+        apply iscontr_total2.
+        * apply disp_ff_functor_on_morphisms_id_pos_iscontr.
+          apply mor_isaset.
+        * intros ?.
+          apply disp_ff_functor_on_morphisms_comp_pos_iscontr.
+          apply mor_isaset.
   Defined.
 
   (* Types for parts of a fully faithful functor that rely on morphisms *)


### PR DESCRIPTION
This PR builds on #170. TODO

- [x] Construct type category from a comprehension category;
- [ ] Show that constructions form equivalence.