### PR TITLE
Style update

### DIFF
--- a/TypeTheory/ALV1/CwF_Defs_Equiv.v
+++ b/TypeTheory/ALV1/CwF_Defs_Equiv.v
@@ -115,9 +115,10 @@ Proof.
   eapply weqcomp.
     unfold obj_ext_structure.
     apply weqtotal2asstor. simpl.
-  eapply weqcomp. Focus 2. apply weqtotal2asstol. simpl.
-  eapply weqcomp. Focus 2. eapply invweq.
-        apply weqtotal2dirprodassoc. simpl.
+  eapply weqcomp. 2: { apply weqtotal2asstol. }
+  simpl. eapply weqcomp. 
+  2: { eapply invweq, weqtotal2dirprodassoc. }
+  simpl.
   apply weqfibtototal.
   intro Ty.
   eapply weqcomp.
@@ -131,7 +132,7 @@ Defined.
 
 Definition weq_cwf'_cwf1_structure : cwf'_structure C ≃ cwf1_structure.
 Proof.
-  eapply weqcomp. Focus 2. apply weqtotal2asstor'.
+  eapply weqcomp. 2: { apply weqtotal2asstor'. }
   eapply weqcomp. apply weqtotal2asstol'.
   use weqbandf.
   - apply weq_rep1_cwf'_data.

--- a/TypeTheory/ALV1/CwF_Defs_Equiv.v
+++ b/TypeTheory/ALV1/CwF_Defs_Equiv.v
@@ -38,8 +38,6 @@ Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.ALV1.CwF_def.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
 
-Set Automatic Introduction.
-
 Section Fix_Category.
 
 Context {C : category}.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
@@ -31,9 +31,6 @@ Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Maps.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Equivalence.
 
-Local Set Automatic Introduction.
-(* only needed since imports globally unset it *)
-
 
 (** Some local notations, *)
 

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Cats_Standalone.v
@@ -114,7 +114,7 @@ Proof.
   apply (pullback_HSET_elements_unique Pb); clear Pb.
   - unfold yoneda_morphisms_data; cbn.
     etrans. use (pr2 (term_to_section t')). apply pathsinv0.
-    etrans. Focus 2. refine (pr2 (term_to_section t)).
+    etrans. 2: { refine (pr2 (term_to_section t)). }
     etrans. apply @pathsinv0, assoc.
     apply maponpaths.
     apply comp_ext_compare_π.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
@@ -432,7 +432,7 @@ Lemma term_fun_str_square_comm {Y : term_fun_structure_data}
   : #Yo (π A) ;; yy A = Q Y A ;; pp Y.
 Proof.
   apply pathsinv0.
-  etrans. Focus 2. apply yy_natural.
+  etrans. 2: { apply yy_natural. }
   etrans. apply yy_comp_nat_trans.
   apply maponpaths, e.
 Qed.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
@@ -29,8 +29,6 @@ Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.Auxiliary.Auxiliary.
 
-Set Automatic Introduction.
-
 (** * Object-extension structures 
 
 We start by fixing the common core of families structures and split type-category structures: an _object-extension structure_, a presheaf of “types” together with “extension” and “dependent projection” operations, as in the following definition: *)

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
@@ -51,7 +51,7 @@ Proof.
   unfold canonical_TM_to_given_data; cbn.
   etrans. apply maponpaths, (pr2 Y).
   etrans. apply (toforallpaths _ _ _ (!functor_comp (TM Y) _ _ ) _).
-  etrans. Focus 2. apply (toforallpaths _ _ _ (functor_comp (TM Y) _ _ ) _).
+  etrans. 2: { apply (toforallpaths _ _ _ (functor_comp (TM Y) _ _ ) _). }
   apply maponpaths_2. 
   apply (@PullbackArrow_PullbackPr2 C _ _ _ _ _ (make_Pullback _ _ _ _ _ _ _)).
 Qed.
@@ -184,7 +184,8 @@ Qed.
 Lemma given_TM_to_canonical_te {Γ:C} A
   : (given_TM_to_canonical : nat_trans _ _) (Γ ◂ A) (te Y A) = (te_from_qq Z A).
 Proof.
-  etrans. Focus 2. exact (toforallpaths _ _ _ (canonical_to_given_to_canonical _) _).
+  etrans.
+  2: { exact (toforallpaths _ _ _ (canonical_to_given_to_canonical _) _). }
   cbn. apply maponpaths, @pathsinv0, canonical_TM_to_given_te.
 Qed.
 
@@ -312,14 +313,16 @@ Proof.
   simpl in XR.
   specialize (XR (fun YZ => iscompatible_term_qq (pr1 YZ) (pr2 YZ))).
   apply XR.
-  eapply weqcomp. Focus 2.
-  unfold T2. unfold compatible_term_structure.
-  set (XR := @weqtotal2asstor).
-  specialize (XR (qq_morphism_structure X)).
-  specialize (XR (fun _ => term_fun_structure C X)).
-  simpl in XR.
-  specialize (XR (fun YZ => iscompatible_term_qq (pr2 YZ) (pr1 YZ))).
-  apply XR.
+  eapply weqcomp.
+  2: {
+    unfold T2, compatible_term_structure.
+    set (XR := @weqtotal2asstor).
+    specialize (XR (qq_morphism_structure X)).
+    specialize (XR (fun _ => term_fun_structure C X)).
+    simpl in XR.
+    specialize (XR (fun YZ => iscompatible_term_qq (pr2 YZ) (pr1 YZ))).
+    apply XR.
+  }
   use weqbandf.
   - apply weqdirprodcomm.
   - intros. simpl.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Equivalence.v
@@ -11,9 +11,6 @@ Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Maps.
 
-Local Set Automatic Introduction.
-(* only needed since imports globally unset it *)
-
 Open Scope mor_scope.
 
 

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
@@ -123,7 +123,8 @@ Proof.
       etrans. apply assoc.
       apply maponpaths_2, comp_ext_compare_π.
     etrans. apply assoc.
-    etrans. Focus 2. apply id_left. apply maponpaths_2.
+    etrans. 2: { apply id_left. }
+    apply maponpaths_2.
     exact (pr2 (term_to_section _)).
   - etrans. refine (!toforallpaths _ _ _ (nat_trans_eq_pointwise (W' _ _ _ _) _) _).
     etrans. apply Q_comp_ext_compare.
@@ -235,15 +236,17 @@ Proof.
         etrans. { apply maponpaths, comp_ext_compare_π. }
         apply (PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ _)).
       - apply (MorphismsIntoPullbackEqual (qq_π_Pb Z _ _)).
-        + etrans. Focus 2. apply assoc.
-          etrans. Focus 2.
+        + etrans. 2: { apply assoc. }
+          etrans.
+          2: {
             apply maponpaths, @pathsinv0.
             apply (PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ _)).
-          etrans. Focus 2. apply @pathsinv0, id_right.
+          }
+          etrans. 2: { apply @pathsinv0, id_right. }
           etrans. apply @pathsinv0, assoc.
           etrans. eapply maponpaths, qq_π.
           etrans. apply assoc.
-          etrans. Focus 2. apply id_left.
+          etrans. 2: { apply id_left. }
           apply maponpaths_2.
           etrans. apply @pathsinv0, assoc.
           etrans. { apply maponpaths, comp_ext_compare_π. }
@@ -402,26 +405,26 @@ Proof.
         apply (PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ _)).
       * etrans. apply @pathsinv0, assoc.
         use (maponpaths _ _ @ _).
-            { use (qq Z _ _ ;; qq Z _ _). }
-          { etrans. Focus 2. {
+        { use (qq Z _ _ ;; qq Z _ _). }
+        -- etrans.
+          2: {
             eapply iso_inv_on_right.
-            etrans. Focus 2. apply @pathsinv0, assoc. 
-            apply qq_comp. } Unfocus.
+            etrans. 2: { apply @pathsinv0, assoc. }
+            apply qq_comp. }
           apply @pathsinv0, iso_inv_on_right.
           apply @pathsinv0.
           etrans. apply assoc.
           etrans. apply maponpaths_2, @pathsinv0, comp_ext_compare_comp.
           apply comp_ext_compare_qq_general.
-         apply (section_qq_π _ _ _ e). }
-        etrans. apply assoc.
-        etrans. { apply maponpaths_2,
+          apply (section_qq_π _ _ _ e).
+        -- etrans. { apply assoc. }
+          etrans. { apply maponpaths_2,
                   (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)). }
-        etrans. apply @pathsinv0, assoc.
-        etrans.
-          apply maponpaths.
-          apply (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)).
-        apply id_right.
-  - idtac. intros ft. apply subtypePath.
+          etrans. { apply @pathsinv0, assoc. }
+          etrans. 2: { apply id_right. }
+          apply maponpaths,
+                  (PullbackArrow_PullbackPr2 (make_Pullback _ _ _ _ _ _ _)).
+  - intros ft. apply subtypePath.
     { intro. apply isapropdirprod.
     + apply homset_property.
     + apply setproperty. }
@@ -437,8 +440,7 @@ Proof.
       apply @pathsinv0, iso_inv_on_right.
       use (_ @ !assoc _ _ _).
       apply qq_comp.
-    etrans. Focus 2. 
-      exact (comp_ext_compare_qq Z (!e1) _).
+    etrans. 2: { exact (comp_ext_compare_qq Z (!e1) _). }
     etrans. apply assoc.
     apply maponpaths_2.
     etrans. apply maponpaths, @pathsinv0, comp_ext_compare_inv.
@@ -469,7 +471,7 @@ Proof.
   (* TODO: use [tm_from_qq_eq'] here *)
   use tm_from_qq_eq; simpl.
   - etrans. apply (toforallpaths _ _ _ (!functor_comp (TY X) _ _ ) A).
-    etrans. Focus 2. apply (toforallpaths _ _ _ (functor_comp (TY X) _ _ ) A).
+    etrans. 2: { apply (toforallpaths _ _ _ (functor_comp (TY X) _ _ ) A). }
     apply maponpaths_2; cbn.
     apply @pathsinv0, qq_π.
   - apply PullbackArrowUnique.

--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Maps.v
@@ -17,10 +17,6 @@ Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
 
-
-Local Set Automatic Introduction.
-(* only needed since imports globally unset it *)
-
 Section Fix_Base_Category.
 
 Context {C : category} {X : obj_ext_structure C}.

--- a/TypeTheory/ALV1/CwF_def.v
+++ b/TypeTheory/ALV1/CwF_def.v
@@ -22,8 +22,6 @@ Require Import TypeTheory.ALV1.RelativeUniverses.
 Require Import TypeTheory.ALV1.Transport_along_Equivs.
 Require Import TypeTheory.ALV1.RelUnivYonedaCompletion.
 
-Set Automatic Introduction.
-
 Section Auxiliary.
 
 (** * Preliminaries *)

--- a/TypeTheory/ALV1/CwF_def.v
+++ b/TypeTheory/ALV1/CwF_def.v
@@ -95,7 +95,7 @@ Lemma cwf_square_comm {Γ} {A}
   : #Yo π ;; yy A = yy t ;; pp.
 Proof.
   apply pathsinv0.
-  etrans. Focus 2. apply yy_natural.
+  etrans. 2: { apply yy_natural. }
   etrans. apply yy_comp_nat_trans.
   apply maponpaths, e.
 Qed.
@@ -311,14 +311,14 @@ Proof.
     -> ((ΓA,π),(v,(e,p)))
     -> ((ΓA,π),((v,e),p))
   *)
-  eapply weqcomp. Focus 2.
-    refine (weqfp _ _).
-    apply weqtotal2asstor'.
-  eapply weqcomp. Focus 2.
-    eapply weqtotal2asstol.
-    eapply weqcomp. Focus 2.
-    refine (weqfibtototal _ _ _).
+  eapply weqcomp.
+  2: { refine (weqfp _ _). apply weqtotal2asstor'. }
+  eapply weqcomp.
+  2: { eapply weqtotal2asstol. }
+  eapply weqcomp.
+  2: { refine (weqfibtototal _ _ _).
     intro. apply weqtotal2asstor'.
+  }
   (* convert the term argument under [yy] *)
   apply weqfibtototal. intros [ΓA π]; simpl.
   use weqbandf.
@@ -345,8 +345,9 @@ Proof.
   apply weqonsecfibers. intro Γ.
   (* convert the type argument under [yy] *) 
   eapply weqcomp.
-    Focus 2. eapply invweq.
+  2: { eapply invweq.
     refine (weqonsecbase _ _). apply yy.
+  }
   apply weqonsecfibers. intro A.
   apply  weq_cwf_fiber_representation_fpullback.
 Defined.
@@ -481,7 +482,7 @@ Lemma Morphism_of_presheaves_transfer_recover : Tm_iso ;; pp = pp'_eta ;; Ty_iso
 Proof.
   assert (XR := nat_trans_ax (counit_from_left_adjoint Fopequiv) _ _ pp).
   apply pathsinv0.
-  etrans.  Focus 2. apply XR.
+  etrans. 2: { apply XR. }
   clear XR.
   set (TT := #(right_adjoint Fopequiv) pp).
   set (TTT := #ηη TT).
@@ -580,7 +581,7 @@ Lemma RC_morphism_of_presheaves_recover : RC_Tm_iso ;; pp = RC_pp'_eta ;; RC_Ty_
 Proof.
   assert (XR := nat_trans_ax (counit_from_left_adjoint RCequiv) _ _ pp).
   apply pathsinv0.
-  etrans.  Focus 2. apply XR.
+  etrans.  2: { apply XR. }
   clear XR.
   set (TT := #(right_adjoint RCequiv) pp).
   set (TTT := #ηη TT).

--- a/TypeTheory/ALV1/RelUnivYonedaCompletion.v
+++ b/TypeTheory/ALV1/RelUnivYonedaCompletion.v
@@ -12,8 +12,6 @@ Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.ALV1.RelativeUniverses.
 Require Import TypeTheory.ALV1.Transport_along_Equivs.
 
-Set Automatic Introduction.
-
 (** * Instantiating the hypotheses of transfer of relative universes to Yoneda *)
 
 Local Notation "[ C , D ]" := (functor_category C D).

--- a/TypeTheory/ALV1/RelativeUniverses.v
+++ b/TypeTheory/ALV1/RelativeUniverses.v
@@ -20,8 +20,6 @@ Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
 Require Import TypeTheory.Auxiliary.Auxiliary.
 
-Set Automatic Introduction.
-
 Local Notation "[ C , D ]" := (functor_category C D).
 
 (** * Relative universe structures *)

--- a/TypeTheory/ALV1/RelativeUniverses.v
+++ b/TypeTheory/ALV1/RelativeUniverses.v
@@ -70,11 +70,13 @@ Definition rel_universe_structure_prop (Y : rel_universe_structure_data)
 Definition weq_rel_universe_structure_ :
    rel_universe_structure ≃ ∑ Y : rel_universe_structure_data, rel_universe_structure_prop Y.
 Proof.
-  eapply weqcomp. Focus 2.
+  eapply weqcomp.
+  2: {
     set (XR:=@weqforalltototal (ob C)).
     specialize (XR (fun X => ∏ f : D⟦ J X, U⟧, fpullback_data f)). simpl in XR.
     specialize (XR (fun X pX => ∏ A, fpullback_prop  (pX  A))).
     apply XR.
+  }
   apply weqonsecfibers.
   intro X.
   apply weqforalltototal.
@@ -397,7 +399,7 @@ Definition rel_universe_fpullback_mor_id
   : rel_universe_fpullback_mor (identity X) e
   = identity (fpb_ob (U X f)).
 Proof.
-  refine (_ @ _). Focus 2. { apply fully_faithful_inv_identity. } Unfocus.
+  refine (_ @ _). 2: { apply fully_faithful_inv_identity. }
   apply (maponpaths (fully_faithful_inv_hom _ _ _)). 
   apply (map_into_Pb_unique _ (pr2 (pr2 (U _ _)))).
   - refine (_ @ _). { apply Pb_map_commutes_1. }
@@ -419,18 +421,18 @@ Definition rel_universe_fpullback_mor_comp
     = rel_universe_fpullback_mor g e
     ;; rel_universe_fpullback_mor g' e'.
 Proof.
-  refine (_ @ _). Focus 2. { apply fully_faithful_inv_comp. } Unfocus.
+  refine (_ @ _). 2: { apply fully_faithful_inv_comp. }
   apply (maponpaths (fully_faithful_inv_hom _ _ _)).
   apply (map_into_Pb_unique _ (pr2 (pr2 (U _ _)))).
   - refine (_ @ _). { apply Pb_map_commutes_1. }
-    refine (_ @ _). Focus 2.
-    { apply pathsinv0.
+    refine (_ @ _).
+    2: { apply pathsinv0.
       refine (_ @ _). { apply pathsinv0, assoc. } 
       refine (_ @ _). { apply maponpaths, Pb_map_commutes_1. }
       refine (_ @ _). { apply maponpaths, functor_comp. }
       refine (_ @ _). { apply assoc. }
       apply maponpaths_2, Pb_map_commutes_1.
-    } Unfocus.
+    }
     refine (_ @ _). { apply maponpaths, assoc. }
     apply functor_comp.
   - refine (_ @ _). { apply Pb_map_commutes_2. }
@@ -864,7 +866,7 @@ Proof.
       cbn. unfold precomp_with. rewrite id_right.
       assert (XR := nat_trans_ax α').
       apply pathsinv0. 
-      etrans. Focus 2. apply XR.
+      etrans. 2: { apply XR. }
       cbn.
       apply pathsinv0. 
       etrans. apply maponpaths_2. apply maponpaths. 
@@ -894,7 +896,7 @@ Proof.
       * cbn. unfold precomp_with. rewrite id_right. rewrite id_right.
         assert (XR := nat_trans_ax α').
         cbn in XR. 
-        etrans. Focus 2. apply assoc.
+        etrans. 2: { apply assoc. }
         rewrite <- XR.
         rewrite assoc.
         apply maponpaths_2.

--- a/TypeTheory/ALV1/RepMaps.v
+++ b/TypeTheory/ALV1/RepMaps.v
@@ -24,9 +24,6 @@ Require Import TypeTheory.ALV1.RelativeUniverses.
 Require Import TypeTheory.ALV1.RelUnivYonedaCompletion.
 Require Import TypeTheory.ALV1.Transport_along_Equivs.
 
-Set Automatic Introduction.
-
-
 (** * Definition of a representable map of presheaves
 
 A representable map of presheaves consists of 

--- a/TypeTheory/ALV1/RepMaps.v
+++ b/TypeTheory/ALV1/RepMaps.v
@@ -124,8 +124,8 @@ Proof.
   unfold is_universe_relative_to.
   apply weqonsecfibers. intro Γ.
   eapply weqcomp.
-    Focus 2. eapply invweq.
-    refine (weqonsecbase _ _). apply yy.
+  2: { eapply invweq.
+    refine (weqonsecbase _ _). apply yy. }
   apply weqonsecfibers. intro A.
   apply weqimplimpl.
   - apply hinhfun. apply weq_cwf_fiber_representation_fpullback.

--- a/TypeTheory/ALV1/Transport_along_Equivs.v
+++ b/TypeTheory/ALV1/Transport_along_Equivs.v
@@ -34,8 +34,6 @@ Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.ALV1.RelativeUniverses.
 
 
-Set Automatic Introduction.
-
 (** * Transfer of relative universes to Yoneda along weak equivalence *)
 
 Local Notation "[ C , D ]" := (functor_category C D).

--- a/TypeTheory/ALV2/CwF_Cats.v
+++ b/TypeTheory/ALV2/CwF_Cats.v
@@ -35,7 +35,6 @@ Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.ALV1.CwF_def.
 
-Set Automatic Introduction.
 
 Section Auxiliary.
 

--- a/TypeTheory/ALV2/CwF_Cats_Iso.v
+++ b/TypeTheory/ALV2/CwF_Cats_Iso.v
@@ -38,8 +38,6 @@ Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
 Require Import UniMath.CategoryTheory.DisplayedCats.Equivalences.
 
 
-Set Automatic Introduction.
-
 Section CwF_Cat_Equiv.
 
   Context (C : category).

--- a/TypeTheory/ALV2/CwF_Cats_Simple.v
+++ b/TypeTheory/ALV2/CwF_Cats_Simple.v
@@ -30,7 +30,6 @@ Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.ALV1.CwF_def.
 
-Set Automatic Introduction.
 
 Section CwF_structure_cat.
   Context {C : category}.

--- a/TypeTheory/ALV2/CwF_Cats_Simple_Iso.v
+++ b/TypeTheory/ALV2/CwF_Cats_Simple_Iso.v
@@ -25,7 +25,6 @@ Require Import TypeTheory.ALV2.CwF_Cats.
 Require TypeTheory.ALV2.CwF_Cats_Simple.
 Require Import UniMath.CategoryTheory.catiso.
 
-Set Automatic Introduction.
 
 Section CwF_Cats_Simple_Iso.
 

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Cats.v
@@ -21,8 +21,6 @@ Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
 Require Import UniMath.CategoryTheory.DisplayedCats.Auxiliary.
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 
-Local Set Automatic Introduction.
-(* only needed since imports globally unset it *)
 
 (* TODO: as ever, upstream to [Systems.Auxiliary], and look for in library. *)
 Section Auxiliary.

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
@@ -284,25 +284,25 @@ Proof.
   use tm_from_qq_eq_reindex.
   - cbn.
   (* Putting these equalities under [abstract] shaves a couple of seconds off the overall Qed time, but makes the proof script rather less readable. *) 
-    etrans. Focus 2. exact (toforallpaths _ _ _ (functor_comp (TY _) _ _) _).
-    etrans. Focus 2. cbn. apply maponpaths_2, @pathsinv0, obj_ext_mor_ax.
+    etrans. 2: { exact (toforallpaths _ _ _ (functor_comp (TY _) _ _) _). }
+    etrans. 2: { cbn. apply maponpaths_2, @pathsinv0, obj_ext_mor_ax. }
     exact (toforallpaths _ _ _ (nat_trans_ax (obj_ext_mor_TY F) _ _ _) _).
-  - etrans. Focus 2. apply @pathsinv0, 
-        (postCompWithPullbackArrow _ _ _ (make_Pullback _ _ _ _ _ _ _)).
+  - etrans. 2: { apply @pathsinv0, 
+        (postCompWithPullbackArrow _ _ _ (make_Pullback _ _ _ _ _ _ _)). }
     apply PullbackArrowUnique.
     + cbn.
       etrans. apply @pathsinv0, assoc.
       etrans. apply maponpaths, qq_π.
       etrans. apply assoc.
-      etrans. Focus 2. apply @pathsinv0, id_right.
-      etrans. Focus 2. apply id_left.
+      etrans. 2: { apply @pathsinv0, id_right. }
+      etrans. 2: { apply id_left. }
       apply maponpaths_2.
       etrans. apply @pathsinv0, assoc.
       etrans. apply maponpaths, comp_ext_compare_π.
       etrans. apply @pathsinv0, assoc.
       etrans. apply maponpaths, obj_ext_mor_ax.
       apply (PullbackArrow_PullbackPr1 (make_Pullback _ _ _ _ _ _ _)).
-    + etrans. Focus 2. apply @pathsinv0, id_right.
+    + etrans. 2: { apply @pathsinv0, id_right. }
       etrans. cbn. apply maponpaths_2, maponpaths_2, maponpaths.
         etrans. apply comp_ext_compare_comp.
         apply maponpaths_2, comp_ext_compare_comp.

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Cats.v
@@ -19,8 +19,6 @@ Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Maps.
 Require Import TypeTheory.ALV2.CwF_SplitTypeCat_Cats.
 Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Equivalence. (* TODO: needed for some natural transformations. *)
 
-Local Set Automatic Introduction.
-(* only needed since imports globally unset it *)
 
 (* TODO: globalise upstream? *)
 Notation "# F" := (disp_functor_on_morphisms F)

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Comparison.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Equiv_Comparison.v
@@ -28,7 +28,6 @@ Require Import TypeTheory.ALV2.CwF_SplitTypeCat_Cats.
 Require Import TypeTheory.ALV2.CwF_SplitTypeCat_Univalent_Cats.
 Require Import TypeTheory.ALV2.CwF_SplitTypeCat_Equiv_Cats.
 
-Local Set Automatic Introduction.
 
 Section Auxiliary.
 

--- a/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
+++ b/TypeTheory/ALV2/CwF_SplitTypeCat_Univalent_Cats.v
@@ -19,9 +19,6 @@ Require Import TypeTheory.ALV1.CwF_SplitTypeCat_Defs.
 Require Import TypeTheory.ALV2.CwF_SplitTypeCat_Cats.
 Require Import TypeTheory.ALV2.CwF_SplitTypeCat_Equiv_Cats.
 
-Local Set Automatic Introduction.
-(* only needed since imports globally unset it *)
-
 
 Section Auxiliary.
 

--- a/TypeTheory/ALV2/RelUnivTransfer.v
+++ b/TypeTheory/ALV2/RelUnivTransfer.v
@@ -29,8 +29,6 @@ Require Import TypeTheory.ALV2.RelUniv_Cat_Simple.
 Require Import TypeTheory.ALV2.RelUniv_Cat.
 Require Import UniMath.CategoryTheory.catiso.
 
-Set Automatic Introduction.
-
 Section RelUniv_Transfer.
 
   (*       J

--- a/TypeTheory/ALV2/RelUniv_Cat.v
+++ b/TypeTheory/ALV2/RelUniv_Cat.v
@@ -35,8 +35,6 @@ Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.ALV1.RelativeUniverses.
 Require Import TypeTheory.ALV2.RelUniv_Cat_Simple.
 
-Local Set Automatic Introduction.
-(* only needed since imports globally unset it *)
 
 Section RelUniv.
 

--- a/TypeTheory/ALV2/RelUniv_Cat_Iso.v
+++ b/TypeTheory/ALV2/RelUniv_Cat_Iso.v
@@ -26,8 +26,6 @@ Require Import TypeTheory.ALV2.RelUniv_Cat_Simple.
 Require Import TypeTheory.ALV2.RelUniv_Cat.
 Require Import UniMath.CategoryTheory.catiso.
 
-Set Automatic Introduction.
-
 Section Cat_Iso.
 
   Context {C D : category}.

--- a/TypeTheory/ALV2/RelUniv_Cat_Simple.v
+++ b/TypeTheory/ALV2/RelUniv_Cat_Simple.v
@@ -36,8 +36,6 @@ Require Import TypeTheory.ALV1.RelativeUniverses.
 
 Require Import UniMath.CategoryTheory.catiso.
 
-Local Set Automatic Introduction.
-(* only needed since imports globally unset it *)
 
 Section RelUniv.
 

--- a/TypeTheory/ALV2/RelUniv_Cat_Yo_CwF_Iso.v
+++ b/TypeTheory/ALV2/RelUniv_Cat_Yo_CwF_Iso.v
@@ -27,8 +27,6 @@ Require Import TypeTheory.ALV2.RelUniv_Cat_Simple.
 Require Import TypeTheory.ALV2.RelUniv_Cat.
 Require Import UniMath.CategoryTheory.catiso.
 
-Set Automatic Introduction.
-
 Section Cat_Equiv.
 
   Context (C : category).

--- a/TypeTheory/Auxiliary/Auxiliary.v
+++ b/TypeTheory/Auxiliary/Auxiliary.v
@@ -25,9 +25,6 @@ Require Export UniMath.CategoryTheory.catiso.
 Require Export UniMath.CategoryTheory.CategoryEquality.
 
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
-(* Require Import TypeTheory.Auxiliary.UnicodeNotations. *)
-
-Set Automatic Introduction.
 
 Undelimit Scope transport.
 

--- a/TypeTheory/Auxiliary/Auxiliary.v
+++ b/TypeTheory/Auxiliary/Auxiliary.v
@@ -143,7 +143,7 @@ Proof.
     apply (base_paths _ _ H1).
   } 
   set (XR := fiber_paths X0). cbn in XR.
-  etrans. Focus 2. apply XR.
+  etrans. 2: { apply XR. }
   apply pathsinv0. 
   etrans. apply maponpaths_2. apply (isasetX _ _ _ (idpath x)).
   apply idpath_transportf.
@@ -227,10 +227,10 @@ Lemma transportf_comp_lemma (X : UU) (B : X -> UU) {A A' A'': X} (e : A = A'') (
   -> transportf _ e x = transportf _ e' x'.
 Proof.
   intro H.
-  eapply pathscomp0. Focus 2.
-    apply maponpaths. exact H.
-  eapply pathscomp0. Focus 2.
-    symmetry. apply transport_f_f.
+  eapply pathscomp0.
+  2: { apply maponpaths. exact H. }
+  eapply pathscomp0.
+  2: { symmetry. apply transport_f_f. }
   apply (maponpaths (fun p => transportf _ p x)).
   apply pathsinv0.
   eapply pathscomp0.
@@ -625,13 +625,14 @@ Proof.
        intermediate_path ((f1 ;; ηinv _ ) ;; (η _ ;; f2) ;; f3) end.
     + repeat rewrite <- assoc. apply maponpaths.
       repeat rewrite assoc.
-      etrans. Focus 2. do 2 apply maponpaths_2. eapply pathsinv0, iso_after_iso_inv.
+      etrans.
+      2: { do 2 apply maponpaths_2. eapply pathsinv0, iso_after_iso_inv. }
       rewrite id_left. apply idpath.
     + assert (XR := nat_trans_ax η). simpl in XR. rewrite <- XR. clear XR.
       repeat rewrite <- assoc.
       etrans. do 3 apply maponpaths. apply  triangle_id_right_ad. rewrite id_right.
       rewrite assoc.
-      etrans. Focus 2. apply id_left.
+      etrans. 2: { apply id_left. }
       apply maponpaths_2.
       etrans. apply maponpaths_2. apply functor_on_inv_from_iso.
       assert (XR := triangle_id_right_ad (pr2 (pr1 GG))).
@@ -1193,8 +1194,8 @@ Proof.
       intro; apply isapropdirprod; apply homset_property.
     cbn.
     apply (post_comp_with_iso_is_inj _ _ _ (iso_inv_from_iso i_d) (pr2 _)).
-    eapply @pathscomp0. Focus 2.
-      rewrite <- assoc. cbn. rewrite iso_inv_after_iso. eapply pathsinv0, id_right.
+    eapply @pathscomp0.
+    2: { rewrite <- assoc. cbn. rewrite iso_inv_after_iso. eapply pathsinv0, id_right. }
     apply PullbackArrowUnique; cbn.
     + apply (post_comp_with_iso_is_inj _ _ _ i_b (pr2 _)).
       repeat rewrite <- assoc.
@@ -1578,7 +1579,7 @@ Section Pullback_Unique_Up_To_Iso.
     unshelve refine (map_into_Pb H' pb' _ _ _  ).
     - exact (f ;; h).
     - exact g.
-    - eapply pathscomp0. Focus 2. apply H.
+    - eapply pathscomp0. 2: { apply H. }
       eapply pathscomp0. apply (!assoc _ _ _ ).
       apply maponpaths. apply T.
   Defined.

--- a/TypeTheory/Categories/category_FAM.v
+++ b/TypeTheory/Categories/category_FAM.v
@@ -17,8 +17,6 @@ Require Import UniMath.CategoryTheory.rezk_completion.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 Require Import TypeTheory.Auxiliary.Auxiliary.
 
-Set Automatic Introduction.
-
 Section Auxiliary.
 
 Lemma transportf_eqweqmap (A B : UU) (p : A = B) C (A' : A → C) (b : B) :

--- a/TypeTheory/Categories/category_FAM.v
+++ b/TypeTheory/Categories/category_FAM.v
@@ -166,7 +166,7 @@ Proof.
     destruct f as [f x].
     destruct g as [g y].
     simpl in *.
-    eapply weqcomp. Focus 2. apply weqtoforallpaths.
+    eapply weqcomp. 2: { apply weqtoforallpaths. }
     apply weqpathscomp0l.
     apply funextsec; intro t.
     apply (transportf_toforallpaths _ (λ a b, (A ₂) a --> (B ₂) b)).
@@ -383,30 +383,31 @@ Proof.
     exists inv. subst inv.
     split.
     
-    + eapply pathscomp0. Focus 2. apply fg2. symmetry.
+    + eapply pathscomp0. 2: { apply fg2. }
+      symmetry.
       eapply pathscomp0. apply (functtransportf (A ₂)).
       eapply pathscomp0. symmetry; apply idtoiso_postcompose.
       eapply pathscomp0. symmetry; apply assoc.
       apply maponpaths. eapply pathscomp0. apply idtoiso_postcompose.
       symmetry. apply functtransportf.
       
-    + eapply pathscomp0. Focus 2. apply gf2.
+    + eapply pathscomp0. 2: { apply gf2. }
       eapply pathscomp0. apply maponpaths_2.
         eapply pathscomp0. apply (functtransportf (A ₂)).
         symmetry; apply idtoiso_postcompose.
       symmetry. eapply pathscomp0. apply (functtransportf (B ₂)).
       eapply pathscomp0. symmetry; apply idtoiso_postcompose.
       eapply pathscomp0. symmetry; apply assoc.
-      eapply pathscomp0. Focus 2. apply assoc.
+      eapply pathscomp0. 2: { apply assoc. }
       apply maponpaths.
 
       assert (f2_natl : forall a1 a2 (p : a2 = a1),
                           f2 a2 ;; idtoiso (maponpaths (fun a => B ₂ (f1 a)) p)
                           = idtoiso (maponpaths (A ₂) p) ;; f2 a1).
         destruct p. eapply pathscomp0. apply id_right. sym. apply id_left.
-      eapply pathscomp0. Focus 2. apply f2_natl.
+      eapply pathscomp0. 2: { apply f2_natl. }
       apply maponpaths , maponpaths, maponpaths.
-      eapply pathscomp0. Focus 2. apply maponpathscomp.
+      eapply pathscomp0. 2: { apply maponpathscomp. }
       apply maponpaths. apply (pr2 B).
 Qed.
 
@@ -508,7 +509,7 @@ Proof.
   unshelve refine (total2_paths_f _ _).
   - apply funextsec; intros a.
     destruct A as [[A1 A2] A3].
-    eapply pathscomp0. Focus 2. exact (idpath (identity _)).
+    eapply pathscomp0. 2: { exact (idpath (identity _)). }
     exact (idpath _).
   - apply proofirrelevance.
     apply isofhleveltotal2.

--- a/TypeTheory/Categories/category_of_elements.v
+++ b/TypeTheory/Categories/category_of_elements.v
@@ -124,7 +124,7 @@ Proof.
   intro H.
   set (T:= maponpaths (inv_from_iso f) H).
   apply pathsinv0.
-  etrans. Focus 2. apply T.
+  etrans. 2: { apply T. }
   apply pathsinv0.
   set (HT:= iso_inv_after_iso f).
   set (HT':= toforallpaths _ _ _ HT).

--- a/TypeTheory/Categories/category_of_elements.v
+++ b/TypeTheory/Categories/category_of_elements.v
@@ -13,9 +13,6 @@ Require Import UniMath.CategoryTheory.opp_precat.
 Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
-Set Automatic Introduction.
-
-
 
 Section category_of_elements_covariant.
 

--- a/TypeTheory/Displayed_Cats/ComprehensionC.v
+++ b/TypeTheory/Displayed_Cats/ComprehensionC.v
@@ -23,7 +23,6 @@ Require Import UniMath.CategoryTheory.DisplayedCats.ComprehensionC.
 Require Import TypeTheory.Displayed_Cats.DisplayedCatFromCwDM.
 Require Import TypeTheory.OtherDefs.DM.
 
-Local Set Automatic Introduction.
 
 Section Comp_Cat_of_DM_Structure.
 

--- a/TypeTheory/Displayed_Cats/DisplayedCatFromCwDM.v
+++ b/TypeTheory/Displayed_Cats/DisplayedCatFromCwDM.v
@@ -20,8 +20,6 @@ Require Import UniMath.CategoryTheory.DisplayedCats.Fibrations.
 
 Require Import TypeTheory.OtherDefs.DM.
 
-Local Set Automatic Introduction.
-(* only needed since imports globally unset it *)
 
 (** ** Displayed category induced by a display map category
 

--- a/TypeTheory/Displayed_Cats/DisplayedCatFromCwDM.v
+++ b/TypeTheory/Displayed_Cats/DisplayedCatFromCwDM.v
@@ -116,15 +116,15 @@ Definition pullback_is_cartesian
 Proof.
   intros Hpb Δ g q hh.
   eapply iscontrweqf.
-  Focus 2. { 
+  2: { 
     use Hpb.
     + exact (ob_from_DM_over q).
     + exact (pr1 hh).
     + simpl in q. refine (q ;; g).
     + etrans. apply (pr2 hh). apply assoc.
-  } Unfocus.
+  }
   eapply weqcomp.
-  Focus 2. apply weqtotal2asstol.
+  2: { apply weqtotal2asstol. }
   apply weq_subtypes_iff.
   - intro. apply isapropdirprod; apply homset_property.
   - intro. apply (isofhleveltotal2 1). 

--- a/TypeTheory/OtherDefs/CwF_1.v
+++ b/TypeTheory/OtherDefs/CwF_1.v
@@ -523,8 +523,8 @@ Definition pre_cwf_law_2' Γ (A : C ⟨ Γ ⟩) Γ' (γ : Γ' --> Γ) (a : C ⟨
       (transportb _ (maponpaths (fun g => A[[g]]) (cwf_law_1 _ _ _ _ _ _))
         a). 
 Proof.
-  eapply pathscomp0. Focus 2.
-    apply maponpaths, maponpaths. exact (cwf_law_2 _ _ _ _ γ a).
+  eapply pathscomp0.
+  2: { apply maponpaths, maponpaths. exact (cwf_law_2 _ _ _ _ γ a). }
   apply pathsinv0.
   rew_trans_@.
   etrans. apply maponpaths, transportf_rtype_mapeq.
@@ -606,10 +606,10 @@ Definition dpr_q_pbpairing_commutes
   (hk := @pairing _ C Γ' (A[[f]]) X k (dpr_q_pbpairing_precwf_aux A f h k H))
 : (hk ;; q_precwf A f = h) × (hk ;; π (A[[f]]) = k).
 Proof.
-  split. Focus 2. apply cwf_law_1.
+  split. 2: { apply cwf_law_1. }
   unfold q_precwf.
-  etrans. Focus 2.
-    apply map_to_comp_as_pair_precwf.
+  etrans.
+  2: { apply map_to_comp_as_pair_precwf. }
   etrans.
     apply cwf_law_3.
   assert ((k ♯ (dpr_q_pbpairing_precwf_aux A f h k H)) ;; (π (A [[f]]) ;; f) 
@@ -680,7 +680,7 @@ Proof.
     apply maponpaths, (rterm_mapeq e2).
   eapply pathscomp0. apply transport_f_f.
   eapply pathscomp0.
-    Focus 2. symmetry. apply transportf_rtype_mapeq.
+  2: { symmetry. apply transportf_rtype_mapeq. }
   repeat apply term_typeeq_transport_lemma. 
   apply term_typeeq_transport_lemma_2.
   apply idpath.

--- a/TypeTheory/OtherDefs/CwF_1.v
+++ b/TypeTheory/OtherDefs/CwF_1.v
@@ -21,8 +21,6 @@ Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 Require Import TypeTheory.Auxiliary.Auxiliary.
 
 
-Set Automatic Introduction.
-
 Local Notation "# F" := (functor_on_morphisms F)(at level 3).
 
 (** * A "preview" of the definition *)

--- a/TypeTheory/OtherDefs/CwF_Pitts.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts.v
@@ -517,8 +517,8 @@ Definition pre_cwf_law_2' Γ (A : C ⟨ Γ ⟩) Γ' (γ : Γ' --> Γ) (a : C ⟨
       (transportb _ (maponpaths (fun g => A{{g}}) (cwf_law_1 _ _ _ _ _ _))
         a). 
 Proof.
-  eapply pathscomp0. Focus 2.
-    apply maponpaths, maponpaths. exact (cwf_law_2 _ _ _ _ γ a).
+  eapply pathscomp0.
+  2: { apply maponpaths, maponpaths. exact (cwf_law_2 _ _ _ _ γ a). }
   apply pathsinv0.
   rew_trans_@.
   etrans. apply maponpaths, transportf_rtype_mapeq.
@@ -600,12 +600,12 @@ Definition dpr_q_pbpairing_commutes
   (hk := @pairing _ C Γ' (A{{f}}) X k (dpr_q_pbpairing_precwf_aux A f h k H))
 : (hk ;; q_precwf A f = h) × (hk ;; π (A{{f}}) = k).
 Proof.
-  split. Focus 2. apply cwf_law_1.
+  split. 2: { apply cwf_law_1. }
   unfold q_precwf.
-  etrans. Focus 2.
-    apply map_to_comp_as_pair_precwf.
   etrans.
-    apply cwf_law_3.
+  2: { apply map_to_comp_as_pair_precwf. }
+  etrans.
+  { apply cwf_law_3. }
   assert ((k ♯ (dpr_q_pbpairing_precwf_aux A f h k H)) ;; (π (A {{f}}) ;; f) 
           = h ;; π A) as e1.
     eapply pathscomp0. apply assoc.
@@ -674,7 +674,7 @@ Proof.
     apply maponpaths, (rterm_mapeq e2).
   eapply pathscomp0. apply transport_f_f.
   eapply pathscomp0.
-    Focus 2. symmetry. apply transportf_rtype_mapeq.
+  2: { symmetry. apply transportf_rtype_mapeq. }
   repeat apply term_typeeq_transport_lemma. 
   apply term_typeeq_transport_lemma_2.
   apply idpath.

--- a/TypeTheory/OtherDefs/CwF_Pitts.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts.v
@@ -23,8 +23,6 @@ Require Import TypeTheory.Auxiliary.Auxiliary.
 Open Scope cat.
 Open Scope cat_deprecated.
 
-Set Automatic Introduction.
-
 (** * A "preview" of the definition *)
 
 Module Record_Preview.

--- a/TypeTheory/OtherDefs/CwF_Pitts_completion.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_completion.v
@@ -18,8 +18,6 @@ Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 Require Import TypeTheory.OtherDefs.CwF_Pitts.
 Require Import TypeTheory.Categories.category_of_elements.
 
-Set Automatic Introduction.
-
 Arguments iso: clear implicits.
 
 (** How to get a functor from RC(C) to D when having one from C to D **)

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat.v
@@ -102,13 +102,11 @@ Proof.
     exists (reindx_type_id C).
     intros Γ A. 
     unfold q_typecat; simpl. unfold q_precwf.
-    eapply pathscomp0. Focus 2. apply id_left.
-    eapply pathscomp0. Focus 2.
-      refine (maponpaths (fun q => q ;; _) _).
-      Unfocus.
-    eapply pathscomp0. Focus 2.
-      symmetry. apply pairing_transport.
-      Focus 2. apply cwf_law_4.
+    eapply pathscomp0. 2: { apply id_left. }
+    eapply pathscomp0.
+    2: refine (maponpaths (fun q => q ;; _) _).    
+    eapply pathscomp0. 2: { symmetry. apply pairing_transport. }
+    2: { apply cwf_law_4. }
     eapply pathscomp0.
     apply (pairing_mapeq _ _ (id_right _ )).
     apply maponpaths. simpl.
@@ -139,13 +137,12 @@ Proof.
     etrans.
     + refine (pairing_mapeq _ X' _ _ ).
       unfold X; clear X; unfold X'; clear X'.
-      etrans. Focus 2.  eapply pathsinv0.
-            apply maponpaths_2. apply cwf_law_3.
-      etrans. Focus 2. eapply pathsinv0.  apply assoc.
+      etrans. 2: { apply pathsinv0, maponpaths_2, cwf_law_3. }
+      etrans. 2: { apply pathsinv0, assoc. }
       etrans. apply assoc.
       apply maponpaths_2.
-      etrans. Focus 2. eapply pathsinv0. apply cwf_law_1.
-      etrans; [ | eapply pathsinv0; apply assoc ].
+      etrans. 2: { apply pathsinv0, cwf_law_1. }
+      etrans. 2: { apply pathsinv0, assoc. }
       apply maponpaths_2. sym. apply cwf_law_1.
     + apply maponpaths.
       match goal with |[ |- transportf _ ?e _ = transportf _ ?e' _  ] =>
@@ -153,8 +150,7 @@ Proof.
       intros p p'.
       rew_trans_@.
       apply term_typeeq_transport_lemma.
-      etrans. Focus 2.
-      apply rterm_typeeq.
+      etrans. 2:{ apply rterm_typeeq. }
       match goal with |[ |- transportf _ ?e _ = transportf _ ?e' _  ] =>
                        generalize e; generalize e' end.
       clear p p'.
@@ -173,7 +169,7 @@ Proof.
       apply term_typeeq_transport_lemma.
       match goal with |[ |- _ = transportf _ ?e _ ⟦ _ ⟧ ] => generalize e end.
       intro q.
-      etrans. Focus 2. apply rterm_typeeq.
+      etrans. 2: { apply rterm_typeeq. }
       rewrite  pre_cwf_law_2'.
       rewrite transport_f_f.
       unfold transportb.

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat.v
@@ -20,8 +20,6 @@ Require Import TypeTheory.ALV1.TypeCat.
 Require Import TypeTheory.OtherDefs.CwF_Pitts.
 Require Import TypeTheory.Auxiliary.Auxiliary.
 
-Set Automatic Introduction.
-
 (* Locally override the notation [ γ ♯ a ], at a higher level,
   to get more informative bracketing when pairing meets composition. *) 
 Local Notation "γ ## a" := (pairing γ a) (at level 75).

--- a/TypeTheory/OtherDefs/DM.v
+++ b/TypeTheory/OtherDefs/DM.v
@@ -23,8 +23,6 @@ Require Import TypeTheory.Auxiliary.Auxiliary.
 Open Scope cat.
 Open Scope cat_deprecated.
 
-Set Automatic Introduction.
-
 (** * A "preview" of the definition *)
 
 Module Record_Preview.


### PR DESCRIPTION
A couple of pieces of tidying up:

- removed `Set Automatic Introduction` in various files — previously required because UniMath exported `Unset Automatic Introduction`, but now unnecessary
- removed use of `Focus` and `Unfocus` — deprecated in UniMath’s current Coq and scheduled for removal soon (possibly already removed in more recent Coq), cf. https://github.com/coq/coq/pull/6909, https://github.com/coq/coq/issues/10688