### PR TITLE
Split type categories and discrete comprehension categories (categorically)

### DIFF
--- a/TypeTheory/ALV2/.package/files
+++ b/TypeTheory/ALV2/.package/files
@@ -16,5 +16,6 @@ FullyFaithfulDispFunctor.v
 DiscreteComprehensionCat.v
 SplitTypeCat_ComprehensionCat.v
 SplitTypeCat_Cat_Simple.v
+DiscCompCat_Cat.v
 DiscCompCatDef_Cat.v
 SplitTypeCat_DiscCompCatDef_catiso.v

--- a/TypeTheory/ALV2/.package/files
+++ b/TypeTheory/ALV2/.package/files
@@ -16,5 +16,6 @@ FullyFaithfulDispFunctor.v
 DiscreteComprehensionCat.v
 SplitTypeCat_ComprehensionCat.v
 SplitTypeCat_Cat_Simple.v
+DiscCompCatDef_Cat.v
 DiscCompCat_Cat.v
 SplitTypeCat_DiscCompCat_catiso.v

--- a/TypeTheory/ALV2/.package/files
+++ b/TypeTheory/ALV2/.package/files
@@ -15,3 +15,6 @@ TypeCat_ComprehensionCat.v
 FullyFaithfulDispFunctor.v
 DiscreteComprehensionCat.v
 SplitTypeCat_ComprehensionCat.v
+SplitTypeCat_Cat_Simple.v
+DiscCompCat_Cat.v
+SplitTypeCat_DiscCompCat_catiso.v

--- a/TypeTheory/ALV2/.package/files
+++ b/TypeTheory/ALV2/.package/files
@@ -17,5 +17,4 @@ DiscreteComprehensionCat.v
 SplitTypeCat_ComprehensionCat.v
 SplitTypeCat_Cat_Simple.v
 DiscCompCatDef_Cat.v
-DiscCompCat_Cat.v
-SplitTypeCat_DiscCompCat_catiso.v
+SplitTypeCat_DiscCompCatDef_catiso.v

--- a/TypeTheory/ALV2/DiscCompCatDef_Cat.v
+++ b/TypeTheory/ALV2/DiscCompCatDef_Cat.v
@@ -1,0 +1,442 @@
+(**
+    TODO
+*)
+
+Require Import UniMath.Foundations.Sets.
+Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
+
+Require Import TypeTheory.Auxiliary.Auxiliary.
+Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
+Require Import TypeTheory.ALV1.TypeCat.
+Require Import TypeTheory.ALV2.DiscreteComprehensionCat.
+
+Require Import UniMath.CategoryTheory.DisplayedCats.Auxiliary.
+Require Import UniMath.CategoryTheory.DisplayedCats.Core.
+Require Import UniMath.CategoryTheory.DisplayedCats.Fibrations.
+
+Local Definition D_ob {C : category} :=
+  discrete_comprehension_cat_structure_with_default_mor_D_ob (C := C).
+
+Local Definition F_ob {C : category} :=
+  discrete_comprehension_cat_structure_with_default_mor_F_ob (C := C).
+
+Local Definition D_lift_ob {C : category} :=
+  discrete_comprehension_cat_structure_with_default_mor_D_lift_ob (C := C).
+
+Local Definition D_ob_isaset {C : category} :=
+  discrete_comprehension_cat_structure_with_default_mor_D_ob_isaset (C := C).
+
+Local Definition D_id {C : category} :=
+  discrete_comprehension_cat_structure_with_default_mor_D_id (C := C).
+
+Local Definition D_comp {C : category} :=
+  discrete_comprehension_cat_structure_with_default_mor_D_comp (C := C).
+
+Local Definition F_mor {C : category} :=
+  discrete_comprehension_cat_structure_with_default_mor_F_mor (C := C).
+
+Section DiscCompCat_mor.
+
+  Context (C : category).
+
+  Definition DiscCompCatDef_TY
+             (DC : discrete_comprehension_cat_structure_with_default_mor C)
+    : preShv C.
+  Proof.
+    set (D_ob := pr1 DC).
+    set (D_lift_ob := pr1 (pr2 (pr2 DC))).
+    set (D_ob_isaset := pr1 (pr2 (pr2 (pr2 DC)))).
+    set (D_id := pr1 (pr1 (pr2 (pr2 (pr2 (pr2 (pr2 DC))))))).
+    set (D_comp := pr2 (pr1 (pr2 (pr2 (pr2 (pr2 (pr2 DC))))))).
+    simpl in *.
+    use tpair.
+    - use tpair.
+      + intros Γ. use tpair.
+        * exact (D_ob Γ).
+        * exact (D_ob_isaset Γ).
+      + exact D_lift_ob.
+    - use make_dirprod.
+      + intros Γ. apply funextsec; intros A. apply D_id.
+      + intros Γ Γ' Γ'' f g. apply funextsec; intros A.
+        apply (D_comp _ _ _ _ _ _ _ _ (idpath _) (idpath _)).
+  Defined.
+
+  Definition DiscCompCatDef_mor_data
+             (X Y : discrete_comprehension_cat_structure_with_default_mor C)
+    : UU
+    := ∑ (F_TY : ∏ {Γ : C}, D_ob X Γ → D_ob Y Γ),
+       (* ϕ : *) ∏ (Γ : C) (A : D_ob X Γ),
+            pr1 (F_ob X Γ A) --> pr1 (F_ob Y Γ (F_TY A)).
+
+  Local Definition F_TY 
+             {X Y : discrete_comprehension_cat_structure_with_default_mor C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    := pr1 mor.
+
+  Local Definition ϕ
+             {X Y : discrete_comprehension_cat_structure_with_default_mor C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    := pr2 mor.
+
+  Definition DiscCompCatDef_mor_axiom_F_TY
+             {X Y : discrete_comprehension_cat_structure_with_default_mor C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    : UU
+    := ∏ (Γ Γ' : C) (f : C ⟦ Γ', Γ ⟧) (A : D_ob X Γ),
+       F_TY mor _ (D_lift_ob X _ _ f A) = D_lift_ob Y _ _ f (F_TY mor _ A).
+                    
+  Definition DiscCompCatDef_mor_axiom_ϕ_dpr
+             {X Y : discrete_comprehension_cat_structure_with_default_mor C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    : UU
+    := ∏ (Γ : C) (A : D_ob X Γ),
+       ϕ mor Γ A ;; pr2 (F_ob Y Γ (F_TY mor _ A)) = pr2 (F_ob X Γ A).
+
+  Definition F_ob_compare
+             {X : discrete_comprehension_cat_structure_with_default_mor C}
+             {Γ : C} {A A' : D_ob X Γ} (e : A = A')
+    : iso (pr1 (F_ob X Γ A)) (pr1 (F_ob X Γ A')).
+  Proof.
+    apply idtoiso, maponpaths, maponpaths, e.
+  Defined.
+
+  Lemma F_ob_compare_id {X : discrete_comprehension_cat_structure_with_default_mor C}
+        {Γ : C} (A : D_ob X Γ)
+    : F_ob_compare (idpath A) = identity_iso (pr1 (F_ob X Γ A)).
+  Proof.
+    apply idpath.
+  Qed.
+
+  Lemma F_ob_compare_id_general {X : discrete_comprehension_cat_structure_with_default_mor C}
+        {Γ : C} {A : D_ob X Γ}
+        (e : A = A)
+    : F_ob_compare e = identity_iso (pr1 (F_ob X Γ A)).
+  Proof.
+    apply @pathscomp0 with (F_ob_compare (idpath _)). 
+    apply maponpaths, D_ob_isaset.
+    apply idpath.
+  Qed.
+
+  Lemma F_ob_compare_comp {X : discrete_comprehension_cat_structure_with_default_mor C}
+        {Γ : C} {A A' A'' : D_ob X Γ} (e : A = A') (e' : A' = A'')
+    : pr1 (F_ob_compare (e @ e')) = F_ob_compare e ;; F_ob_compare e'.
+  Proof.
+    apply pathsinv0.
+    etrans. apply idtoiso_concat_pr. 
+    unfold F_ob_compare. apply maponpaths, maponpaths.
+    apply pathsinv0.
+    etrans. 2: apply maponpathscomp0. 
+    apply maponpaths.
+    apply maponpathscomp0.
+  Qed.
+
+  Lemma F_ob_compare_comp_general {X : discrete_comprehension_cat_structure_with_default_mor C}
+        {Γ : C} {A A' A'' : D_ob X Γ}
+        (e : A = A') (e' : A' = A'') (e'' : A = A'')
+    : pr1 (F_ob_compare e'') = F_ob_compare e ;; F_ob_compare e'.
+  Proof.
+    refine (_ @ F_ob_compare_comp _ _).
+    apply maponpaths, maponpaths, D_ob_isaset.
+  Qed.
+
+  Definition Δ
+             {X Y : discrete_comprehension_cat_structure_with_default_mor C}
+             (mor : DiscCompCatDef_mor_data X Y)
+             (F_TY_ax : DiscCompCatDef_mor_axiom_F_TY mor)
+    : ∏ (Γ Γ' : C) (f : C ⟦ Γ', Γ ⟧) (A : D_ob X Γ),
+      C ⟦ pr1 (F_ob Y Γ' (F_TY mor Γ' (D_lift_ob X Γ Γ' f A))),
+          pr1 (F_ob Y Γ' (D_lift_ob Y Γ Γ' f (F_TY mor Γ A))) ⟧.
+  Proof.
+    intros Γ A Γ' f.
+    use F_ob_compare.
+    apply F_TY_ax.
+  Defined.
+    
+  Lemma Δ_ϕ
+        {X Y : discrete_comprehension_cat_structure_with_default_mor C}
+        (G : DiscCompCatDef_mor_data X Y)
+        {Γ : C} {A A' : D_ob X Γ}
+        (e : A = A')
+    : F_ob_compare e ;; ϕ G Γ A' = ϕ G Γ A ;; F_ob_compare (maponpaths (F_TY G _) e).
+  Proof.
+    destruct e; simpl. etrans. apply id_left. apply pathsinv0, id_right.
+  Defined.
+
+  Definition DiscCompCatDef_mor_axiom_ϕ_qq
+             {X Y : discrete_comprehension_cat_structure_with_default_mor C}
+             (mor : DiscCompCatDef_mor_data X Y)
+             (F_TY_ax : DiscCompCatDef_mor_axiom_F_TY mor)
+    : UU
+    := ∏ (Γ Γ' : C) (f : C ⟦ Γ', Γ ⟧) (A : D_ob X Γ),
+       pr1 (F_mor X Γ' Γ (D_lift_ob X _ _ f A) A f (idpath _)) ;; ϕ mor Γ A =
+       ϕ mor Γ' (D_lift_ob X _ _ f A) ;; Δ mor F_TY_ax Γ Γ' f A ;; pr1 (F_mor Y Γ' Γ (D_lift_ob Y _ _ f (F_TY mor _ A)) (F_TY mor _ A) f (idpath _))
+  .
+
+  Definition DiscCompCatDef_mor_axioms
+             {X Y : discrete_comprehension_cat_structure_with_default_mor C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    : UU
+    := ∑ (F_TY_ax : DiscCompCatDef_mor_axiom_F_TY mor)
+        (ϕ_dpr_ax : DiscCompCatDef_mor_axiom_ϕ_dpr mor),
+      (* ϕ_qq_ax : *) DiscCompCatDef_mor_axiom_ϕ_qq mor F_TY_ax.
+
+  Definition isaprop_DiscCompCatDef_mor_axiom_F_TY
+             {X Y : discrete_comprehension_cat_structure_with_default_mor C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    : isaprop (DiscCompCatDef_mor_axiom_F_TY mor).
+  Proof.
+    repeat (apply impred_isaprop; intros ?).
+    apply D_ob_isaset.
+  Qed.
+
+  Definition isaprop_DiscCompCatDef_mor_axiom_ϕ_dpr
+             {X Y : discrete_comprehension_cat_structure_with_default_mor C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    : isaprop (DiscCompCatDef_mor_axiom_ϕ_dpr mor).
+  Proof.
+    repeat (apply impred_isaprop; intros ?).
+    apply homset_property.
+  Qed.
+       
+  Definition isaprop_DiscCompCatDef_mor_axiom_ϕ_qq
+             {X Y : discrete_comprehension_cat_structure_with_default_mor C}
+             (mor : DiscCompCatDef_mor_data X Y)
+             (F_TY_ax : DiscCompCatDef_mor_axiom_F_TY mor)
+    : isaprop (DiscCompCatDef_mor_axiom_ϕ_qq mor F_TY_ax).
+  Proof.
+    repeat (apply impred_isaprop; intros ?).
+    apply homset_property.
+  Qed.
+
+  Definition isaprop_DiscCompCatDef_mor_axioms
+             {X Y : discrete_comprehension_cat_structure_with_default_mor C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    : isaprop (DiscCompCatDef_mor_axioms mor).
+  Proof.
+    apply Propositions.isaproptotal2.
+    - intros ?. apply isapropdirprod.
+      + apply isaprop_DiscCompCatDef_mor_axiom_ϕ_dpr.
+      + apply isaprop_DiscCompCatDef_mor_axiom_ϕ_qq.
+    - intros. apply isaprop_DiscCompCatDef_mor_axiom_F_TY. 
+  Qed.
+
+  Definition DiscCompCatDef_mor
+             (X Y : discrete_comprehension_cat_structure_with_default_mor C)
+    : UU
+    := ∑ (mor : DiscCompCatDef_mor_data X Y), DiscCompCatDef_mor_axioms mor.
+
+  Definition DiscCompCatDef_mor_to_mor_data
+             {X Y : discrete_comprehension_cat_structure_with_default_mor C}
+             (mor : DiscCompCatDef_mor X Y)
+    : DiscCompCatDef_mor_data X Y
+    := pr1 mor.
+
+  Coercion DiscCompCatDef_mor_to_mor_data : DiscCompCatDef_mor >-> DiscCompCatDef_mor_data.
+
+  Definition DiscCompCatDef_mor_eq
+             {X Y : discrete_comprehension_cat_structure_with_default_mor C}
+             (F G : DiscCompCatDef_mor X Y)
+             (F_TY_eq : ∏ Γ (A : D_ob X Γ), F_TY F _ A = F_TY G _ A)
+             (ϕ_eq : ∏ Γ (A : D_ob X Γ),
+                     ϕ F _ A ;; F_ob_compare (F_TY_eq Γ A) = ϕ G _ A)
+    : F = G.
+  Proof.
+    use total2_paths_f. 2: apply isaprop_DiscCompCatDef_mor_axioms.
+    use total2_paths_f.
+    - repeat (apply funextsec; intros ?). apply F_TY_eq.
+    - etrans. use transportf_forall.
+      apply funextsec; intros Γ.
+      etrans. use transportf_forall.
+      apply funextsec; intros A.
+      refine (_ @ ϕ_eq Γ A).
+      etrans. apply (functtransportf
+                       (λ x, x Γ A)
+                       (λ y, C ⟦ pr1 (F_ob X Γ A), pr1 (F_ob Y Γ y) ⟧)).
+      etrans. apply (functtransportf
+                       (λ x, F_ob Y Γ x)
+                       (λ y, C ⟦ pr1 (F_ob X Γ A), pr1 y ⟧)).
+      etrans. apply (functtransportf
+                       (λ x, pr1 x)
+                       (λ y, C ⟦ pr1 (F_ob X Γ A), y ⟧)).
+      etrans. apply pathsinv0, idtoiso_postcompose.
+      apply maponpaths.
+      unfold F_ob_compare.
+      apply maponpaths.
+      apply maponpaths.
+      apply maponpaths.
+      apply maponpaths.
+      apply D_ob_isaset.
+  Defined.
+
+  Definition DiscCompCatDef_precat_ob_mor
+    : precategory_ob_mor
+    := (_ ,, DiscCompCatDef_mor).
+                                                              
+             
+  Definition DiscCompCatDef_mor_id_data
+             (X : discrete_comprehension_cat_structure_with_default_mor C)
+    : DiscCompCatDef_mor_data X X.
+  Proof.
+    use tpair.
+    + intros Γ. apply idfun.
+    + intros Γ A. apply identity.
+  Defined.
+
+  Definition DiscCompCatDef_mor_id_axioms
+             (X : discrete_comprehension_cat_structure_with_default_mor C)
+    : DiscCompCatDef_mor_axioms (DiscCompCatDef_mor_id_data X).
+  Proof.
+    use tpair. 2: use make_dirprod.
+    + intros Γ Γ' f A. apply idpath.
+    + intros Γ A. apply id_left.
+    + intros Γ Γ' f A.
+      etrans. apply id_right.
+      apply pathsinv0.
+      etrans. apply assoc'.
+      etrans. apply id_left.
+      apply id_left.
+  Qed.
+
+  Definition DiscCompCatDef_mor_id
+             (X : discrete_comprehension_cat_structure_with_default_mor C)
+    : DiscCompCatDef_mor X X
+    := (_ ,, DiscCompCatDef_mor_id_axioms X).
+  
+  Definition DiscCompCatDef_mor_comp_data
+             (X Y Z : discrete_comprehension_cat_structure_with_default_mor C)
+             (F : DiscCompCatDef_mor_data X Y)
+             (G : DiscCompCatDef_mor_data Y Z)
+    : DiscCompCatDef_mor_data X Z.
+  Proof.
+    use tpair.
+    + intros Γ A. apply (F_TY G _ (F_TY F _ A)).
+    + intros Γ A. apply (ϕ F _ _ ;; ϕ G _ _).
+  Defined.
+
+  Definition DiscCompCatDef_mor_comp_axioms
+             (X Y Z : discrete_comprehension_cat_structure_with_default_mor C)
+             (F : DiscCompCatDef_mor X Y)
+             (G : DiscCompCatDef_mor Y Z)
+    : DiscCompCatDef_mor_axioms (DiscCompCatDef_mor_comp_data X Y Z F G).
+  Proof.
+    use tpair. 2: use make_dirprod.
+    + intros Γ Γ' f A. cbn.
+      etrans. apply maponpaths.
+      apply (pr1 (pr2 F)).
+      apply (pr1 (pr2 G)).
+    + intros Γ A. cbn.
+      etrans. apply assoc'.
+      etrans. apply maponpaths.
+      apply (pr1 (pr2 (pr2 G))).
+      apply (pr1 (pr2 (pr2 F))).
+    + intros Γ Γ' f A. cbn.
+      etrans. apply assoc.
+      etrans. apply maponpaths_2.
+      apply (pr2 (pr2 (pr2 F))).
+      etrans. apply assoc'.
+      etrans. apply maponpaths.
+      apply (pr2 (pr2 (pr2 G))).
+      etrans. apply assoc.
+      apply maponpaths_2.
+      etrans. apply assoc'.
+      etrans. 2: apply assoc.
+      apply maponpaths.
+
+      etrans. apply assoc.
+      etrans. apply maponpaths_2, Δ_ϕ.
+      etrans. apply assoc'.
+
+      apply maponpaths.
+      apply pathsinv0.
+      apply F_ob_compare_comp_general.
+  Qed.
+
+  Definition DiscCompCatDef_mor_comp
+             (X Y Z : discrete_comprehension_cat_structure_with_default_mor C)
+             (F : DiscCompCatDef_mor X Y)
+             (G : DiscCompCatDef_mor Y Z)
+    : DiscCompCatDef_mor X Z
+    := (_ ,, DiscCompCatDef_mor_comp_axioms X Y Z F G).
+
+  Definition DiscCompCatDef_precat_id_comp
+    : precategory_id_comp (DiscCompCatDef_precat_ob_mor)
+    := (DiscCompCatDef_mor_id , DiscCompCatDef_mor_comp).
+
+  Definition DiscCompCatDef_precat_data
+    : precategory_data
+    := (_ ,, DiscCompCatDef_precat_id_comp).
+
+  Definition DiscCompCatDef_precat_id_left
+             (X Y : DiscCompCatDef_precat_data)
+             (F : DiscCompCatDef_precat_data ⟦ X, Y ⟧)
+    : identity X ;; F = F.
+  Proof.
+    use DiscCompCatDef_mor_eq.
+    - intros Γ A. apply idpath.
+    - intros Γ A. etrans. apply id_right. apply id_left.
+  Qed.
+
+  Definition DiscCompCatDef_precat_id_right
+             (X Y : DiscCompCatDef_precat_data)
+             (F : DiscCompCatDef_precat_data ⟦ X, Y ⟧)
+    : F ;; identity Y = F.
+  Proof.
+    use DiscCompCatDef_mor_eq.
+    - intros Γ A. apply idpath.
+    - intros Γ A. etrans. apply id_right. apply id_right.
+  Qed.
+
+  Definition DiscCompCatDef_precat_assoc
+             (X Y Z W : DiscCompCatDef_precat_data)
+             (F : DiscCompCatDef_precat_data ⟦ X, Y ⟧)
+             (G : DiscCompCatDef_precat_data ⟦ Y, Z ⟧)
+             (H : DiscCompCatDef_precat_data ⟦ Z, W ⟧)
+    : F ;; (G ;; H) = (F ;; G) ;; H.
+  Proof.
+    use DiscCompCatDef_mor_eq.
+    - intros Γ A. apply idpath.
+    - intros Γ A. etrans. apply id_right. apply assoc.
+  Qed.
+
+  Definition DiscCompCatDef_precat_assoc'
+             (X Y Z W : DiscCompCatDef_precat_data)
+             (F : DiscCompCatDef_precat_data ⟦ X, Y ⟧)
+             (G : DiscCompCatDef_precat_data ⟦ Y, Z ⟧)
+             (H : DiscCompCatDef_precat_data ⟦ Z, W ⟧)
+    : (F ;; G) ;; H = F ;; (G ;; H).
+  Proof.
+    use DiscCompCatDef_mor_eq.
+    - intros Γ A. apply idpath.
+    - intros Γ A. etrans. apply id_right. apply assoc'.
+  Qed.
+
+  Definition DiscCompCatDef_precat_axioms
+    : is_precategory DiscCompCatDef_precat_data.
+  Proof.
+    use make_is_precategory.
+    - apply DiscCompCatDef_precat_id_left.
+    - apply DiscCompCatDef_precat_id_right.
+    - apply DiscCompCatDef_precat_assoc.
+    - apply DiscCompCatDef_precat_assoc'.
+  Qed.
+
+  Definition DiscCompCatDef_precat : precategory
+    := (_ ,, DiscCompCatDef_precat_axioms).
+
+  Definition DiscCompCatDef_precat_has_homsets
+    : has_homsets DiscCompCatDef_precat.
+  Proof.
+    intros X Y.
+    apply isaset_total2. 2: intros ?; apply isasetaprop, isaprop_DiscCompCatDef_mor_axioms.
+    - apply isaset_total2.
+      + repeat (apply impred_isaset; intros ?).
+        apply D_ob_isaset.
+      + intros ?.
+        repeat (apply impred_isaset; intros ?).
+        apply homset_property.
+  Defined.
+
+  Definition DiscCompCatDef_cat : category
+    := (DiscCompCatDef_precat ,, DiscCompCatDef_precat_has_homsets).
+
+End DiscCompCat_mor.

--- a/TypeTheory/ALV2/DiscCompCatDef_DiscCompCat_catiso.v
+++ b/TypeTheory/ALV2/DiscCompCatDef_DiscCompCat_catiso.v
@@ -36,8 +36,11 @@ Section SplitTypeCat_DiscCompCat_catiso.
     apply weqonsecfibers; intros Γ'.
     apply weqonsecfibers; intros f.
     apply weqonsecfibers; intros A.
-    use weq_iso.
+    use weqimplimpl.
     - intros p.
+      cbn.
+      lazy beta delta iota zeta.
+      cbv beta delta.
       etrans.
       apply (p (DiscCompCatDef_Cat.D_lift_ob (DiscCompCat_DiscCompCatDef_weq X) _ _ f A)
                (invweq (mor_with_unique_lift_mor_weq _ _ _ (pr1 (pr2 (pr2 (pr2 (pr2 X)))))) (idpath _))

--- a/TypeTheory/ALV2/DiscCompCatDef_DiscCompCat_catiso.v
+++ b/TypeTheory/ALV2/DiscCompCatDef_DiscCompCat_catiso.v
@@ -1,0 +1,84 @@
+(**
+    TODO
+*)
+
+Require Import UniMath.Foundations.Sets.
+Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
+
+Require Import UniMath.CategoryTheory.DisplayedCats.Auxiliary.
+Require Import UniMath.CategoryTheory.DisplayedCats.Core.
+
+Require Import TypeTheory.Auxiliary.Auxiliary.
+
+Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
+Require Import TypeTheory.ALV2.DiscCompCat_Cat.
+Require Import TypeTheory.ALV2.DiscCompCatDef_Cat.
+Require Import TypeTheory.ALV2.DiscreteComprehensionCat.
+
+Section SplitTypeCat_DiscCompCat_catiso.
+
+  Context (C : category).
+
+  Definition DiscCompCat_DiscCompCatDef_weq
+    : DiscCompCat_cat C ≃ DiscCompCatDef_cat C
+    := discrete_comprehension_cat_structure_with_default_mor_weq1.
+
+  Definition DiscCompCat_DiscCompCatDef_mor_weq
+             (X Y : DiscCompCat_cat C)
+    : DiscCompCat_cat C ⟦ X, Y ⟧
+        ≃ DiscCompCatDef_cat C ⟦ DiscCompCat_DiscCompCatDef_weq X
+                               , DiscCompCat_DiscCompCatDef_weq Y ⟧.
+  Proof.
+    apply (PartA.weqtotal2 (idweq _)); intros F_TY.
+    apply (PartA.weqtotal2 (idweq _)); intros F_TY_ax.
+    apply (PartA.weqtotal2 (idweq _)); intros ϕ_dpr_ax.
+    apply weqonsecfibers; intros Γ.
+    apply weqonsecfibers; intros Γ'.
+    apply weqonsecfibers; intros f.
+    apply weqonsecfibers; intros A.
+    use weq_iso.
+    - intros p.
+      etrans.
+      apply (p (DiscCompCatDef_Cat.D_lift_ob (DiscCompCat_DiscCompCatDef_weq X) _ _ f A)
+               (invweq (mor_with_unique_lift_mor_weq _ _ _ (pr1 (pr2 (pr2 (pr2 (pr2 X)))))) (idpath _))
+            ).
+      set (uf := pr2 (pr2 (pr2 mor) Γ Γ' f A)).
+      set (p := uf (A' ,, ff) : (A' ,, ff) = _).
+    - intros p A' ff.
+      etrans.
+      set (mor := pr1 (pr2 (pr2 (pr2 (pr2 (DiscCompCat_DiscCompCatDef_weq X)))))).
+      set (uf := pr2 (pr2 (pr2 mor) Γ Γ' f A)).
+      set (p := uf (A' ,, ff) : (A' ,, ff) = _).
+      apply p.
+  Defined.
+
+  Definition DiscCompCat_DiscCompCatDef_functor_data
+    : functor_data (DiscCompCatDef_cat C) (DiscCompCat_cat C).
+  Proof.
+    use tpair.
+    - apply DiscCompCat_DiscCompCatDef_weq.
+    - intros X Y. apply idweq.
+  Defined.
+
+  Definition DiscCompCat_DiscCompCatDef_functor_axioms
+    : is_functor DiscCompCat_DiscCompCatDef_functor_data.
+  Proof.
+    use make_dirprod.
+    - intros X. apply idpath.
+    - intros X Y Z f g. apply idpath.
+  Defined.
+
+  Definition DiscCompCat_DiscCompCatDef_functor
+    : functor (DiscCompCatDef_cat C) (DiscCompCat_cat C)
+    := (_ ,, DiscCompCat_DiscCompCatDef_functor_axioms).
+
+  Definition DiscCompCat_DiscCompCatDef_functor_is_catiso
+    : is_catiso DiscCompCat_DiscCompCatDef_functor.
+  Proof.
+    unfold is_catiso.
+    use make_dirprod.
+    - intros X Y. apply (pr2 (idweq _)).
+    - apply (pr2 DiscCompCat_DiscCompCatDef_weq).
+  Defined.
+  
+End SplitTypeCat_DiscCompCat_catiso.

--- a/TypeTheory/ALV2/DiscCompCat_Cat.v
+++ b/TypeTheory/ALV2/DiscCompCat_Cat.v
@@ -1,0 +1,74 @@
+(**
+    TODO
+*)
+
+Require Import UniMath.Foundations.Sets.
+Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
+
+Require Import TypeTheory.Auxiliary.Auxiliary.
+Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
+Require Import TypeTheory.ALV1.TypeCat.
+Require Import TypeTheory.ALV2.DiscreteComprehensionCat.
+
+Require Import UniMath.CategoryTheory.DisplayedCats.Auxiliary.
+Require Import UniMath.CategoryTheory.DisplayedCats.Core.
+Require Import UniMath.CategoryTheory.DisplayedCats.Fibrations.
+
+Section DiscCompCat_Cat_Simple.
+
+  Context (C : category).
+
+  Definition preshv_from_disc_comp_cat_structure
+             (DCC : discrete_comprehension_cat_structure C)
+    : preShv C.
+  Proof.
+    apply preshv_from_disc_fib_ob.
+    exists (pr1 DCC).
+    exact (pr1 (pr2 DCC)).
+  Defined.
+
+  Local Definition TY := preshv_from_disc_comp_cat_structure.
+
+  Definition DiscCompCat_ob_mor
+    : precategory_ob_mor.
+  Proof.
+    use tpair.
+    - apply (discrete_comprehension_cat_structure C).
+    - intros X Y. exact (TY X --> TY Y).
+  Defined.
+
+  Definition DiscCompCat_id_comp
+    : precategory_id_comp DiscCompCat_ob_mor.
+  Proof.
+    use make_dirprod.
+    - intros X. apply identity.
+    - intros X Y Z. apply compose.
+  Defined.
+
+  Definition DiscCompCat_precat_data
+    : precategory_data
+    := (DiscCompCat_ob_mor ,, DiscCompCat_id_comp).
+
+  Definition DiscCompCat_precat_axioms
+    : is_precategory DiscCompCat_precat_data.
+  Proof.
+    repeat use make_dirprod.
+    - intros; apply id_left.
+    - intros; apply id_right.
+    - intros; apply assoc.
+    - intros; apply assoc'.
+  Defined.
+
+  Definition DiscCompCat_precat : precategory
+    := (_ ,, DiscCompCat_precat_axioms).
+
+  Definition DiscCompCat_precat_homsets : has_homsets DiscCompCat_precat.
+  Proof.
+    unfold has_homsets.
+    intros. apply homset_property.
+  Defined.
+
+  Definition DiscCompCat_cat : category
+    := (DiscCompCat_precat ,, DiscCompCat_precat_homsets).
+  
+End DiscCompCat_Cat_Simple.

--- a/TypeTheory/ALV2/DiscCompCat_Cat.v
+++ b/TypeTheory/ALV2/DiscCompCat_Cat.v
@@ -91,9 +91,6 @@ Section DiscCompCat_Cat_Simple.
   Defined.
 
   Local Definition TY := preshv_from_disc_comp_cat_structure.
-
-  Search disp_nat_trans.
-  Search nat_trans.
   
   Definition DiscCompCat_mor
              (X Y : discrete_comprehension_cat_structure C)
@@ -131,8 +128,24 @@ Section DiscCompCat_Cat_Simple.
         * apply idpath.
         * apply isaprop_disp_functor_axioms.
       + use total2_paths_f.
-        * repeat (apply funextsec; intros ?).
-          etrans. apply (pr1_transportf
+        * unfold disp_nat_trans.
+          etrans. apply (
+                      pr1_transportf
+                        (disp_functor (functor_identity C) (pr1 a) (pr1 b))
+                        (λ x, disp_nat_trans_data
+                                (nat_trans_id (functor_identity C)) 
+                                (pr1 (pr2 (pr2 a))) (disp_functor_composite x (pr1 (pr2 (pr2 b)))))
+                        (λ x b0, disp_nat_trans_axioms b0)
+                    ).
+          repeat (apply funextsec; intros ?).
+          use total2_paths_f.
+          cbn. apply idpath.
+          use total2_paths_f.
+          -- etrans. simpl.
+             Check pr1_transportf. unfold disp_nat_trans.
+          Check pr1 (pr2 f) x x0.
+          cbn.
+          etrans. apply pr1_transportf.
                            _ _
                            (λ x xx, _)
                          ).

--- a/TypeTheory/ALV2/DiscCompCat_Cat.v
+++ b/TypeTheory/ALV2/DiscCompCat_Cat.v
@@ -14,6 +14,69 @@ Require Import UniMath.CategoryTheory.DisplayedCats.Auxiliary.
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 Require Import UniMath.CategoryTheory.DisplayedCats.Fibrations.
 
+Section Auxiliary.
+
+  Definition disp_functor_composite_assoc 
+             {C : category}
+             (X Y Z W : disp_cat C)
+             (F : disp_functor (functor_identity C) X Y)
+             (G : disp_functor (functor_identity C) Y Z)
+             (H : disp_functor (functor_identity C) Z W)
+    : disp_nat_trans (nat_trans_id (functor_identity _))
+        (disp_functor_composite (disp_functor_composite F G) H)
+        (disp_functor_composite F (disp_functor_composite G H)).
+  Proof.
+    apply disp_nat_trans_id.
+  Defined.
+
+  Definition disp_nat_trans_right
+             {C : category}
+             {X Y Z : disp_cat C}
+             (F : disp_functor (functor_identity C) X Y)
+             {G : disp_functor (functor_identity C) Y Z}
+             {H : disp_functor (functor_identity C) Y Z}
+             (α : disp_nat_trans (nat_trans_id _) G H)
+    : disp_nat_trans (nat_trans_id _)
+        (disp_functor_composite F G)
+        (disp_functor_composite F H).
+  Proof.
+    use tpair.
+    - intros Γ A. apply α.
+    - intros Γ Γ' f A A' ff. cbn.
+      apply (pr2 α Γ Γ' f (F _ A) (F _ A') (disp_functor_on_morphisms F ff)).
+  Defined.
+
+  Lemma nat_trans_id_id
+        {C : category}
+    : (nat_trans_comp _ _ _
+                      (nat_trans_id (functor_identity C))
+                      (nat_trans_id (functor_identity C)))
+      = nat_trans_id (functor_identity C).
+  Proof.
+    use total2_paths_f.
+    - repeat (apply funextsec; intros ?). cbn.
+      apply id_left.
+    - repeat (apply funextsec; intros ?). apply homset_property.
+  Defined.
+
+  Definition disp_nat_trans_comp_over_id
+             {C : category}
+             {D D' : disp_cat C}
+             {R'' : disp_functor_data (functor_identity _) D' D}
+             {R' : disp_functor_data (functor_identity _) D' D}
+             {R : disp_functor_data (functor_identity _) D' D}
+             (b' : disp_nat_trans (nat_trans_id _) R'' R')
+             (b : disp_nat_trans (nat_trans_id _) R' R)
+    : disp_nat_trans (nat_trans_id _) R'' R.
+  Proof.
+    apply (transportf (λ (a : nat_trans _ _), disp_nat_trans a R'' R)
+                      nat_trans_id_id
+                      (disp_nat_trans_comp b' b)
+          ).
+  Defined.
+
+End Auxiliary.
+
 Section DiscCompCat_Cat_Simple.
 
   Context (C : category).
@@ -29,20 +92,30 @@ Section DiscCompCat_Cat_Simple.
 
   Local Definition TY := preshv_from_disc_comp_cat_structure.
 
+  Search disp_nat_trans.
+  Search nat_trans.
+  
+  Definition DiscCompCat_mor
+             (X Y : discrete_comprehension_cat_structure C)
+    : UU
+    := ∑ (F_TY : disp_functor (functor_identity _) (pr1 X) (pr1 Y)),
+       disp_nat_trans (nat_trans_id (functor_identity C)) (pr1 (pr2 (pr2 X)))
+                      (disp_functor_composite F_TY (pr1 (pr2 (pr2 Y)))).
+
   Definition DiscCompCat_ob_mor
-    : precategory_ob_mor.
-  Proof.
-    use tpair.
-    - apply (discrete_comprehension_cat_structure C).
-    - intros X Y. exact (TY X --> TY Y).
-  Defined.
+    : precategory_ob_mor
+    := (discrete_comprehension_cat_structure C ,, DiscCompCat_mor).
 
   Definition DiscCompCat_id_comp
     : precategory_id_comp DiscCompCat_ob_mor.
   Proof.
     use make_dirprod.
-    - intros X. apply identity.
-    - intros X Y Z. apply compose.
+    - intros X.
+      exists (disp_functor_identity _).
+      apply disp_nat_trans_id.
+    - intros X Y Z F G.
+      exists (disp_functor_composite (pr1 F) (pr1 G)).
+      apply (disp_nat_trans_comp_over_id (pr2 F) (disp_nat_trans_right (pr1 F) (pr2 G))).
   Defined.
 
   Definition DiscCompCat_precat_data
@@ -53,7 +126,17 @@ Section DiscCompCat_Cat_Simple.
     : is_precategory DiscCompCat_precat_data.
   Proof.
     repeat use make_dirprod.
-    - intros; apply id_left.
+    - intros. use total2_paths_f.
+      + use total2_paths_f.
+        * apply idpath.
+        * apply isaprop_disp_functor_axioms.
+      + use total2_paths_f.
+        * repeat (apply funextsec; intros ?).
+          etrans. apply (pr1_transportf
+                           _ _
+                           (λ x xx, _)
+                         ).
+          cbn. left.
     - intros; apply id_right.
     - intros; apply assoc.
     - intros; apply assoc'.

--- a/TypeTheory/ALV2/DiscCompCat_Cat.v
+++ b/TypeTheory/ALV2/DiscCompCat_Cat.v
@@ -69,10 +69,22 @@ Section Auxiliary.
              (b : disp_nat_trans (nat_trans_id _) R' R)
     : disp_nat_trans (nat_trans_id _) R'' R.
   Proof.
-    apply (transportf (λ (a : nat_trans _ _), disp_nat_trans a R'' R)
-                      nat_trans_id_id
-                      (disp_nat_trans_comp b' b)
-          ).
+    set (α := disp_nat_trans_comp b' b).
+    use tpair.
+    - intros Γ A.
+      apply (transportf _ (id_left (identity Γ))
+                        (α Γ A)).
+    - intros Γ Γ' f A A' ff.
+      set (H := disp_nat_trans_ax α ff).
+      cbn in *.
+      etrans. apply mor_disp_transportf_prewhisker.
+      etrans. apply maponpaths, H.
+      etrans. apply transport_f_b.
+      apply pathsinv0.
+      etrans. apply maponpaths, mor_disp_transportf_postwhisker.
+      etrans. apply transport_b_f.
+      apply maponpaths_2.
+      apply homset_property.
   Defined.
 
 End Auxiliary.

--- a/TypeTheory/ALV2/DiscCompCat_Cat.v
+++ b/TypeTheory/ALV2/DiscCompCat_Cat.v
@@ -152,7 +152,7 @@ Section DiscCompCat_mor.
     : F_ob_compare e ;; ϕ G Γ A' = ϕ G Γ A ;; F_ob_compare (maponpaths (F_TY G _) e).
   Proof.
     destruct e; simpl. etrans. apply id_left. apply pathsinv0, id_right.
-  Defined.
+  Qed.
 
   Definition F_TY_on_morphisms
              {X Y : discrete_comprehension_cat_structure1 C}
@@ -167,7 +167,7 @@ Section DiscCompCat_mor.
     etrans. apply pathsinv0, (F_TY_ax Γ' Γ f A').
     apply maponpaths.
     apply (mor_with_unique_lift_mor_weq _ _ (D_ob_isaset X) _ ff).
-  Defined.
+  Qed.
 
   Definition DiscCompCat_mor_axiom_ϕ_qq
              {X Y : discrete_comprehension_cat_structure1 C}

--- a/TypeTheory/ALV2/DiscCompCat_Cat.v
+++ b/TypeTheory/ALV2/DiscCompCat_Cat.v
@@ -53,7 +53,7 @@ Section DiscCompCat_mor.
 
   Context (C : category).
 
-  Definition DiscCompCatDef_mor_data
+  Definition DiscCompCat_mor_data
              (X Y : discrete_comprehension_cat_structure1 C)
     : UU
     := ∑ (F_TY : ∏ {Γ : C}, D_ob X Γ → D_ob Y Γ),
@@ -62,24 +62,24 @@ Section DiscCompCat_mor.
 
   Local Definition F_TY 
              {X Y : discrete_comprehension_cat_structure1 C}
-             (mor : DiscCompCatDef_mor_data X Y)
+             (mor : DiscCompCat_mor_data X Y)
     := pr1 mor.
 
   Local Definition ϕ
              {X Y : discrete_comprehension_cat_structure1 C}
-             (mor : DiscCompCatDef_mor_data X Y)
+             (mor : DiscCompCat_mor_data X Y)
     := pr2 mor.
 
-  Definition DiscCompCatDef_mor_axiom_F_TY
+  Definition DiscCompCat_mor_axiom_F_TY
              {X Y : discrete_comprehension_cat_structure1 C}
-             (mor : DiscCompCatDef_mor_data X Y)
+             (mor : DiscCompCat_mor_data X Y)
     : UU
     := ∏ (Γ Γ' : C) (f : C ⟦ Γ', Γ ⟧) (A : D_ob X Γ),
        F_TY mor _ (D_lift_ob X _ _ f A) = D_lift_ob Y _ _ f (F_TY mor _ A).
                     
-  Definition DiscCompCatDef_mor_axiom_ϕ_dpr
+  Definition DiscCompCat_mor_axiom_ϕ_dpr
              {X Y : discrete_comprehension_cat_structure1 C}
-             (mor : DiscCompCatDef_mor_data X Y)
+             (mor : DiscCompCat_mor_data X Y)
     : UU
     := ∏ (Γ : C) (A : D_ob X Γ),
        ϕ mor Γ A ;; pr2 (F_ob Y Γ (F_TY mor _ A)) = pr2 (F_ob X Γ A).
@@ -133,8 +133,8 @@ Section DiscCompCat_mor.
 
   Definition Δ
              {X Y : discrete_comprehension_cat_structure1 C}
-             (mor : DiscCompCatDef_mor_data X Y)
-             (F_TY_ax : DiscCompCatDef_mor_axiom_F_TY mor)
+             (mor : DiscCompCat_mor_data X Y)
+             (F_TY_ax : DiscCompCat_mor_axiom_F_TY mor)
     : ∏ (Γ Γ' : C) (f : C ⟦ Γ', Γ ⟧) (A : D_ob X Γ),
       C ⟦ pr1 (F_ob Y Γ' (F_TY mor Γ' (D_lift_ob X Γ Γ' f A))),
           pr1 (F_ob Y Γ' (D_lift_ob Y Γ Γ' f (F_TY mor Γ A))) ⟧.
@@ -146,7 +146,7 @@ Section DiscCompCat_mor.
     
   Lemma Δ_ϕ
         {X Y : discrete_comprehension_cat_structure1 C}
-        (G : DiscCompCatDef_mor_data X Y)
+        (G : DiscCompCat_mor_data X Y)
         {Γ : C} {A A' : D_ob X Γ}
         (e : A = A')
     : F_ob_compare e ;; ϕ G Γ A' = ϕ G Γ A ;; F_ob_compare (maponpaths (F_TY G _) e).
@@ -156,8 +156,8 @@ Section DiscCompCat_mor.
 
   Definition F_TY_on_morphisms
              {X Y : discrete_comprehension_cat_structure1 C}
-             (mor : DiscCompCatDef_mor_data X Y)
-             (F_TY_ax : DiscCompCatDef_mor_axiom_F_TY mor)
+             (mor : DiscCompCat_mor_data X Y)
+             (F_TY_ax : DiscCompCat_mor_axiom_F_TY mor)
              {Γ Γ' : C} {f : C ⟦ Γ, Γ' ⟧}
              {A : D_ob X Γ} {A' : D_ob X Γ'}
     : D_mor X Γ Γ' A A' f → D_mor Y Γ Γ' (F_TY mor _ A) (F_TY mor _ A') f.
@@ -169,10 +169,10 @@ Section DiscCompCat_mor.
     apply (mor_with_unique_lift_mor_weq _ _ (D_ob_isaset X) _ ff).
   Defined.
 
-  Definition DiscCompCatDef_mor_axiom_ϕ_qq
+  Definition DiscCompCat_mor_axiom_ϕ_qq
              {X Y : discrete_comprehension_cat_structure1 C}
-             (mor : DiscCompCatDef_mor_data X Y)
-             (F_TY_ax : DiscCompCatDef_mor_axiom_F_TY mor)
+             (mor : DiscCompCat_mor_data X Y)
+             (F_TY_ax : DiscCompCat_mor_axiom_F_TY mor)
     : UU
     := ∏ (Γ Γ' : C) (f : C ⟦ Γ', Γ ⟧)
          (A : D_ob X Γ) (A' : D_ob X Γ') (ff : D_mor X _ _ A' A f),
@@ -180,76 +180,76 @@ Section DiscCompCat_mor.
        ϕ mor Γ' A' ;; pr1 (F_mor Y Γ' Γ (F_TY mor _ A') (F_TY mor _ A) f
                                  (F_TY_on_morphisms mor F_TY_ax ff)).
 
-  Definition DiscCompCatDef_mor_axioms
+  Definition DiscCompCat_mor_axioms
              {X Y : discrete_comprehension_cat_structure1 C}
-             (mor : DiscCompCatDef_mor_data X Y)
+             (mor : DiscCompCat_mor_data X Y)
     : UU
-    := ∑ (F_TY_ax : DiscCompCatDef_mor_axiom_F_TY mor)
-        (ϕ_dpr_ax : DiscCompCatDef_mor_axiom_ϕ_dpr mor),
-      (* ϕ_qq_ax : *) DiscCompCatDef_mor_axiom_ϕ_qq mor F_TY_ax.
+    := ∑ (F_TY_ax : DiscCompCat_mor_axiom_F_TY mor)
+        (ϕ_dpr_ax : DiscCompCat_mor_axiom_ϕ_dpr mor),
+      (* ϕ_qq_ax : *) DiscCompCat_mor_axiom_ϕ_qq mor F_TY_ax.
 
-  Definition isaprop_DiscCompCatDef_mor_axiom_F_TY
+  Definition isaprop_DiscCompCat_mor_axiom_F_TY
              {X Y : discrete_comprehension_cat_structure1 C}
-             (mor : DiscCompCatDef_mor_data X Y)
-    : isaprop (DiscCompCatDef_mor_axiom_F_TY mor).
+             (mor : DiscCompCat_mor_data X Y)
+    : isaprop (DiscCompCat_mor_axiom_F_TY mor).
   Proof.
     repeat (apply impred_isaprop; intros ?).
     apply D_ob_isaset.
   Qed.
 
-  Definition isaprop_DiscCompCatDef_mor_axiom_ϕ_dpr
+  Definition isaprop_DiscCompCat_mor_axiom_ϕ_dpr
              {X Y : discrete_comprehension_cat_structure1 C}
-             (mor : DiscCompCatDef_mor_data X Y)
-    : isaprop (DiscCompCatDef_mor_axiom_ϕ_dpr mor).
+             (mor : DiscCompCat_mor_data X Y)
+    : isaprop (DiscCompCat_mor_axiom_ϕ_dpr mor).
   Proof.
     repeat (apply impred_isaprop; intros ?).
     apply homset_property.
   Qed.
        
-  Definition isaprop_DiscCompCatDef_mor_axiom_ϕ_qq
+  Definition isaprop_DiscCompCat_mor_axiom_ϕ_qq
              {X Y : discrete_comprehension_cat_structure1 C}
-             (mor : DiscCompCatDef_mor_data X Y)
-             (F_TY_ax : DiscCompCatDef_mor_axiom_F_TY mor)
-    : isaprop (DiscCompCatDef_mor_axiom_ϕ_qq mor F_TY_ax).
+             (mor : DiscCompCat_mor_data X Y)
+             (F_TY_ax : DiscCompCat_mor_axiom_F_TY mor)
+    : isaprop (DiscCompCat_mor_axiom_ϕ_qq mor F_TY_ax).
   Proof.
     repeat (apply impred_isaprop; intros ?).
     apply homset_property.
   Qed.
 
-  Definition isaprop_DiscCompCatDef_mor_axioms
+  Definition isaprop_DiscCompCat_mor_axioms
              {X Y : discrete_comprehension_cat_structure1 C}
-             (mor : DiscCompCatDef_mor_data X Y)
-    : isaprop (DiscCompCatDef_mor_axioms mor).
+             (mor : DiscCompCat_mor_data X Y)
+    : isaprop (DiscCompCat_mor_axioms mor).
   Proof.
     apply Propositions.isaproptotal2.
     - intros ?. apply isapropdirprod.
-      + apply isaprop_DiscCompCatDef_mor_axiom_ϕ_dpr.
-      + apply isaprop_DiscCompCatDef_mor_axiom_ϕ_qq.
-    - intros. apply isaprop_DiscCompCatDef_mor_axiom_F_TY. 
+      + apply isaprop_DiscCompCat_mor_axiom_ϕ_dpr.
+      + apply isaprop_DiscCompCat_mor_axiom_ϕ_qq.
+    - intros. apply isaprop_DiscCompCat_mor_axiom_F_TY. 
   Qed.
 
-  Definition DiscCompCatDef_mor
+  Definition DiscCompCat_mor
              (X Y : discrete_comprehension_cat_structure1 C)
     : UU
-    := ∑ (mor : DiscCompCatDef_mor_data X Y), DiscCompCatDef_mor_axioms mor.
+    := ∑ (mor : DiscCompCat_mor_data X Y), DiscCompCat_mor_axioms mor.
 
-  Definition DiscCompCatDef_mor_to_mor_data
+  Definition DiscCompCat_mor_to_mor_data
              {X Y : discrete_comprehension_cat_structure1 C}
-             (mor : DiscCompCatDef_mor X Y)
-    : DiscCompCatDef_mor_data X Y
+             (mor : DiscCompCat_mor X Y)
+    : DiscCompCat_mor_data X Y
     := pr1 mor.
 
-  Coercion DiscCompCatDef_mor_to_mor_data : DiscCompCatDef_mor >-> DiscCompCatDef_mor_data.
+  Coercion DiscCompCat_mor_to_mor_data : DiscCompCat_mor >-> DiscCompCat_mor_data.
 
-  Definition DiscCompCatDef_mor_eq
+  Definition DiscCompCat_mor_eq
              {X Y : discrete_comprehension_cat_structure1 C}
-             (F G : DiscCompCatDef_mor X Y)
+             (F G : DiscCompCat_mor X Y)
              (F_TY_eq : ∏ Γ (A : D_ob X Γ), F_TY F _ A = F_TY G _ A)
              (ϕ_eq : ∏ Γ (A : D_ob X Γ),
                      ϕ F _ A ;; F_ob_compare (F_TY_eq Γ A) = ϕ G _ A)
     : F = G.
   Proof.
-    use total2_paths_f. 2: apply isaprop_DiscCompCatDef_mor_axioms.
+    use total2_paths_f. 2: apply isaprop_DiscCompCat_mor_axioms.
     use total2_paths_f.
     - repeat (apply funextsec; intros ?). apply F_TY_eq.
     - etrans. use transportf_forall.
@@ -276,23 +276,23 @@ Section DiscCompCat_mor.
       apply D_ob_isaset.
   Defined.
 
-  Definition DiscCompCatDef_precat_ob_mor
+  Definition DiscCompCat_precat_ob_mor
     : precategory_ob_mor
-    := (_ ,, DiscCompCatDef_mor).
+    := (_ ,, DiscCompCat_mor).
                                                               
              
-  Definition DiscCompCatDef_mor_id_data
+  Definition DiscCompCat_mor_id_data
              (X : discrete_comprehension_cat_structure1 C)
-    : DiscCompCatDef_mor_data X X.
+    : DiscCompCat_mor_data X X.
   Proof.
     use tpair.
     + intros Γ. apply idfun.
     + intros Γ A. apply identity.
   Defined.
 
-  Definition DiscCompCatDef_mor_id_axioms
+  Definition DiscCompCat_mor_id_axioms
              (X : discrete_comprehension_cat_structure1 C)
-    : DiscCompCatDef_mor_axioms (DiscCompCatDef_mor_id_data X).
+    : DiscCompCat_mor_axioms (DiscCompCat_mor_id_data X).
   Proof.
     use tpair. 2: use make_dirprod.
     + intros Γ Γ' f A. apply idpath.
@@ -307,27 +307,27 @@ Section DiscCompCat_mor.
       apply D_ob_isaset.
   Qed.
 
-  Definition DiscCompCatDef_mor_id
+  Definition DiscCompCat_mor_id
              (X : discrete_comprehension_cat_structure1 C)
-    : DiscCompCatDef_mor X X
-    := (_ ,, DiscCompCatDef_mor_id_axioms X).
+    : DiscCompCat_mor X X
+    := (_ ,, DiscCompCat_mor_id_axioms X).
   
-  Definition DiscCompCatDef_mor_comp_data
+  Definition DiscCompCat_mor_comp_data
              (X Y Z : discrete_comprehension_cat_structure1 C)
-             (F : DiscCompCatDef_mor_data X Y)
-             (G : DiscCompCatDef_mor_data Y Z)
-    : DiscCompCatDef_mor_data X Z.
+             (F : DiscCompCat_mor_data X Y)
+             (G : DiscCompCat_mor_data Y Z)
+    : DiscCompCat_mor_data X Z.
   Proof.
     use tpair.
     + intros Γ A. apply (F_TY G _ (F_TY F _ A)).
     + intros Γ A. apply (ϕ F _ _ ;; ϕ G _ _).
   Defined.
 
-  Definition DiscCompCatDef_mor_comp_axioms
+  Definition DiscCompCat_mor_comp_axioms
              (X Y Z : discrete_comprehension_cat_structure1 C)
-             (F : DiscCompCatDef_mor X Y)
-             (G : DiscCompCatDef_mor Y Z)
-    : DiscCompCatDef_mor_axioms (DiscCompCatDef_mor_comp_data X Y Z F G).
+             (F : DiscCompCat_mor X Y)
+             (G : DiscCompCat_mor Y Z)
+    : DiscCompCat_mor_axioms (DiscCompCat_mor_comp_data X Y Z F G).
   Proof.
     use tpair. 2: use make_dirprod.
     + intros Γ Γ' f A. cbn.
@@ -355,83 +355,83 @@ Section DiscCompCat_mor.
       apply D_ob_isaset.
   Qed.
 
-  Definition DiscCompCatDef_mor_comp
+  Definition DiscCompCat_mor_comp
              (X Y Z : discrete_comprehension_cat_structure1 C)
-             (F : DiscCompCatDef_mor X Y)
-             (G : DiscCompCatDef_mor Y Z)
-    : DiscCompCatDef_mor X Z
-    := (_ ,, DiscCompCatDef_mor_comp_axioms X Y Z F G).
+             (F : DiscCompCat_mor X Y)
+             (G : DiscCompCat_mor Y Z)
+    : DiscCompCat_mor X Z
+    := (_ ,, DiscCompCat_mor_comp_axioms X Y Z F G).
 
-  Definition DiscCompCatDef_precat_id_comp
-    : precategory_id_comp (DiscCompCatDef_precat_ob_mor)
-    := (DiscCompCatDef_mor_id , DiscCompCatDef_mor_comp).
+  Definition DiscCompCat_precat_id_comp
+    : precategory_id_comp (DiscCompCat_precat_ob_mor)
+    := (DiscCompCat_mor_id , DiscCompCat_mor_comp).
 
-  Definition DiscCompCatDef_precat_data
+  Definition DiscCompCat_precat_data
     : precategory_data
-    := (_ ,, DiscCompCatDef_precat_id_comp).
+    := (_ ,, DiscCompCat_precat_id_comp).
 
-  Definition DiscCompCatDef_precat_id_left
-             (X Y : DiscCompCatDef_precat_data)
-             (F : DiscCompCatDef_precat_data ⟦ X, Y ⟧)
+  Definition DiscCompCat_precat_id_left
+             (X Y : DiscCompCat_precat_data)
+             (F : DiscCompCat_precat_data ⟦ X, Y ⟧)
     : identity X ;; F = F.
   Proof.
-    use DiscCompCatDef_mor_eq.
+    use DiscCompCat_mor_eq.
     - intros Γ A. apply idpath.
     - intros Γ A. etrans. apply id_right. apply id_left.
   Qed.
 
-  Definition DiscCompCatDef_precat_id_right
-             (X Y : DiscCompCatDef_precat_data)
-             (F : DiscCompCatDef_precat_data ⟦ X, Y ⟧)
+  Definition DiscCompCat_precat_id_right
+             (X Y : DiscCompCat_precat_data)
+             (F : DiscCompCat_precat_data ⟦ X, Y ⟧)
     : F ;; identity Y = F.
   Proof.
-    use DiscCompCatDef_mor_eq.
+    use DiscCompCat_mor_eq.
     - intros Γ A. apply idpath.
     - intros Γ A. etrans. apply id_right. apply id_right.
   Qed.
 
-  Definition DiscCompCatDef_precat_assoc
-             (X Y Z W : DiscCompCatDef_precat_data)
-             (F : DiscCompCatDef_precat_data ⟦ X, Y ⟧)
-             (G : DiscCompCatDef_precat_data ⟦ Y, Z ⟧)
-             (H : DiscCompCatDef_precat_data ⟦ Z, W ⟧)
+  Definition DiscCompCat_precat_assoc
+             (X Y Z W : DiscCompCat_precat_data)
+             (F : DiscCompCat_precat_data ⟦ X, Y ⟧)
+             (G : DiscCompCat_precat_data ⟦ Y, Z ⟧)
+             (H : DiscCompCat_precat_data ⟦ Z, W ⟧)
     : F ;; (G ;; H) = (F ;; G) ;; H.
   Proof.
-    use DiscCompCatDef_mor_eq.
+    use DiscCompCat_mor_eq.
     - intros Γ A. apply idpath.
     - intros Γ A. etrans. apply id_right. apply assoc.
   Qed.
 
-  Definition DiscCompCatDef_precat_assoc'
-             (X Y Z W : DiscCompCatDef_precat_data)
-             (F : DiscCompCatDef_precat_data ⟦ X, Y ⟧)
-             (G : DiscCompCatDef_precat_data ⟦ Y, Z ⟧)
-             (H : DiscCompCatDef_precat_data ⟦ Z, W ⟧)
+  Definition DiscCompCat_precat_assoc'
+             (X Y Z W : DiscCompCat_precat_data)
+             (F : DiscCompCat_precat_data ⟦ X, Y ⟧)
+             (G : DiscCompCat_precat_data ⟦ Y, Z ⟧)
+             (H : DiscCompCat_precat_data ⟦ Z, W ⟧)
     : (F ;; G) ;; H = F ;; (G ;; H).
   Proof.
-    use DiscCompCatDef_mor_eq.
+    use DiscCompCat_mor_eq.
     - intros Γ A. apply idpath.
     - intros Γ A. etrans. apply id_right. apply assoc'.
   Qed.
 
-  Definition DiscCompCatDef_precat_axioms
-    : is_precategory DiscCompCatDef_precat_data.
+  Definition DiscCompCat_precat_axioms
+    : is_precategory DiscCompCat_precat_data.
   Proof.
     use make_is_precategory.
-    - apply DiscCompCatDef_precat_id_left.
-    - apply DiscCompCatDef_precat_id_right.
-    - apply DiscCompCatDef_precat_assoc.
-    - apply DiscCompCatDef_precat_assoc'.
+    - apply DiscCompCat_precat_id_left.
+    - apply DiscCompCat_precat_id_right.
+    - apply DiscCompCat_precat_assoc.
+    - apply DiscCompCat_precat_assoc'.
   Qed.
 
-  Definition DiscCompCatDef_precat : precategory
-    := (_ ,, DiscCompCatDef_precat_axioms).
+  Definition DiscCompCat_precat : precategory
+    := (_ ,, DiscCompCat_precat_axioms).
 
-  Definition DiscCompCatDef_precat_has_homsets
-    : has_homsets DiscCompCatDef_precat.
+  Definition DiscCompCat_precat_has_homsets
+    : has_homsets DiscCompCat_precat.
   Proof.
     intros X Y.
-    apply isaset_total2. 2: intros ?; apply isasetaprop, isaprop_DiscCompCatDef_mor_axioms.
+    apply isaset_total2. 2: intros ?; apply isasetaprop, isaprop_DiscCompCat_mor_axioms.
     - apply isaset_total2.
       + repeat (apply impred_isaset; intros ?).
         apply D_ob_isaset.
@@ -440,7 +440,7 @@ Section DiscCompCat_mor.
         apply homset_property.
   Defined.
 
-  Definition DiscCompCatDef_cat : category
-    := (DiscCompCatDef_precat ,, DiscCompCatDef_precat_has_homsets).
+  Definition DiscCompCat_cat : category
+    := (DiscCompCat_precat ,, DiscCompCat_precat_has_homsets).
 
 End DiscCompCat_mor.

--- a/TypeTheory/ALV2/DiscCompCat_Cat.v
+++ b/TypeTheory/ALV2/DiscCompCat_Cat.v
@@ -14,169 +14,433 @@ Require Import UniMath.CategoryTheory.DisplayedCats.Auxiliary.
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 Require Import UniMath.CategoryTheory.DisplayedCats.Fibrations.
 
-Section Auxiliary.
+Local Definition D_ob {C : category} :=
+  discrete_comprehension_cat_structure1_D_ob (C := C).
 
-  Definition disp_functor_composite_assoc 
-             {C : category}
-             (X Y Z W : disp_cat C)
-             (F : disp_functor (functor_identity C) X Y)
-             (G : disp_functor (functor_identity C) Y Z)
-             (H : disp_functor (functor_identity C) Z W)
-    : disp_nat_trans (nat_trans_id (functor_identity _))
-        (disp_functor_composite (disp_functor_composite F G) H)
-        (disp_functor_composite F (disp_functor_composite G H)).
-  Proof.
-    apply disp_nat_trans_id.
-  Defined.
+Local Definition F_ob {C : category} :=
+  discrete_comprehension_cat_structure1_F_ob (C := C).
 
-  Definition disp_nat_trans_right
-             {C : category}
-             {X Y Z : disp_cat C}
-             (F : disp_functor (functor_identity C) X Y)
-             {G : disp_functor (functor_identity C) Y Z}
-             {H : disp_functor (functor_identity C) Y Z}
-             (α : disp_nat_trans (nat_trans_id _) G H)
-    : disp_nat_trans (nat_trans_id _)
-        (disp_functor_composite F G)
-        (disp_functor_composite F H).
-  Proof.
-    use tpair.
-    - intros Γ A. apply α.
-    - intros Γ Γ' f A A' ff. cbn.
-      apply (pr2 α Γ Γ' f (F _ A) (F _ A') (disp_functor_on_morphisms F ff)).
-  Defined.
+Local Definition D_lift_ob {C : category} :=
+  discrete_comprehension_cat_structure1_D_lift_ob (C := C).
 
-  Lemma nat_trans_id_id
-        {C : category}
-    : (nat_trans_comp _ _ _
-                      (nat_trans_id (functor_identity C))
-                      (nat_trans_id (functor_identity C)))
-      = nat_trans_id (functor_identity C).
-  Proof.
-    use total2_paths_f.
-    - repeat (apply funextsec; intros ?). cbn.
-      apply id_left.
-    - repeat (apply funextsec; intros ?). apply homset_property.
-  Defined.
+Local Definition D_ob_isaset {C : category} :=
+  discrete_comprehension_cat_structure1_D_ob_isaset (C := C).
 
-  Definition disp_nat_trans_comp_over_id
-             {C : category}
-             {D D' : disp_cat C}
-             {R'' : disp_functor_data (functor_identity _) D' D}
-             {R' : disp_functor_data (functor_identity _) D' D}
-             {R : disp_functor_data (functor_identity _) D' D}
-             (b' : disp_nat_trans (nat_trans_id _) R'' R')
-             (b : disp_nat_trans (nat_trans_id _) R' R)
-    : disp_nat_trans (nat_trans_id _) R'' R.
-  Proof.
-    set (α := disp_nat_trans_comp b' b).
-    use tpair.
-    - intros Γ A.
-      apply (transportf _ (id_left (identity Γ))
-                        (α Γ A)).
-    - intros Γ Γ' f A A' ff.
-      set (H := disp_nat_trans_ax α ff).
-      cbn in *.
-      etrans. apply mor_disp_transportf_prewhisker.
-      etrans. apply maponpaths, H.
-      etrans. apply transport_f_b.
-      apply pathsinv0.
-      etrans. apply maponpaths, mor_disp_transportf_postwhisker.
-      etrans. apply transport_b_f.
-      apply maponpaths_2.
-      apply homset_property.
-  Defined.
+Local Definition D_id {C : category} :=
+  discrete_comprehension_cat_structure1_D_id (C := C).
 
-End Auxiliary.
+Local Definition D_comp {C : category} :=
+  discrete_comprehension_cat_structure1_D_comp (C := C).
 
-Section DiscCompCat_Cat_Simple.
+Local Definition D_mor_with_unique_lift {C : category} :=
+  discrete_comprehension_cat_structure1_D_mor_with_unique_lift (C := C).
+
+Local Definition D_mor {C : category}
+      (DC : discrete_comprehension_cat_structure1 C)
+  := pr1 (D_mor_with_unique_lift DC).
+
+Local Definition D_lift_mor {C : category}
+      (DC : discrete_comprehension_cat_structure1 C)
+      {Γ Γ' : C}
+      (f : C ⟦ Γ', Γ ⟧) (A : pr1 DC Γ)
+  : D_mor DC Γ' Γ (D_lift_ob DC Γ Γ' f A) A f
+  := pr1 (pr2 (pr2 (D_mor_with_unique_lift DC)) Γ Γ' f A).
+
+Local Definition F_mor {C : category} :=
+  discrete_comprehension_cat_structure1_F_mor (C := C).
+
+Section DiscCompCat_mor.
 
   Context (C : category).
 
-  Definition preshv_from_disc_comp_cat_structure
-             (DCC : discrete_comprehension_cat_structure C)
-    : preShv C.
-  Proof.
-    apply preshv_from_disc_fib_ob.
-    exists (pr1 DCC).
-    exact (pr1 (pr2 DCC)).
-  Defined.
-
-  Local Definition TY := preshv_from_disc_comp_cat_structure.
-  
-  Definition DiscCompCat_mor
-             (X Y : discrete_comprehension_cat_structure C)
+  Definition DiscCompCatDef_mor_data
+             (X Y : discrete_comprehension_cat_structure1 C)
     : UU
-    := ∑ (F_TY : disp_functor (functor_identity _) (pr1 X) (pr1 Y)),
-       disp_nat_trans (nat_trans_id (functor_identity C)) (pr1 (pr2 (pr2 X)))
-                      (disp_functor_composite F_TY (pr1 (pr2 (pr2 Y)))).
+    := ∑ (F_TY : ∏ {Γ : C}, D_ob X Γ → D_ob Y Γ),
+       (* ϕ : *) ∏ (Γ : C) (A : D_ob X Γ),
+            pr1 (F_ob X Γ A) --> pr1 (F_ob Y Γ (F_TY A)).
 
-  Definition DiscCompCat_ob_mor
+  Local Definition F_TY 
+             {X Y : discrete_comprehension_cat_structure1 C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    := pr1 mor.
+
+  Local Definition ϕ
+             {X Y : discrete_comprehension_cat_structure1 C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    := pr2 mor.
+
+  Definition DiscCompCatDef_mor_axiom_F_TY
+             {X Y : discrete_comprehension_cat_structure1 C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    : UU
+    := ∏ (Γ Γ' : C) (f : C ⟦ Γ', Γ ⟧) (A : D_ob X Γ),
+       F_TY mor _ (D_lift_ob X _ _ f A) = D_lift_ob Y _ _ f (F_TY mor _ A).
+                    
+  Definition DiscCompCatDef_mor_axiom_ϕ_dpr
+             {X Y : discrete_comprehension_cat_structure1 C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    : UU
+    := ∏ (Γ : C) (A : D_ob X Γ),
+       ϕ mor Γ A ;; pr2 (F_ob Y Γ (F_TY mor _ A)) = pr2 (F_ob X Γ A).
+
+  Definition F_ob_compare
+             {X : discrete_comprehension_cat_structure1 C}
+             {Γ : C} {A A' : D_ob X Γ} (e : A = A')
+    : iso (pr1 (F_ob X Γ A)) (pr1 (F_ob X Γ A')).
+  Proof.
+    apply idtoiso, maponpaths, maponpaths, e.
+  Defined.
+
+  Lemma F_ob_compare_id {X : discrete_comprehension_cat_structure1 C}
+        {Γ : C} (A : D_ob X Γ)
+    : F_ob_compare (idpath A) = identity_iso (pr1 (F_ob X Γ A)).
+  Proof.
+    apply idpath.
+  Qed.
+
+  Lemma F_ob_compare_id_general {X : discrete_comprehension_cat_structure1 C}
+        {Γ : C} {A : D_ob X Γ}
+        (e : A = A)
+    : F_ob_compare e = identity_iso (pr1 (F_ob X Γ A)).
+  Proof.
+    apply @pathscomp0 with (F_ob_compare (idpath _)). 
+    apply maponpaths, D_ob_isaset.
+    apply idpath.
+  Qed.
+
+  Lemma F_ob_compare_comp {X : discrete_comprehension_cat_structure1 C}
+        {Γ : C} {A A' A'' : D_ob X Γ} (e : A = A') (e' : A' = A'')
+    : pr1 (F_ob_compare (e @ e')) = F_ob_compare e ;; F_ob_compare e'.
+  Proof.
+    apply pathsinv0.
+    etrans. apply idtoiso_concat_pr. 
+    unfold F_ob_compare. apply maponpaths, maponpaths.
+    apply pathsinv0.
+    etrans. 2: apply maponpathscomp0. 
+    apply maponpaths.
+    apply maponpathscomp0.
+  Qed.
+
+  Lemma F_ob_compare_comp_general {X : discrete_comprehension_cat_structure1 C}
+        {Γ : C} {A A' A'' : D_ob X Γ}
+        (e : A = A') (e' : A' = A'') (e'' : A = A'')
+    : pr1 (F_ob_compare e'') = F_ob_compare e ;; F_ob_compare e'.
+  Proof.
+    refine (_ @ F_ob_compare_comp _ _).
+    apply maponpaths, maponpaths, D_ob_isaset.
+  Qed.
+
+  Definition Δ
+             {X Y : discrete_comprehension_cat_structure1 C}
+             (mor : DiscCompCatDef_mor_data X Y)
+             (F_TY_ax : DiscCompCatDef_mor_axiom_F_TY mor)
+    : ∏ (Γ Γ' : C) (f : C ⟦ Γ', Γ ⟧) (A : D_ob X Γ),
+      C ⟦ pr1 (F_ob Y Γ' (F_TY mor Γ' (D_lift_ob X Γ Γ' f A))),
+          pr1 (F_ob Y Γ' (D_lift_ob Y Γ Γ' f (F_TY mor Γ A))) ⟧.
+  Proof.
+    intros Γ A Γ' f.
+    use F_ob_compare.
+    apply F_TY_ax.
+  Defined.
+    
+  Lemma Δ_ϕ
+        {X Y : discrete_comprehension_cat_structure1 C}
+        (G : DiscCompCatDef_mor_data X Y)
+        {Γ : C} {A A' : D_ob X Γ}
+        (e : A = A')
+    : F_ob_compare e ;; ϕ G Γ A' = ϕ G Γ A ;; F_ob_compare (maponpaths (F_TY G _) e).
+  Proof.
+    destruct e; simpl. etrans. apply id_left. apply pathsinv0, id_right.
+  Defined.
+
+  Definition F_TY_on_morphisms
+             {X Y : discrete_comprehension_cat_structure1 C}
+             (mor : DiscCompCatDef_mor_data X Y)
+             (F_TY_ax : DiscCompCatDef_mor_axiom_F_TY mor)
+             {Γ Γ' : C} {f : C ⟦ Γ, Γ' ⟧}
+             {A : D_ob X Γ} {A' : D_ob X Γ'}
+    : D_mor X Γ Γ' A A' f → D_mor Y Γ Γ' (F_TY mor _ A) (F_TY mor _ A') f.
+  Proof.
+    intros ff.
+    apply (invweq (mor_with_unique_lift_mor_weq _ _ (D_ob_isaset Y) _)).
+    etrans. apply pathsinv0, (F_TY_ax Γ' Γ f A').
+    apply maponpaths.
+    apply (mor_with_unique_lift_mor_weq _ _ (D_ob_isaset X) _ ff).
+  Defined.
+
+  Definition DiscCompCatDef_mor_axiom_ϕ_qq
+             {X Y : discrete_comprehension_cat_structure1 C}
+             (mor : DiscCompCatDef_mor_data X Y)
+             (F_TY_ax : DiscCompCatDef_mor_axiom_F_TY mor)
+    : UU
+    := ∏ (Γ Γ' : C) (f : C ⟦ Γ', Γ ⟧)
+         (A : D_ob X Γ) (A' : D_ob X Γ') (ff : D_mor X _ _ A' A f),
+       pr1 (F_mor X Γ' Γ A' A f ff) ;; ϕ mor Γ A =
+       ϕ mor Γ' A' ;; pr1 (F_mor Y Γ' Γ (F_TY mor _ A') (F_TY mor _ A) f
+                                 (F_TY_on_morphisms mor F_TY_ax ff)).
+
+  Definition DiscCompCatDef_mor_axioms
+             {X Y : discrete_comprehension_cat_structure1 C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    : UU
+    := ∑ (F_TY_ax : DiscCompCatDef_mor_axiom_F_TY mor)
+        (ϕ_dpr_ax : DiscCompCatDef_mor_axiom_ϕ_dpr mor),
+      (* ϕ_qq_ax : *) DiscCompCatDef_mor_axiom_ϕ_qq mor F_TY_ax.
+
+  Definition isaprop_DiscCompCatDef_mor_axiom_F_TY
+             {X Y : discrete_comprehension_cat_structure1 C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    : isaprop (DiscCompCatDef_mor_axiom_F_TY mor).
+  Proof.
+    repeat (apply impred_isaprop; intros ?).
+    apply D_ob_isaset.
+  Qed.
+
+  Definition isaprop_DiscCompCatDef_mor_axiom_ϕ_dpr
+             {X Y : discrete_comprehension_cat_structure1 C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    : isaprop (DiscCompCatDef_mor_axiom_ϕ_dpr mor).
+  Proof.
+    repeat (apply impred_isaprop; intros ?).
+    apply homset_property.
+  Qed.
+       
+  Definition isaprop_DiscCompCatDef_mor_axiom_ϕ_qq
+             {X Y : discrete_comprehension_cat_structure1 C}
+             (mor : DiscCompCatDef_mor_data X Y)
+             (F_TY_ax : DiscCompCatDef_mor_axiom_F_TY mor)
+    : isaprop (DiscCompCatDef_mor_axiom_ϕ_qq mor F_TY_ax).
+  Proof.
+    repeat (apply impred_isaprop; intros ?).
+    apply homset_property.
+  Qed.
+
+  Definition isaprop_DiscCompCatDef_mor_axioms
+             {X Y : discrete_comprehension_cat_structure1 C}
+             (mor : DiscCompCatDef_mor_data X Y)
+    : isaprop (DiscCompCatDef_mor_axioms mor).
+  Proof.
+    apply Propositions.isaproptotal2.
+    - intros ?. apply isapropdirprod.
+      + apply isaprop_DiscCompCatDef_mor_axiom_ϕ_dpr.
+      + apply isaprop_DiscCompCatDef_mor_axiom_ϕ_qq.
+    - intros. apply isaprop_DiscCompCatDef_mor_axiom_F_TY. 
+  Qed.
+
+  Definition DiscCompCatDef_mor
+             (X Y : discrete_comprehension_cat_structure1 C)
+    : UU
+    := ∑ (mor : DiscCompCatDef_mor_data X Y), DiscCompCatDef_mor_axioms mor.
+
+  Definition DiscCompCatDef_mor_to_mor_data
+             {X Y : discrete_comprehension_cat_structure1 C}
+             (mor : DiscCompCatDef_mor X Y)
+    : DiscCompCatDef_mor_data X Y
+    := pr1 mor.
+
+  Coercion DiscCompCatDef_mor_to_mor_data : DiscCompCatDef_mor >-> DiscCompCatDef_mor_data.
+
+  Definition DiscCompCatDef_mor_eq
+             {X Y : discrete_comprehension_cat_structure1 C}
+             (F G : DiscCompCatDef_mor X Y)
+             (F_TY_eq : ∏ Γ (A : D_ob X Γ), F_TY F _ A = F_TY G _ A)
+             (ϕ_eq : ∏ Γ (A : D_ob X Γ),
+                     ϕ F _ A ;; F_ob_compare (F_TY_eq Γ A) = ϕ G _ A)
+    : F = G.
+  Proof.
+    use total2_paths_f. 2: apply isaprop_DiscCompCatDef_mor_axioms.
+    use total2_paths_f.
+    - repeat (apply funextsec; intros ?). apply F_TY_eq.
+    - etrans. use transportf_forall.
+      apply funextsec; intros Γ.
+      etrans. use transportf_forall.
+      apply funextsec; intros A.
+      refine (_ @ ϕ_eq Γ A).
+      etrans. apply (functtransportf
+                       (λ x, x Γ A)
+                       (λ y, C ⟦ pr1 (F_ob X Γ A), pr1 (F_ob Y Γ y) ⟧)).
+      etrans. apply (functtransportf
+                       (λ x, F_ob Y Γ x)
+                       (λ y, C ⟦ pr1 (F_ob X Γ A), pr1 y ⟧)).
+      etrans. apply (functtransportf
+                       (λ x, pr1 x)
+                       (λ y, C ⟦ pr1 (F_ob X Γ A), y ⟧)).
+      etrans. apply pathsinv0, idtoiso_postcompose.
+      apply maponpaths.
+      unfold F_ob_compare.
+      apply maponpaths.
+      apply maponpaths.
+      apply maponpaths.
+      apply maponpaths.
+      apply D_ob_isaset.
+  Defined.
+
+  Definition DiscCompCatDef_precat_ob_mor
     : precategory_ob_mor
-    := (discrete_comprehension_cat_structure C ,, DiscCompCat_mor).
-
-  Definition DiscCompCat_id_comp
-    : precategory_id_comp DiscCompCat_ob_mor.
+    := (_ ,, DiscCompCatDef_mor).
+                                                              
+             
+  Definition DiscCompCatDef_mor_id_data
+             (X : discrete_comprehension_cat_structure1 C)
+    : DiscCompCatDef_mor_data X X.
   Proof.
-    use make_dirprod.
-    - intros X.
-      exists (disp_functor_identity _).
-      apply disp_nat_trans_id.
-    - intros X Y Z F G.
-      exists (disp_functor_composite (pr1 F) (pr1 G)).
-      apply (disp_nat_trans_comp_over_id (pr2 F) (disp_nat_trans_right (pr1 F) (pr2 G))).
+    use tpair.
+    + intros Γ. apply idfun.
+    + intros Γ A. apply identity.
   Defined.
 
-  Definition DiscCompCat_precat_data
-    : precategory_data
-    := (DiscCompCat_ob_mor ,, DiscCompCat_id_comp).
-
-  Definition DiscCompCat_precat_axioms
-    : is_precategory DiscCompCat_precat_data.
+  Definition DiscCompCatDef_mor_id_axioms
+             (X : discrete_comprehension_cat_structure1 C)
+    : DiscCompCatDef_mor_axioms (DiscCompCatDef_mor_id_data X).
   Proof.
-    repeat use make_dirprod.
-    - intros. use total2_paths_f.
-      + use total2_paths_f.
-        * apply idpath.
-        * apply isaprop_disp_functor_axioms.
-      + use total2_paths_f.
-        * unfold disp_nat_trans.
-          etrans. apply (
-                      pr1_transportf
-                        (disp_functor (functor_identity C) (pr1 a) (pr1 b))
-                        (λ x, disp_nat_trans_data
-                                (nat_trans_id (functor_identity C)) 
-                                (pr1 (pr2 (pr2 a))) (disp_functor_composite x (pr1 (pr2 (pr2 b)))))
-                        (λ x b0, disp_nat_trans_axioms b0)
-                    ).
-          repeat (apply funextsec; intros ?).
-          use total2_paths_f.
-          cbn. apply idpath.
-          use total2_paths_f.
-          -- etrans. simpl.
-             Check pr1_transportf. unfold disp_nat_trans.
-          Check pr1 (pr2 f) x x0.
-          cbn.
-          etrans. apply pr1_transportf.
-                           _ _
-                           (λ x xx, _)
-                         ).
-          cbn. left.
-    - intros; apply id_right.
-    - intros; apply assoc.
-    - intros; apply assoc'.
-  Defined.
+    use tpair. 2: use make_dirprod.
+    + intros Γ Γ' f A. apply idpath.
+    + intros Γ A. apply id_left.
+    + intros Γ Γ' f A A' ff.
+      etrans. apply id_right. cbn.
+      apply pathsinv0.
+      etrans. apply id_left.
+      apply maponpaths.
+      apply maponpaths.
+      apply isaprop_mor_with_unique_lift_mor.
+      apply D_ob_isaset.
+  Qed.
 
-  Definition DiscCompCat_precat : precategory
-    := (_ ,, DiscCompCat_precat_axioms).
-
-  Definition DiscCompCat_precat_homsets : has_homsets DiscCompCat_precat.
-  Proof.
-    unfold has_homsets.
-    intros. apply homset_property.
-  Defined.
-
-  Definition DiscCompCat_cat : category
-    := (DiscCompCat_precat ,, DiscCompCat_precat_homsets).
+  Definition DiscCompCatDef_mor_id
+             (X : discrete_comprehension_cat_structure1 C)
+    : DiscCompCatDef_mor X X
+    := (_ ,, DiscCompCatDef_mor_id_axioms X).
   
-End DiscCompCat_Cat_Simple.
+  Definition DiscCompCatDef_mor_comp_data
+             (X Y Z : discrete_comprehension_cat_structure1 C)
+             (F : DiscCompCatDef_mor_data X Y)
+             (G : DiscCompCatDef_mor_data Y Z)
+    : DiscCompCatDef_mor_data X Z.
+  Proof.
+    use tpair.
+    + intros Γ A. apply (F_TY G _ (F_TY F _ A)).
+    + intros Γ A. apply (ϕ F _ _ ;; ϕ G _ _).
+  Defined.
+
+  Definition DiscCompCatDef_mor_comp_axioms
+             (X Y Z : discrete_comprehension_cat_structure1 C)
+             (F : DiscCompCatDef_mor X Y)
+             (G : DiscCompCatDef_mor Y Z)
+    : DiscCompCatDef_mor_axioms (DiscCompCatDef_mor_comp_data X Y Z F G).
+  Proof.
+    use tpair. 2: use make_dirprod.
+    + intros Γ Γ' f A. cbn.
+      etrans. apply maponpaths.
+      apply (pr1 (pr2 F)).
+      apply (pr1 (pr2 G)).
+    + intros Γ A. cbn.
+      etrans. apply assoc'.
+      etrans. apply maponpaths.
+      apply (pr1 (pr2 (pr2 G))).
+      apply (pr1 (pr2 (pr2 F))).
+    + intros Γ Γ' f A A' ff. cbn.
+      etrans. apply assoc.
+      etrans. apply maponpaths_2.
+      apply (pr2 (pr2 (pr2 F))).
+      etrans. apply assoc'.
+      etrans. apply maponpaths.
+      apply (pr2 (pr2 (pr2 G))).
+      etrans. 2: apply assoc.
+      apply maponpaths.
+      apply maponpaths.
+      apply maponpaths.
+      apply maponpaths.
+      apply isaprop_mor_with_unique_lift_mor.
+      apply D_ob_isaset.
+  Qed.
+
+  Definition DiscCompCatDef_mor_comp
+             (X Y Z : discrete_comprehension_cat_structure1 C)
+             (F : DiscCompCatDef_mor X Y)
+             (G : DiscCompCatDef_mor Y Z)
+    : DiscCompCatDef_mor X Z
+    := (_ ,, DiscCompCatDef_mor_comp_axioms X Y Z F G).
+
+  Definition DiscCompCatDef_precat_id_comp
+    : precategory_id_comp (DiscCompCatDef_precat_ob_mor)
+    := (DiscCompCatDef_mor_id , DiscCompCatDef_mor_comp).
+
+  Definition DiscCompCatDef_precat_data
+    : precategory_data
+    := (_ ,, DiscCompCatDef_precat_id_comp).
+
+  Definition DiscCompCatDef_precat_id_left
+             (X Y : DiscCompCatDef_precat_data)
+             (F : DiscCompCatDef_precat_data ⟦ X, Y ⟧)
+    : identity X ;; F = F.
+  Proof.
+    use DiscCompCatDef_mor_eq.
+    - intros Γ A. apply idpath.
+    - intros Γ A. etrans. apply id_right. apply id_left.
+  Qed.
+
+  Definition DiscCompCatDef_precat_id_right
+             (X Y : DiscCompCatDef_precat_data)
+             (F : DiscCompCatDef_precat_data ⟦ X, Y ⟧)
+    : F ;; identity Y = F.
+  Proof.
+    use DiscCompCatDef_mor_eq.
+    - intros Γ A. apply idpath.
+    - intros Γ A. etrans. apply id_right. apply id_right.
+  Qed.
+
+  Definition DiscCompCatDef_precat_assoc
+             (X Y Z W : DiscCompCatDef_precat_data)
+             (F : DiscCompCatDef_precat_data ⟦ X, Y ⟧)
+             (G : DiscCompCatDef_precat_data ⟦ Y, Z ⟧)
+             (H : DiscCompCatDef_precat_data ⟦ Z, W ⟧)
+    : F ;; (G ;; H) = (F ;; G) ;; H.
+  Proof.
+    use DiscCompCatDef_mor_eq.
+    - intros Γ A. apply idpath.
+    - intros Γ A. etrans. apply id_right. apply assoc.
+  Qed.
+
+  Definition DiscCompCatDef_precat_assoc'
+             (X Y Z W : DiscCompCatDef_precat_data)
+             (F : DiscCompCatDef_precat_data ⟦ X, Y ⟧)
+             (G : DiscCompCatDef_precat_data ⟦ Y, Z ⟧)
+             (H : DiscCompCatDef_precat_data ⟦ Z, W ⟧)
+    : (F ;; G) ;; H = F ;; (G ;; H).
+  Proof.
+    use DiscCompCatDef_mor_eq.
+    - intros Γ A. apply idpath.
+    - intros Γ A. etrans. apply id_right. apply assoc'.
+  Qed.
+
+  Definition DiscCompCatDef_precat_axioms
+    : is_precategory DiscCompCatDef_precat_data.
+  Proof.
+    use make_is_precategory.
+    - apply DiscCompCatDef_precat_id_left.
+    - apply DiscCompCatDef_precat_id_right.
+    - apply DiscCompCatDef_precat_assoc.
+    - apply DiscCompCatDef_precat_assoc'.
+  Qed.
+
+  Definition DiscCompCatDef_precat : precategory
+    := (_ ,, DiscCompCatDef_precat_axioms).
+
+  Definition DiscCompCatDef_precat_has_homsets
+    : has_homsets DiscCompCatDef_precat.
+  Proof.
+    intros X Y.
+    apply isaset_total2. 2: intros ?; apply isasetaprop, isaprop_DiscCompCatDef_mor_axioms.
+    - apply isaset_total2.
+      + repeat (apply impred_isaset; intros ?).
+        apply D_ob_isaset.
+      + intros ?.
+        repeat (apply impred_isaset; intros ?).
+        apply homset_property.
+  Defined.
+
+  Definition DiscCompCatDef_cat : category
+    := (DiscCompCatDef_precat ,, DiscCompCatDef_precat_has_homsets).
+
+End DiscCompCat_mor.

--- a/TypeTheory/ALV2/DiscreteComprehensionCat.v
+++ b/TypeTheory/ALV2/DiscreteComprehensionCat.v
@@ -429,7 +429,7 @@ Section DiscreteComprehensionCats.
     eapply weqcomp. apply weqdirprodasstor.
     apply (weqdirprodf (idweq _)).
     apply weqdirprodasstor.
-  Qed.
+  Defined.
 
   Definition discrete_comprehension_cat_structure2' {C : category}
              (D_ob : C → UU)

--- a/TypeTheory/ALV2/DiscreteComprehensionCat.v
+++ b/TypeTheory/ALV2/DiscreteComprehensionCat.v
@@ -372,17 +372,6 @@ Section MorWithUniqueLift.
                @ ! pr2 iscontr_mor_with_unique_lift' default_mor_with_unique_lift).
   Defined.
 
-  Definition mor_with_unique_lift_reformulation
-             (mor : mor_with_unique_lift)
-             {Γ Γ' : C} {f : C ⟦ Γ', Γ ⟧} {A : D_ob Γ}
-             (P : ∏ (A' : D_ob Γ'), pr1 mor _ _ A' A f → UU)
-    : P (D_lift_ob Γ Γ' f A) (invweq (mor_with_unique_lift_mor_weq mor) (idpath _))
-        ≃ (∏ (A' : D_ob Γ') (ff : pr1 mor Γ' Γ A' A f), P A' ff).
-  Proof.
-    use weq_iso.
-    - intros p.
-      
-  Abort.
 
 End MorWithUniqueLift.
 

--- a/TypeTheory/ALV2/DiscreteComprehensionCat.v
+++ b/TypeTheory/ALV2/DiscreteComprehensionCat.v
@@ -317,6 +317,42 @@ Section MorWithUniqueLift.
           ∘ mor_with_unique_lift''_weq
           ∘ mor_with_unique_lift'_weq)%weq.
 
+  Definition mor_with_unique_lift_mor_weq
+             (mor : mor_with_unique_lift)
+             {Γ Γ' : C} {f : C ⟦ Γ, Γ' ⟧}
+             {A : D_ob Γ} {A' : D_ob Γ'}
+    : pr1 mor Γ Γ' A A' f ≃ default_mor Γ Γ' A A' f.
+  Proof.
+    set (uf := pr2 (pr2 mor) Γ' Γ f A').
+    use weq_iso.
+    - intros ff.
+      exact (! maponpaths pr1 (pr2 uf (A ,, ff))).
+    - intros p.
+      exact (transportf (λ B, pr1 mor Γ Γ' B A' f) p (pr1 uf)).
+    - intros ff.
+      apply (transportf_pathsinv0' (λ B, pr1 mor Γ Γ' B A' f)).
+      apply pathsinv0.
+      apply (transportf_transpose_right
+               (P := λ B, pr1 mor Γ Γ' B A' f)
+             ).
+      apply (fiber_paths_from_total2_paths
+               (B := λ x, pr1 mor Γ Γ' x A' f)
+               (A ,, ff)
+               (D_lift_ob Γ' Γ f A' ,, pr1 uf)).
+    - intros p. apply D_ob_isaset.
+  Defined.
+
+  Definition isaprop_mor_with_unique_lift_mor
+             (mor : mor_with_unique_lift)
+             {Γ Γ' : C} {f : C ⟦ Γ, Γ' ⟧}
+             {A : D_ob Γ} {A' : D_ob Γ'}
+    : isaprop (pr1 mor Γ Γ' A A' f).
+  Proof.
+    apply (isapropinclb (mor_with_unique_lift_mor_weq mor)).
+    - apply isinclweq, (pr2 (mor_with_unique_lift_mor_weq mor)).
+    - apply isaprop_default_mor.
+  Defined.
+
   Definition iscontr_mor_with_unique_lift'
     : iscontr mor_with_unique_lift.
   Proof.
@@ -443,6 +479,71 @@ Section DiscreteComprehensionCats.
          (D_mor : mor_with_unique_lift D_ob (@D_lift_ob)),
 
        discrete_comprehension_cat_structure2 D_ob Fob (@D_lift_ob) D_ob_isaset D_mor.
+
+  Section DiscCompCat1_Accessors.
+
+    Definition discrete_comprehension_cat_structure1_D_ob
+                {C : category}
+                (DC : discrete_comprehension_cat_structure1 C)
+        : C → UU
+        := pr1 DC.
+
+    Definition discrete_comprehension_cat_structure1_F_ob
+                {C : category}
+                (DC : discrete_comprehension_cat_structure1 C)
+        : ∏ {Γ : C},
+        discrete_comprehension_cat_structure1_D_ob DC Γ
+        → disp_codomain C Γ
+        := pr1 (pr2 DC).
+
+    Definition discrete_comprehension_cat_structure1_D_lift_ob
+                {C : category}
+                (DC : discrete_comprehension_cat_structure1 C)
+        : ∏ {Γ Γ' : C},
+        C ⟦ Γ', Γ ⟧
+        → discrete_comprehension_cat_structure1_D_ob DC Γ
+        → discrete_comprehension_cat_structure1_D_ob DC Γ'
+        := pr1 (pr2 (pr2 DC)).
+
+    Definition discrete_comprehension_cat_structure1_D_ob_isaset
+                {C : category}
+                (DC : discrete_comprehension_cat_structure1 C)
+        : ∏ (Γ : C), isaset (discrete_comprehension_cat_structure1_D_ob DC Γ)
+        := pr1 (pr2 (pr2 (pr2 DC))).
+
+    Definition discrete_comprehension_cat_structure1_D_mor_with_unique_lift
+                {C : category}
+                (DC : discrete_comprehension_cat_structure1 C)
+      : mor_with_unique_lift (pr1 DC) (pr1 (pr2 (pr2 DC)))
+      := pr1 (pr2 (pr2 (pr2 (pr2 DC)))).
+
+    Definition discrete_comprehension_cat_structure1_D_mor
+                {C : category}
+                (DC : discrete_comprehension_cat_structure1 C)
+      : ∏ (Γ Γ' : C), pr1 DC Γ → pr1 DC Γ' → C ⟦ Γ, Γ' ⟧ → UU
+      := pr1 (pr1 (pr2 (pr2 (pr2 (pr2 DC))))).
+
+    Definition discrete_comprehension_cat_structure1_D_id
+                {C : category}
+                (DC : discrete_comprehension_cat_structure1 C)
+      : ∏ (Γ : C) (A : discrete_comprehension_cat_structure1_D_ob DC Γ),
+        discrete_comprehension_cat_structure1_D_mor DC _ _ A A (identity Γ)
+        := pr1 (pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 DC))))))).
+
+    Definition discrete_comprehension_cat_structure1_D_comp
+                {C : category}
+                (DC : discrete_comprehension_cat_structure1 C)
+      : _
+        := pr2 (pr1 (pr2 (pr2 (pr2 (pr2 (pr2 (pr2 DC))))))).
+
+    Definition discrete_comprehension_cat_structure1_F_mor
+                {C : category}
+                (DC : discrete_comprehension_cat_structure1 C)
+      : _
+        := pr1 (pr2 (pr2 (pr2 (pr2 (pr2 DC))))).
+
+
+  End DiscCompCat1_Accessors.
 
   Definition discrete_comprehension_cat_structure1_weq {C : category}
     : discrete_comprehension_cat_structure C ≃ discrete_comprehension_cat_structure1 C.

--- a/TypeTheory/ALV2/DiscreteComprehensionCat.v
+++ b/TypeTheory/ALV2/DiscreteComprehensionCat.v
@@ -504,6 +504,58 @@ Section DiscreteComprehensionCats.
          D_ob Fob (@D_lift_ob) D_ob_isaset
          (default_mor_with_unique_lift D_ob (@D_lift_ob) D_ob_isaset).
 
+  Section DiscCompCat_DefaultMor_Accessors.
+
+    Definition discrete_comprehension_cat_structure_with_default_mor_D_ob
+                {C : category}
+                (DC : discrete_comprehension_cat_structure_with_default_mor C)
+        : C → UU
+        := pr1 DC.
+
+    Definition discrete_comprehension_cat_structure_with_default_mor_F_ob
+                {C : category}
+                (DC : discrete_comprehension_cat_structure_with_default_mor C)
+        : ∏ {Γ : C},
+        discrete_comprehension_cat_structure_with_default_mor_D_ob DC Γ
+        → disp_codomain C Γ
+        := pr1 (pr2 DC).
+
+    Definition discrete_comprehension_cat_structure_with_default_mor_D_lift_ob
+                {C : category}
+                (DC : discrete_comprehension_cat_structure_with_default_mor C)
+        : ∏ {Γ Γ' : C},
+        C ⟦ Γ', Γ ⟧
+        → discrete_comprehension_cat_structure_with_default_mor_D_ob DC Γ
+        → discrete_comprehension_cat_structure_with_default_mor_D_ob DC Γ'
+        := pr1 (pr2 (pr2 DC)).
+
+    Definition discrete_comprehension_cat_structure_with_default_mor_D_ob_isaset
+                {C : category}
+                (DC : discrete_comprehension_cat_structure_with_default_mor C)
+        : ∏ (Γ : C), isaset (discrete_comprehension_cat_structure_with_default_mor_D_ob DC Γ)
+        := pr1 (pr2 (pr2 (pr2 DC))).
+
+    Definition discrete_comprehension_cat_structure_with_default_mor_D_id
+                {C : category}
+                (DC : discrete_comprehension_cat_structure_with_default_mor C)
+      : ∏ (Γ : C) (A : discrete_comprehension_cat_structure_with_default_mor_D_ob DC Γ),
+        discrete_comprehension_cat_structure_with_default_mor_D_lift_ob DC (identity Γ) A = A
+        := pr1 (pr1 (pr2 (pr2 (pr2 (pr2 (pr2 DC)))))).
+
+    Definition discrete_comprehension_cat_structure_with_default_mor_D_comp
+                {C : category}
+                (DC : discrete_comprehension_cat_structure_with_default_mor C)
+      : _
+        := pr2 (pr1 (pr2 (pr2 (pr2 (pr2 (pr2 DC)))))).
+
+    Definition discrete_comprehension_cat_structure_with_default_mor_F_mor
+                {C : category}
+                (DC : discrete_comprehension_cat_structure_with_default_mor C)
+      : _
+        := pr1 (pr2 (pr2 (pr2 (pr2 DC)))).
+
+  End DiscCompCat_DefaultMor_Accessors.
+
   Definition discrete_comprehension_cat_structure_with_default_mor_weq1
              {C : category}
     : discrete_comprehension_cat_structure1 C

--- a/TypeTheory/ALV2/DiscreteComprehensionCat.v
+++ b/TypeTheory/ALV2/DiscreteComprehensionCat.v
@@ -162,14 +162,14 @@ Section MorWithUniqueLift.
     : isaprop (default_mor Γ Γ' A A' f).
   Proof.
     apply D_ob_isaset.
-  Defined.
+  Qed.
 
   Definition default_mor_homsets
              (Γ Γ' : C) (f : C ⟦ Γ, Γ' ⟧) (A : D_ob Γ) (A' : D_ob Γ')
     : isaset (default_mor _ _ A A' f).
   Proof.
     intros. apply isasetaprop. apply D_ob_isaset.
-  Defined.
+  Qed.
 
   Context
     (Fob : ∏ Γ : C, D_ob Γ → disp_codomain C Γ).
@@ -302,7 +302,7 @@ Section MorWithUniqueLift.
       apply funextsec; intros f.
       apply isapropweqtoprop.
       apply D_ob_isaset.
-  Defined.
+  Qed.
 
   Definition iscontr_mor_with_unique_lift'''
     : iscontr mor_with_unique_lift'''.
@@ -329,17 +329,19 @@ Section MorWithUniqueLift.
       exact (! maponpaths pr1 (pr2 uf (A ,, ff))).
     - intros p.
       exact (transportf (λ B, pr1 mor Γ Γ' B A' f) p (pr1 uf)).
-    - intros ff.
-      apply (transportf_pathsinv0' (λ B, pr1 mor Γ Γ' B A' f)).
-      apply pathsinv0.
-      apply (transportf_transpose_right
-               (P := λ B, pr1 mor Γ Γ' B A' f)
-             ).
-      apply (fiber_paths_from_total2_paths
-               (B := λ x, pr1 mor Γ Γ' x A' f)
-               (A ,, ff)
-               (D_lift_ob Γ' Γ f A' ,, pr1 uf)).
-    - intros p. apply D_ob_isaset.
+    - abstract (
+          intros ff;
+          apply (transportf_pathsinv0' (λ B, pr1 mor Γ Γ' B A' f));
+          apply pathsinv0;
+          apply (transportf_transpose_right
+                   (P := λ B, pr1 mor Γ Γ' B A' f)
+                );
+          apply (fiber_paths_from_total2_paths
+                   (B := λ x, pr1 mor Γ Γ' x A' f)
+                   (A ,, ff)
+                   (D_lift_ob Γ' Γ f A' ,, pr1 uf))
+        ).
+    - abstract (intros p; apply D_ob_isaset).
   Defined.
 
   Definition isaprop_mor_with_unique_lift_mor
@@ -351,7 +353,7 @@ Section MorWithUniqueLift.
     apply (isapropinclb (mor_with_unique_lift_mor_weq mor)).
     - apply isinclweq, (pr2 (mor_with_unique_lift_mor_weq mor)).
     - apply isaprop_default_mor.
-  Defined.
+  Qed.
 
   Definition iscontr_mor_with_unique_lift'
     : iscontr mor_with_unique_lift.
@@ -380,7 +382,7 @@ Section MorWithUniqueLift.
     use weq_iso.
     - intros p.
       
-  Defined.
+  Abort.
 
 End MorWithUniqueLift.
 
@@ -418,7 +420,7 @@ Section DiscreteComprehensionCats.
     - repeat (apply impred_isaprop; intros ?). apply D_homsets.
     - repeat (apply impred_isaprop; intros ?). apply D_homsets.
     - repeat (apply impred_isaprop; intros ?). apply D_homsets.
-  Defined.
+  Qed.
 
   Definition disp_cat_axioms'_weq {C : precategory} {D : disp_cat_data C}
     : (disp_cat_axioms' C D × (∏ x y f (xx : D x) (yy : D y), isaset (xx -->[f] yy)))
@@ -427,7 +429,7 @@ Section DiscreteComprehensionCats.
     eapply weqcomp. apply weqdirprodasstor.
     apply (weqdirprodf (idweq _)).
     apply weqdirprodasstor.
-  Defined.
+  Qed.
 
   Definition discrete_comprehension_cat_structure2' {C : category}
              (D_ob : C → UU)
@@ -468,7 +470,7 @@ Section DiscreteComprehensionCats.
     - intros. use total2_paths_f.
       + repeat (apply funextsec; intros ?). apply D_ob_isaset.
       + repeat (apply funextsec; intros ?). apply D_ob_isaset.
-  Defined.
+  Qed.
   
   Definition discrete_comprehension_cat_structure2 {C : category}
              (D_ob : C → UU)

--- a/TypeTheory/ALV2/DiscreteComprehensionCat.v
+++ b/TypeTheory/ALV2/DiscreteComprehensionCat.v
@@ -370,6 +370,18 @@ Section MorWithUniqueLift.
                @ ! pr2 iscontr_mor_with_unique_lift' default_mor_with_unique_lift).
   Defined.
 
+  Definition mor_with_unique_lift_reformulation
+             (mor : mor_with_unique_lift)
+             {Γ Γ' : C} {f : C ⟦ Γ', Γ ⟧} {A : D_ob Γ}
+             (P : ∏ (A' : D_ob Γ'), pr1 mor _ _ A' A f → UU)
+    : P (D_lift_ob Γ Γ' f A) (invweq (mor_with_unique_lift_mor_weq mor) (idpath _))
+        ≃ (∏ (A' : D_ob Γ') (ff : pr1 mor Γ' Γ A' A f), P A' ff).
+  Proof.
+    use weq_iso.
+    - intros p.
+      
+  Defined.
+
 End MorWithUniqueLift.
 
 Section DiscreteComprehensionCats.

--- a/TypeTheory/ALV2/SplitTypeCat_Cat_Simple.v
+++ b/TypeTheory/ALV2/SplitTypeCat_Cat_Simple.v
@@ -16,15 +16,33 @@ Section SplitTypeCat_Cat_Simple.
 
   Context (C : category).
 
+  Definition TY'
+    : split_typecat_structure C → preShv C.
+  Proof.
+    intros TC.
+    use tpair.
+    - use tpair.
+      + intros Γ.
+        exists (TC Γ).
+        apply (pr1 (pr2 TC)).
+      + intros Γ Γ' f A.
+        apply (reind_typecat A f).
+    - use make_dirprod.
+      + intros Γ. simpl. 
+        use funextsec; intros A.
+        apply (pr1 (pr1 (pr2 (pr2 TC)))).
+      + intros Γ Γ' Γ'' f g. simpl. 
+        use funextsec; intros A.
+        apply (pr1 (pr2 (pr2 (pr2 TC)))).
+  Defined.
+
   Definition SplitTy_ob_mor
     : precategory_ob_mor.
   Proof.
     use tpair.
-    - apply (split_typecat'_structure C).
-    - intros X Y. exact (TY X --> TY Y).
+    - apply (split_typecat_structure C).
+    - intros X Y. exact (TY' X --> TY' Y).
   Defined.
-
-  Print precategory_data .
 
   Definition SplitTy_id_comp
     : precategory_id_comp SplitTy_ob_mor.

--- a/TypeTheory/ALV2/SplitTypeCat_Cat_Simple.v
+++ b/TypeTheory/ALV2/SplitTypeCat_Cat_Simple.v
@@ -118,7 +118,7 @@ Section SplitTypeCat_Cat_Simple.
       pr1 mor _ (A {{f}})
       = (pr1 mor _ A) {{f}}.
   Proof.
-    intros Γ A Γ' f.
+    intros Γ Γ' f A.
     apply F_TY_ax.
   Defined.
 
@@ -130,7 +130,7 @@ Section SplitTypeCat_Cat_Simple.
       iso (Γ' ◂ pr1 mor _ (A {{f}}))
           (Γ' ◂ (pr1 mor _ A) {{f}}).
   Proof.
-    intros Γ A Γ' f.
+    intros Γ Γ' f A.
     use reind_ext_compare.
     apply F_TY_reind_ext_eq.
     apply F_TY_ax.
@@ -151,7 +151,7 @@ Section SplitTypeCat_Cat_Simple.
              (mor : SplitTy_mor_data X Y)
              (F_TY_ax : SplitTy_mor_axiom_F_TY mor)
     : UU
-    := ∏ (Γ : C) (A : X Γ) (Γ' : C) (f : Γ' --> Γ),
+    := ∏ (Γ Γ' : C) (f : Γ' --> Γ) (A : X Γ),
        q_typecat A f ;; pr2 mor Γ A
        = pr2 mor Γ' (A {{f}}) ;; Δ _ _ _ F_TY_ax Γ A Γ' f ;; q_typecat _ f.
 
@@ -227,7 +227,7 @@ Section SplitTypeCat_Cat_Simple.
     - use tpair. 2: use make_dirprod.
       + intros Γ Γ' f A. apply idpath.
       + intros Γ A. apply id_left.
-      + intros Γ A Γ' f. simpl.
+      + intros Γ Γ' f A. simpl.
         etrans. apply id_right.
         etrans. 2: apply assoc.
         etrans. 2: apply pathsinv0, id_left.
@@ -255,8 +255,8 @@ Section SplitTypeCat_Cat_Simple.
         etrans. apply maponpaths.
         apply (pr1 (pr2 (pr2 gg))).
         apply (pr1 (pr2 (pr2 ff))).
-      + intros Γ A Γ' f. simpl.
-        set (ff_q := pr2 (pr2 (pr2 ff)) Γ A Γ' f).
+      + intros Γ Γ' f A. simpl.
+        set (ff_q := pr2 (pr2 (pr2 ff)) Γ Γ' f A).
         set (gg_q := pr2 (pr2 (pr2 gg))).
         etrans. apply assoc.
         etrans. apply maponpaths_2, ff_q.

--- a/TypeTheory/ALV2/SplitTypeCat_Cat_Simple.v
+++ b/TypeTheory/ALV2/SplitTypeCat_Cat_Simple.v
@@ -1,0 +1,63 @@
+(**
+    TODO
+*)
+
+Require Import UniMath.Foundations.Sets.
+Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
+
+Require Import TypeTheory.Auxiliary.Auxiliary.
+Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
+Require Import TypeTheory.ALV1.TypeCat.
+
+Require Import UniMath.CategoryTheory.DisplayedCats.Auxiliary.
+Require Import UniMath.CategoryTheory.DisplayedCats.Core.
+
+Section SplitTypeCat_Cat_Simple.
+
+  Context (C : category).
+
+  Definition SplitTy_ob_mor
+    : precategory_ob_mor.
+  Proof.
+    use tpair.
+    - apply (split_typecat'_structure C).
+    - intros X Y. exact (TY X --> TY Y).
+  Defined.
+
+  Print precategory_data .
+
+  Definition SplitTy_id_comp
+    : precategory_id_comp SplitTy_ob_mor.
+  Proof.
+    use make_dirprod.
+    - intros X. apply identity.
+    - intros X Y Z. apply compose.
+  Defined.
+
+  Definition SplitTy_precat_data
+    : precategory_data
+    := (SplitTy_ob_mor ,, SplitTy_id_comp).
+
+  Definition SplitTy_precat_axioms
+    : is_precategory SplitTy_precat_data.
+  Proof.
+    repeat use make_dirprod.
+    - intros; apply id_left.
+    - intros; apply id_right.
+    - intros; apply assoc.
+    - intros; apply assoc'.
+  Defined.
+
+  Definition SplitTy_precat : precategory
+    := (_ ,, SplitTy_precat_axioms).
+
+  Definition SplitTy_precat_homsets : has_homsets SplitTy_precat.
+  Proof.
+    unfold has_homsets.
+    intros. apply homset_property.
+  Defined.
+
+  Definition SplitTy_cat : category
+    := (SplitTy_precat ,, SplitTy_precat_homsets).
+  
+End SplitTypeCat_Cat_Simple.

--- a/TypeTheory/ALV2/SplitTypeCat_Cat_Simple.v
+++ b/TypeTheory/ALV2/SplitTypeCat_Cat_Simple.v
@@ -8,6 +8,7 @@ Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
 Require Import TypeTheory.ALV1.TypeCat.
+Require Import TypeTheory.ALV1.TypeCat_Reassoc.
 
 Require Import UniMath.CategoryTheory.DisplayedCats.Auxiliary.
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
@@ -34,6 +35,15 @@ Section SplitTypeCat_Cat_Simple.
       + intros Γ Γ' Γ'' f g. simpl. 
         use funextsec; intros A.
         apply (pr1 (pr2 (pr2 (pr2 TC)))).
+  Defined.
+
+  Definition TY'_TY_eq
+             (TC : split_typecat_structure C)
+    : TY' TC = TY (weq_standalone_to_regrouped TC).
+  Proof.
+    use total2_paths_f.
+    - apply idpath.
+    - apply isaprop_is_functor. apply homset_property.
   Defined.
 
   Definition SplitTy_ob_mor
@@ -79,3 +89,79 @@ Section SplitTypeCat_Cat_Simple.
     := (SplitTy_precat ,, SplitTy_precat_homsets).
   
 End SplitTypeCat_Cat_Simple.
+
+Section SplitTypeCat'_Cat_Simple.
+
+  Context (C : category).
+
+  Definition SplitTy'_ob_mor
+    : precategory_ob_mor.
+  Proof.
+    use tpair.
+    - apply (split_typecat'_structure C).
+    - intros X Y. exact (TY X --> TY Y).
+  Defined.
+
+  Definition SplitTy'_id_comp
+    : precategory_id_comp SplitTy'_ob_mor.
+  Proof.
+    use make_dirprod.
+    - intros X. apply identity.
+    - intros X Y Z. apply compose.
+  Defined.
+
+  Definition SplitTy'_precat_data
+    : precategory_data
+    := (SplitTy'_ob_mor ,, SplitTy'_id_comp).
+
+  Definition SplitTy'_precat_axioms
+    : is_precategory SplitTy'_precat_data.
+  Proof.
+    repeat use make_dirprod.
+    - intros; apply id_left.
+    - intros; apply id_right.
+    - intros; apply assoc.
+    - intros; apply assoc'.
+  Defined.
+
+  Definition SplitTy'_precat : precategory
+    := (_ ,, SplitTy'_precat_axioms).
+
+  Definition SplitTy'_precat_homsets : has_homsets SplitTy'_precat.
+  Proof.
+    unfold has_homsets.
+    intros. apply homset_property.
+  Defined.
+
+  Definition SplitTy'_cat : category
+    := (SplitTy'_precat ,, SplitTy'_precat_homsets).
+
+End SplitTypeCat'_Cat_Simple.
+
+Section SplitTy'_mor_with_ϕ.
+
+  
+
+End SplitTy'_mor_with_ϕ.
+
+Section SplitTy_SplitTy'_catiso.
+
+  Context (C : category).
+
+  Definition SplitTy_SplitTy'_catiso
+    : catiso (SplitTy_cat C) (SplitTy'_cat C).
+  Proof.
+    use tpair.
+    - use tpair.
+      + use tpair.
+        * apply weq_standalone_to_regrouped.
+        * intros X Y. apply (idweq _).
+      + use tpair.
+        * intros X. apply idpath.
+        * intros X Y Z f g. apply idpath.
+    - use tpair.
+      + intros X Y. apply idisweq.
+      + apply (pr2 weq_standalone_to_regrouped).
+  Defined.
+  
+End SplitTy_SplitTy'_catiso.

--- a/TypeTheory/ALV2/SplitTypeCat_DiscCompCatDef_catiso.v
+++ b/TypeTheory/ALV2/SplitTypeCat_DiscCompCatDef_catiso.v
@@ -1,0 +1,110 @@
+(**
+    TODO
+*)
+
+Require Import UniMath.Foundations.Sets.
+Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
+
+Require Import UniMath.CategoryTheory.DisplayedCats.Auxiliary.
+Require Import UniMath.CategoryTheory.DisplayedCats.Core.
+
+Require Import TypeTheory.Auxiliary.Auxiliary.
+
+Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
+Require Import TypeTheory.ALV1.TypeCat.
+Require Import TypeTheory.ALV1.TypeCat_Reassoc.
+Require Import TypeTheory.ALV2.SplitTypeCat_Cat_Simple.
+Require Import TypeTheory.ALV2.DiscCompCatDef_Cat.
+Require Import TypeTheory.ALV2.DiscreteComprehensionCat.
+Require Import TypeTheory.ALV2.SplitTypeCat_ComprehensionCat.
+
+Section SplitTypeCat_DiscCompCatDef_catiso.
+
+  Context (C : category).
+
+  Definition SplitTy_DiscComp_weq
+    : SplitTy_cat C ≃ DiscCompCatDef_cat C
+    := split_typecat_structure_discrete_comprehension_cat_structure_default_mor_weq.
+
+  Definition SplitTy_DiscComp_mor_data_weq
+             {X Y : SplitTy_cat C}
+    : SplitTy_mor_data C X Y ≃
+        DiscCompCatDef_mor_data C (SplitTy_DiscComp_weq X) (SplitTy_DiscComp_weq Y).
+  Proof.
+    apply idweq.
+  Defined.
+    
+  Definition Δ_weq
+             {X Y : SplitTy_cat C}
+             {F : SplitTy_mor_data C X Y}
+             {F_TY_ax : SplitTy_mor_axiom_F_TY C F}
+             {Γ Γ' : C} {f : C ⟦ Γ', Γ ⟧} {A : pr1 X Γ}
+    : pr1 (SplitTypeCat_Cat_Simple.Δ C X Y F F_TY_ax Γ A Γ' f)
+      = Δ C (SplitTy_DiscComp_mor_data_weq F)
+    (λ (Γ0 Γ'0 : C) (f0 : C ⟦ Γ'0, Γ0 ⟧) (A0 : pr1 X Γ0),
+     F_TY_reind_ext_eq C X Y F F_TY_ax Γ0 A0 Γ'0 f0) Γ Γ' f A.
+  Proof.
+    unfold SplitTypeCat_Cat_Simple.Δ, Δ.
+    unfold F_TY_reind_ext_compare, F_TY_reind_ext_eq, reind_ext_compare, F_ob_compare.
+    apply maponpaths.
+    apply maponpaths.
+    apply pathsinv0.
+    apply (maponpathscomp
+             (DiscCompCatDef_Cat.F_ob (SplitTy_DiscComp_weq Y) Γ')
+             pr1).
+  Defined.
+
+  Definition SplitTy_DiscComp_mor_weq
+             (X Y : SplitTy_cat C)
+    : SplitTy_cat C ⟦ X , Y ⟧ ≃
+                  DiscCompCatDef_cat C ⟦ SplitTy_DiscComp_weq X , SplitTy_DiscComp_weq Y ⟧.
+  Proof.
+    apply (PartA.weqtotal2 (idweq _)); intros F.
+    apply (PartA.weqtotal2 (idweq _)); intros F_TY_ax.
+    apply (PartA.weqdirprodf (idweq _)).
+    apply weqonsecfibers; intros Γ.
+    apply weqonsecfibers; intros Γ'.
+    apply weqonsecfibers; intros f.
+    apply weqonsecfibers; intros A.
+    apply MoreEquivalences.weq_pathscomp0r.
+    apply maponpaths_2.
+    apply maponpaths.
+    exact Δ_weq.
+  Defined.
+
+  Definition SplitTy_DiscComp_functor_data
+    : functor_data (SplitTy_cat C) (DiscCompCatDef_cat C).
+  Proof.
+    use tpair.
+    - exact SplitTy_DiscComp_weq.
+    - exact SplitTy_DiscComp_mor_weq.
+  Defined.
+
+  Definition SplitTy_DiscComp_functor_axioms
+    : is_functor SplitTy_DiscComp_functor_data.
+  Proof.
+    use make_dirprod.
+    - intros X.
+      use DiscCompCatDef_mor_eq.
+      + intros Γ A. apply idpath.
+      + intros Γ A. apply id_right.
+    - intros X Y Z f g.
+      use DiscCompCatDef_mor_eq.
+      + intros Γ A. apply idpath.
+      + intros Γ A. apply id_right.
+  Defined.
+
+  Definition SplitTy_DiscComp_functor
+    : functor (SplitTy_cat C) (DiscCompCatDef_cat C)
+    := (_ ,, SplitTy_DiscComp_functor_axioms).
+
+  Definition SplitTy_DiscComp_functor_is_catiso
+    : is_catiso SplitTy_DiscComp_functor.
+  Proof.
+    unfold is_catiso.
+    use make_dirprod.
+    - intros X Y. apply (pr2 (SplitTy_DiscComp_mor_weq X Y)).
+    - apply (pr2 SplitTy_DiscComp_weq).
+  Defined.
+  
+End SplitTypeCat_DiscCompCatDef_catiso.

--- a/TypeTheory/ALV2/SplitTypeCat_DiscCompCat_catiso.v
+++ b/TypeTheory/ALV2/SplitTypeCat_DiscCompCat_catiso.v
@@ -1,0 +1,69 @@
+(**
+    TODO
+*)
+
+Require Import UniMath.Foundations.Sets.
+Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
+
+Require Import UniMath.CategoryTheory.DisplayedCats.Auxiliary.
+Require Import UniMath.CategoryTheory.DisplayedCats.Core.
+
+Require Import TypeTheory.Auxiliary.Auxiliary.
+
+Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
+Require Import TypeTheory.ALV1.TypeCat.
+Require Import TypeTheory.ALV1.TypeCat_Reassoc.
+Require Import TypeTheory.ALV2.SplitTypeCat_Cat_Simple.
+Require Import TypeTheory.ALV2.DiscCompCat_Cat.
+Require Import TypeTheory.ALV2.DiscreteComprehensionCat.
+Require Import TypeTheory.ALV2.SplitTypeCat_ComprehensionCat.
+
+Section SplitTypeCat_DiscCompCat_catiso.
+
+  Context (C : category).
+
+  Definition SplitTy_DiscComp_weq
+    : SplitTy_cat C ≃ DiscCompCat_cat C
+    := split_typecat_structure_discrete_comprehension_cat_structure_weq.
+
+  Definition SplitTy_DiscComp_Ty_eq
+             (X : SplitTy_cat C)
+    : TY' _ (X : split_typecat_structure C)
+      = preshv_from_disc_comp_cat_structure _
+          (SplitTy_DiscComp_weq X : discrete_comprehension_cat_structure C).
+  Proof.
+    use total2_paths_f.
+    - apply idpath.
+    - apply isaprop_is_functor. apply homset_property.
+  Defined.
+
+  Definition SplitTy_DiscComp_functor_data
+    : functor_data (SplitTy_cat C) (DiscCompCat_cat C).
+  Proof.
+    use tpair.
+    - apply SplitTy_DiscComp_weq.
+    - intros X Y. apply idweq.
+  Defined.
+
+  Definition SplitTy_DiscComp_functor_axioms
+    : is_functor SplitTy_DiscComp_functor_data.
+  Proof.
+    use make_dirprod.
+    - intros X. apply idpath.
+    - intros X Y Z f g. apply idpath.
+  Defined.
+
+  Definition SplitTy_DiscComp_functor
+    : functor (SplitTy_cat C) (DiscCompCat_cat C)
+    := (_ ,, SplitTy_DiscComp_functor_axioms).
+
+  Definition SplitTy_DiscComp_functor_is_catiso
+    : is_catiso SplitTy_DiscComp_functor.
+  Proof.
+    unfold is_catiso.
+    use make_dirprod.
+    - intros X Y. apply (pr2 (idweq _)).
+    - apply (pr2 SplitTy_DiscComp_weq).
+  Defined.
+  
+End SplitTypeCat_DiscCompCat_catiso.

--- a/TypeTheory/ALV2/SplitTypeCat_DiscCompCat_catiso.v
+++ b/TypeTheory/ALV2/SplitTypeCat_DiscCompCat_catiso.v
@@ -14,17 +14,17 @@ Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
 Require Import TypeTheory.ALV1.TypeCat.
 Require Import TypeTheory.ALV1.TypeCat_Reassoc.
 Require Import TypeTheory.ALV2.SplitTypeCat_Cat_Simple.
-Require Import TypeTheory.ALV2.DiscCompCat_Cat.
+Require Import TypeTheory.ALV2.DiscCompCatDef_Cat.
 Require Import TypeTheory.ALV2.DiscreteComprehensionCat.
 Require Import TypeTheory.ALV2.SplitTypeCat_ComprehensionCat.
 
-Section SplitTypeCat_DiscCompCat_catiso.
+Section SplitTypeCat_DiscCompCatDef_catiso.
 
   Context (C : category).
 
   Definition SplitTy_DiscComp_weq
-    : SplitTy_cat C ≃ DiscCompCat_cat C
-    := split_typecat_structure_discrete_comprehension_cat_structure_weq.
+    : SplitTy_cat C ≃ DiscCompCatDef_cat C
+    := split_typecat_structure_discrete_comprehension_cat_structure_default_weq.
 
   Definition SplitTy_DiscComp_Ty_eq
              (X : SplitTy_cat C)
@@ -38,7 +38,7 @@ Section SplitTypeCat_DiscCompCat_catiso.
   Defined.
 
   Definition SplitTy_DiscComp_functor_data
-    : functor_data (SplitTy_cat C) (DiscCompCat_cat C).
+    : functor_data (SplitTy_cat C) (DiscCompCatDef_cat C).
   Proof.
     use tpair.
     - apply SplitTy_DiscComp_weq.
@@ -54,7 +54,7 @@ Section SplitTypeCat_DiscCompCat_catiso.
   Defined.
 
   Definition SplitTy_DiscComp_functor
-    : functor (SplitTy_cat C) (DiscCompCat_cat C)
+    : functor (SplitTy_cat C) (DiscCompCatDef_cat C)
     := (_ ,, SplitTy_DiscComp_functor_axioms).
 
   Definition SplitTy_DiscComp_functor_is_catiso
@@ -66,4 +66,4 @@ Section SplitTypeCat_DiscCompCat_catiso.
     - apply (pr2 SplitTy_DiscComp_weq).
   Defined.
   
-End SplitTypeCat_DiscCompCat_catiso.
+End SplitTypeCat_DiscCompCatDef_catiso.


### PR DESCRIPTION
This is a follow up of #175 (there we showed an equivalence of types). In this PR we now construct an equivalence of categories where objects are split type cat structures and discrete comprehension cat structures:

- [x] Define category of split type category structures using `split_type_category` definition;
- [ ] Define category of discrete comprehension category structures, where morphisms are (morally) a displayed functor between discrete fibrations and a displayed natural transformation that makes that displayed functor agree with cartesian displayed functors of objects;
- [ ] Construct an isomorphism of said categories.
- [ ] Show that "simple" morphisms are equivalent to "full" morphisms (with extra ϕ-structure)
- [ ] Construct an isomorphism of "simple" and "full" categories of split type category structures.