### PR TITLE
Refactor to precategories to categories where appropriate

### DIFF
--- a/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
+++ b/TypeTheory/ALV1/CwF_SplitTypeCat_Defs.v
@@ -8,17 +8,17 @@
 
 In this file, we give the definitions of _split type-categories_ (originally due to Cartmell, here following a version given by Pitts) and _categories with families_ (originally due to Dybjer, here following a formulation given by Fiore).
 
-To facilitate comparing them afterwards, we split up their definitions in a slightly unusual way, starting with the part they share.  The key definitions of this file are therefore (all over a fixed base (pre)category [C]):  
+To facilitate comparing them afterwards, we split up their definitions in a slightly unusual way, starting with the part they share.  The key definitions of this file are therefore (all over a fixed base category [C]):
 
 - _object-extension structures_, [obj_ext_structure], the common core of CwF’s and split type-categories;
 - (_functional) term structures_, [term_fun_structure], the rest of the structure of a CwF on [C];
-- _cwf-structures_, [cwf_structure], the full structure of a CwF on a precategory [C]; 
+- _cwf-structures_, [cwf_structure], the full structure of a CwF on a category [C];
 - _CwF’s_, [cwf]; 
 - _q-morphism structures_, [qq_morphism_structure], for rest of the structure of a split type-category on [C];
 - _split type-cat structures_, [split_typecat_structure], the full structure of a split type-category on [C].
 - _split type-categories_, [split_typecat].
 
-NB: we follow the convention that _category_ does not include an assumption of saturation/univalence, i.e. means what is sometimes called _precategory_.
+NB: we follow UniMath’s convention that _category_ does not assume saturation/univalence, i.e. means what is sometimes called _precategory_ in the literature.
 *)
 
 
@@ -526,9 +526,7 @@ End Families_Structures.
 
 Section qq_Morphism_Structures.
 
-(* NOTE: most of this section does not require the [homset_property] for [C]. If the few lemmas that do require it were moved out of the section, e.g. [isaprop_qq_morphism_axioms], then would could take [C] as just a [precategory] here. Perhaps worth doing so?
-
-(Another alternative would be adding an extra argument of type [has_homsets C] to [isaprop_qq_morphism_axioms], but that’s less convenient for later use than just having [C] be a [category] in those lemmas.) *)
+(* NOTE: most of this section does not require the [homset_property] for [C]. If the few lemmas that do require it were moved out of the section, e.g. [isaprop_qq_morphism_axioms], then would could take [C] as just a [precategory] here. Perhaps worth doing so? Would mainly be relevant if we wanted to generalise to bicategories. *)
 
 Context {C : category} {X : obj_ext_structure C}.
 

--- a/TypeTheory/ALV1/CwF_def.v
+++ b/TypeTheory/ALV1/CwF_def.v
@@ -425,8 +425,6 @@ Let TY' : preShv D := Ty (pr1 T').
 Let pp : _ ⟦ TM , TY ⟧ := pr1 T.
 Let pp' : _ ⟦ TM' , TY' ⟧ := pr1 T'.
 
-Let hsDop : has_homsets (opp_precat D) := has_homsets_opp (homset_property _).
-
 Let ηη : functor (preShv D) (preShv C) :=
   pre_composition_functor C^op D^op _ (functor_opp F).
 
@@ -519,8 +517,6 @@ Let TY' : preShv RC := Ty (pr1 T').
 
 Let pp : _ ⟦ TM , TY ⟧ := pr1 T.
 Let pp' : _ ⟦ TM' , TY' ⟧ := pr1 T'.
-
-Let hsRCop : has_homsets (opp_precat RC) := has_homsets_opp (homset_property _).
 
 Let ηη : functor (preShv RC) (preShv C) :=
   pre_composition_functor C^op RC^op _ (functor_opp (Rezk_eta C)).

--- a/TypeTheory/ALV1/RelativeUniverses.v
+++ b/TypeTheory/ALV1/RelativeUniverses.v
@@ -942,8 +942,8 @@ Definition isweq_weak_relative_universe_transfer
            (R_full : full R)
            (isD : is_univalent D) (isD' : is_univalent D')
            (T : functor D' D)
-           (eta : iso (C:=[D, D, pr2 D]) (functor_identity D) (S ∙ T))
-           (eps : iso (C:=[D', D', pr2 D']) (T ∙ S) (functor_identity D'))
+           (eta : iso (C:=[D, D]) (functor_identity D) (S ∙ T))
+           (eps : iso (C:=[D', D']) (T ∙ S) (functor_identity D'))
            (S_faithful : faithful S) 
   : isweq weak_relative_universe_transfer.
 Proof.
@@ -964,8 +964,8 @@ Definition weq_weak_relative_universe_transfer
            (R_full : full R)
            (isD : is_univalent D) (isD' : is_univalent D')
            (T : functor D' D)
-           (eta : iso (C:=[D, D, pr2 D]) (functor_identity D) (S ∙ T))
-           (eps : iso (C:=[D', D', pr2 D']) (T ∙ S) (functor_identity D'))
+           (eta : iso (C:=[D, D]) (functor_identity D) (S ∙ T))
+           (eps : iso (C:=[D', D']) (T ∙ S) (functor_identity D'))
            (S_ff : fully_faithful S)
 : weak_relative_universe J ≃ weak_relative_universe J'
 := make_weq _ (isweq_weak_relative_universe_transfer R_full isD isD' T eta eps S_ff).

--- a/TypeTheory/ALV1/Transport_along_Equivs.v
+++ b/TypeTheory/ALV1/Transport_along_Equivs.v
@@ -143,8 +143,7 @@ Proof.
   set (XTT := ff_Fop_precomp).
   specialize (T XTT).
   set (XR := iso_from_iso_with_postcomp).
-  apply (XR _ _ _ (functor_category_has_homsets _ _ _ )
-                  (functor_category_has_homsets _ _ _ )  _ _ _ XTT).
+  apply (XR _ _ _ _ _ _ XTT).
   eapply iso_comp.
      apply functor_assoc_iso.
   eapply iso_comp.

--- a/TypeTheory/ALV1/Transport_along_Equivs.v
+++ b/TypeTheory/ALV1/Transport_along_Equivs.v
@@ -113,7 +113,7 @@ Proof.
 Defined.
 
 
-Definition epsinv : iso (C:=[_ , _ , has_homsets_preShv _ ])
+Definition epsinv : iso (C:=[_ , _])
                         (functor_identity (preShv C)) (ext ∙ Fop_precomp).
 Proof.
   set (XR':= (counit_iso_from_adj_equivalence_of_precats equiv_Fcomp)).
@@ -122,7 +122,7 @@ Proof.
 Defined.
 
 
-Definition etainv : iso (C:=[ _ , _ , (has_homsets_preShv _ )]) 
+Definition etainv : iso (C:=[ _ , _]) 
                         (Fop_precomp ∙ ext) (functor_identity (preShv D)).
 Proof.
   set (XR := (unit_iso_from_adj_equivalence_of_precats equiv_Fcomp)).

--- a/TypeTheory/ALV1/TypeCat.v
+++ b/TypeTheory/ALV1/TypeCat.v
@@ -188,17 +188,16 @@ Definition is_split_typecat {CC : precategory} (C : typecat_structure CC)
                ;; q_typecat (A{{f}}) g
                ;; q_typecat A f).
 
-Lemma isaprop_is_split_typecat (CC : precategory) (hs : has_homsets CC)
+Lemma isaprop_is_split_typecat (CC : category)
        (C : typecat_structure CC) : isaprop (is_split_typecat C).
 Proof.
   repeat (apply isofhleveltotal2; intros).
   - apply impred; intro; apply isapropisaset.
   - repeat (apply impred; intro). apply x.
-  - repeat (apply impred; intro). apply hs.
+  - repeat (apply impred; intro). apply homset_property.
   - repeat (apply impred; intro). apply x.
-  - intros.  
-    repeat (apply impred; intro).
-    apply hs.
+  - intros.
+    repeat (apply impred; intro). apply homset_property.
 Qed.
 
 Definition typecat := ∑ (C : category), (typecat_structure C).

--- a/TypeTheory/ALV1/TypeCat.v
+++ b/TypeTheory/ALV1/TypeCat.v
@@ -5,7 +5,7 @@
 
 Contents:
 
-  - Definition of type-categories and split type-categories
+  - Definition of type-(pre)categories and split type-categories
   - A few convenience lemmas
 *)
 
@@ -34,13 +34,12 @@ However, that definition includes two _strictness conditions_;
 we follow van den Berg and Garner, _Topological and simplicial models_, Def 2.2.1 #(<a href="http://arxiv.org/abs/1007.4638">arXiv</a>)# 
 in separating these out from the rest of the definition.
 
- An element of [type_precat], as we define it below, is thus exactly a type-category according 
-to the definition of van den Berg and Garner; and an element of [split_type_precat] is a split type-category 
-according to van den Berg and Garner, or a plain type-category in the sense of Pitts 
-(modulo, in either case, the question of equality on objects of the category).
- 
+ An element of [typecat], as we define it below, is thus exactly a type-category according 
+to the definition of van den Berg and Garner (except with an underlying _precategory_, i.e. hom-types not assumed sets); and an element of [split_typecat] is a split type-category 
+according to van den Berg and Garner, or a plain type-category in the sense of Pitts.
+
   In order to avoid the nested sigma-types getting too deep, 
-we split up the structure into two stages: [type_precat_structure1] and [type_precat_structure2]. *)
+we split up the structure into two stages: [typecat_structure1] and [typecat_structure2]. *)
 
 (** * A "preview" of the definition *)
 
@@ -174,8 +173,8 @@ Definition is_type_saturated_typecat {CC : precategory} (C : typecat_structure C
 
 (** * Splitness *)
 
-(** A type-precategory [C] is _split_ if each collection of types [C Γ] is a set, reindexing is strictly functorial, and the [q] maps satisfy the evident functoriality axioms *) 
-Definition is_split_typecat {CC : precategory} (C : typecat_structure CC)
+(** A type-precategory [C] is _split_ if it is a category (i.e. has hom-sets); each collection of types [C Γ] is a set, reindexing is strictly functorial; and the [q] maps satisfy the evident functoriality axioms *) 
+Definition is_split_typecat {CC : category} (C : typecat_structure CC)
   := (∏ Γ:CC, isaset (C Γ))
      × (∑ (reind_id : ∏ Γ (A : C Γ), A {{identity Γ}} = A),
          ∏ Γ (A : C Γ), q_typecat A (identity Γ)
@@ -210,14 +209,14 @@ Definition split_typecat := ∑ (C : typecat), (is_split_typecat C).
 Coercion typecat_of_split_typecat (C : split_typecat) := pr1 C.
 Coercion split_typecat_is_split (C : split_typecat) := pr2 C.
 
-Definition split_typecat_structure (CC : precategory) : UU
+Definition split_typecat_structure (CC : category) : UU
   := ∑ C : typecat_structure CC, is_split_typecat C.
 
-Coercion typecat_from_split (CC : precategory) (C : split_typecat_structure CC)
+Coercion typecat_from_split (CC : category) (C : split_typecat_structure CC)
   : typecat_structure _
   := pr1 C.
 
-Coercion is_split_from_split_typecat (CC : precategory) (C : split_typecat_structure CC)
+Coercion is_split_from_split_typecat (CC : category) (C : split_typecat_structure CC)
   : is_split_typecat C
   := pr2 C.
 

--- a/TypeTheory/ALV2/RelUnivTransfer.v
+++ b/TypeTheory/ALV2/RelUnivTransfer.v
@@ -334,8 +334,8 @@ Section RelUniv_Transfer.
     Context (R_ses : split_ess_surj R)
             (D'_univ : is_univalent D')
             (invS : functor D' D)
-            (eta : iso (C:=[D, D, pr2 D]) (functor_identity D) (S ∙ invS))
-            (eps : iso (C:=[D', D', pr2 D']) (invS ∙ S) (functor_identity D'))
+            (eta : iso (C:=[D, D]) (functor_identity D) (S ∙ invS))
+            (eps : iso (C:=[D', D']) (invS ∙ S) (functor_identity D'))
             (S_ff : fully_faithful S).
 
     Let E := ((S,, (invS,, (pr1 eta, pr1 eps)))
@@ -348,10 +348,10 @@ Section RelUniv_Transfer.
     Let ε' := pr2 (pr121 AE) : nat_trans (invS ∙ S) (functor_identity _).
     Let η := functor_iso_from_pointwise_iso
                 _ _ _ _ _ η' (pr12 (adjointificiation E))
-            : iso (C:=[D, D, pr2 D]) (functor_identity D) (S ∙ invS).
+            : iso (C:=[D, D]) (functor_identity D) (S ∙ invS).
     Let ε := functor_iso_from_pointwise_iso
                 _ _ _ _ _ ε' (pr22 (adjointificiation E))
-            : iso (C:=[D', D', pr2 D']) (invS ∙ S) (functor_identity D').
+            : iso (C:=[D', D']) (invS ∙ S) (functor_identity D').
 
     Let ηx := Constructions.pointwise_iso_from_nat_iso (iso_inv_from_iso η).
     Let αx := Constructions.pointwise_iso_from_nat_iso (α,,α_is_iso).
@@ -655,8 +655,8 @@ Section WeakRelUniv_Transfer.
 
   (* S is an equivalence *)
   Context (T : functor D' D).
-  Context (η : iso (C := [D, D, pr2 D]) (functor_identity D) (S ∙ T)).
-  Context (ε : iso (C := [D', D', pr2 D']) (T ∙ S) (functor_identity D')).
+  Context (η : iso (C := [D, D]) (functor_identity D) (S ∙ T)).
+  Context (ε : iso (C := [D', D']) (T ∙ S) (functor_identity D')).
   Context (S_full : full S).
   Context (S_faithful : faithful S).
 

--- a/TypeTheory/ALV2/SplitTypeCat_ComprehensionCat.v
+++ b/TypeTheory/ALV2/SplitTypeCat_ComprehensionCat.v
@@ -901,8 +901,6 @@ Section SplitTypeCat_DiscreteComprehensionCat_Equiv.
              apply funextsec. intros ?.
              apply isaprop_isPullback.
       + apply isaprop_is_split_typecat.
-        apply homset_property.
-
     - intros DC.
       use total2_paths_f.
       2: use total2_paths_f.

--- a/TypeTheory/Auxiliary/Auxiliary.v
+++ b/TypeTheory/Auxiliary/Auxiliary.v
@@ -11,7 +11,6 @@ Possibly some should be upstreamed to “UniMath” eventually.
 
 *)
 
-
 Require Import UniMath.Foundations.PartD.
 Require Import UniMath.Foundations.Sets.
 Require Import UniMath.Combinatorics.StandardFiniteSets.

--- a/TypeTheory/Auxiliary/Auxiliary.v
+++ b/TypeTheory/Auxiliary/Auxiliary.v
@@ -499,8 +499,8 @@ Proof.
       apply id_left.
 Defined.
 
-Definition iso_ob {C D : precategory} (hsD : has_homsets D)
-          {F G : functor C D} (a : iso (C:= [C, D, hsD]) F G)
+Definition iso_ob {C : precategory} {D : category}
+          {F G : functor C D} (a : iso (C:= [C, D]) F G)
   : ∏ c, iso (F c) (G c).
 Proof.
   intro c.
@@ -523,9 +523,9 @@ Proof.
     + cbn. destruct p as [[a b] f].
       apply pathsdirprod; cbn. 
       * apply (isotoid _ isC). 
-        apply iso_inv_from_iso. apply (iso_ob _ eta).
+        apply iso_inv_from_iso. apply (iso_ob eta).
       * apply (isotoid _ isC).
-        apply iso_inv_from_iso. apply (iso_ob _ eta).
+        apply iso_inv_from_iso. apply (iso_ob eta).
     + cbn. destruct p as [[a b] f]. cbn in *.
       etrans. apply (transportf_pair (λ x : C × C, C ⟦ pr2 x, pr1 x ⟧)).
       cbn.
@@ -544,9 +544,9 @@ Proof.
     + cbn. destruct p as [[a b] f].
       apply pathsdirprod; cbn. 
       * apply (isotoid _ isD). 
-        apply (iso_ob _ eps).
+        apply (iso_ob eps).
       * apply (isotoid _ isD).
-        apply (iso_ob _ eps).
+        apply (iso_ob eps).
     + cbn. destruct p as [[a b] f]. cbn in *.
       etrans. apply (transportf_pair (λ x : D × D, D ⟦ pr2 x, pr1 x ⟧)).
       cbn.
@@ -834,18 +834,6 @@ Qed.
 
 Coercion univalent_category_is_univalent : univalent_category >-> is_univalent.
 
-(* TODO: raise issue in [CategoryTheory.Categories]: delete [category_has_homsets], since now redundant with [homset_property], since [category] coerces to [category]. *)
-
-(* TODO: raise issue: should the [HSET] provided be this by default, and current [HSET] be renamed to [HSET_precategory]? *)
-(* This def exists in UniMath/UniMath
-Definition HSET_univalent_category : univalent_category.
-Proof.
-  exists HSET; split.
-  - apply is_univalent_HSET.
-  - apply has_homsets_HSET.
-Defined.
- *)
-
 Definition functor_univalent_category (C : precategory) (D : univalent_category)
   : univalent_category.
 Proof.
@@ -884,7 +872,7 @@ Lemma yy_comp_nat_trans {C : category}
   : yy v ;; p = yy ((p : nat_trans _ _ )  _ v).
 Proof.
   apply nat_trans_eq.
-  - apply has_homsets_HSET.
+  - apply homset_property.
   - intro c. simpl. 
     apply funextsec. intro f. cbn.
     assert (XR := toforallpaths _ _ _ (nat_trans_ax p _ _ f) v ).
@@ -1000,9 +988,8 @@ Proof.
   apply id_right.
 Defined.
 
-Definition nat_iso_from_pointwise_iso (D E : precategory)
-  (hsE : has_homsets E)
-  (F G : [D, E, hsE])
+Definition nat_iso_from_pointwise_iso (D : precategory) (E : category)
+  (F G : [D, E])
   (a : ∏ d, iso ((F : functor _ _) d) ((G : functor _ _) d))
   (H : is_nat_trans _ _ a)
   : iso F G.
@@ -1014,12 +1001,12 @@ Proof.
   - intro d. apply (pr2 (a d)).
 Defined.
 
-Lemma iso_from_iso_with_postcomp (D E E' : precategory) hsE hsE'
+Lemma iso_from_iso_with_postcomp (D E E' : category)
   (F G : functor D E) (H : functor E E')
   (Hff : fully_faithful H) : 
-  iso (C:=[D, E', hsE']) (functor_composite F H) (functor_composite G H)
+  iso (C:=[D, E']) (functor_composite F H) (functor_composite G H)
   ->
-  iso (C:=[D, E, hsE]) F G.
+  iso (C:=[D, E]) F G.
 Proof.
   intro a.
   use nat_iso_from_pointwise_iso.
@@ -1044,9 +1031,9 @@ Proof.
 Defined.
 
 
-Definition functor_assoc_iso (D1 D2 D3 D4 : precategory) hsD4
+Definition functor_assoc_iso (D1 D2 D3 : precategory) (D4 : category)
      (F : functor D1 D2) (G : functor D2 D3) (H : functor D3 D4) :
-    iso (C:=[D1,D4,hsD4])
+    iso (C:=[D1,D4])
          (functor_composite (functor_composite F G) H)
          (functor_composite F (functor_composite G H)).
 Proof.
@@ -1060,9 +1047,9 @@ Proof.
      ).
 Defined.
 
-Definition functor_comp_id_iso (D1 D2 : precategory) hsD2
+Definition functor_comp_id_iso (D1 : precategory) (D2 : category)
      (F : functor D1 D2) :
-  iso (C:=[D1,D2,hsD2]) (functor_composite F (functor_identity _ )) F.
+  iso (C:=[D1,D2]) (functor_composite F (functor_identity _ )) F.
 Proof.
   use nat_iso_from_pointwise_iso.
   - intro. apply identity_iso.
@@ -1074,10 +1061,10 @@ Proof.
     ).
 Defined.
 
-Definition functor_precomp_iso (D1 D2 D3 : precategory)  hsD3
+Definition functor_precomp_iso (D1 D2 : precategory) (D3 : category)
     (F : functor D1 D2) (G H : functor D2 D3) :
-    iso (C:=[D2,D3,hsD3]) G H ->
-    iso (C:=[D1,D3,hsD3]) (functor_composite F G)
+    iso (C:=[D2,D3]) G H ->
+    iso (C:=[D1,D3]) (functor_composite F G)
                           (functor_composite F H).
 Proof.
   intro a.
@@ -1231,8 +1218,7 @@ End Square_Transfers.
 Section on_pullbacks.
 
 (* TODO: make all these implicit *)
-  Variable C : precategory.
-  Variable hs : has_homsets C.
+  Variable C : category.
   Variables a b c d : C.
   Variables (f : a --> b) (g : a --> c) (k : b --> d) (h : c --> d).
 
@@ -1316,11 +1302,7 @@ Section on_pullbacks.
   Lemma postcomp_pb_with_iso (y : C) (r : y --> d) (i : iso b y) (Hi : i ;; r = k) :
     ∑ H : f ;; i ;; r = g ;; h, isPullback H.
   Proof.
-    simple refine (@commutes_and_is_pullback_transfer_iso (C,,hs)
-              _ _ _ _  _ _ _ _
-              _ _ _ _  _ _ _ _
-              _ _ _ _  _ _ _ _
-              _ Pb);
+    simple refine (commutes_and_is_pullback_transfer_iso _ _ _ _ _ Pb);
     try apply identity_iso;
     try rewrite id_left;
     try rewrite id_right;
@@ -1339,13 +1321,13 @@ Section on_pullbacks.
   Lemma is_symmetric'_isPullback
     : isPullback (!sqr_comm) -> isPullback sqr_comm.
   Proof.
-    refine (is_symmetric_isPullback hs _).
+    use is_symmetric_isPullback; apply homset_property.
   Defined.
 
 End on_pullbacks.
 
-Arguments map_into_Pb {_ _ _ _ _ _ _ _ _ } _ _ {_} _ _ _ .
-Arguments map_into_Pb_unique {_ _ _ _ _ _ _ _ _} _ _ {_} _ _ _ _   .
+Arguments map_into_Pb {_ _ _ _ _ _ _ _ _ } _ Pb {_} _ _ _.
+Arguments map_into_Pb_unique {_ _ _ _ _ _ _ _ _} _ Pb {_} _ _ _ _.
 
 Section Pullbacks_hSet.
 
@@ -1501,7 +1483,7 @@ Proof.
     + apply (pr2 (pr1 XR) Three).
   - intro t.
     apply subtypePath.
-    + intro. apply isapropdirprod; apply has_homsets_HSET.
+    + intro. apply isapropdirprod; apply homset_property.
     + simpl.
       apply path_to_ctr.
       destruct t as [t [H1 H2]].

--- a/TypeTheory/Auxiliary/CategoryTheory.v
+++ b/TypeTheory/Auxiliary/CategoryTheory.v
@@ -148,7 +148,7 @@ Proof.
     apply is_iso_counit_over_id, axioms_of_equiv_over_id.
 Defined.
 
-(* Notes towards some possible improvements in UniMath’s treatment of adjunctions, equivalences (and a few other unrelated things in the library):
+(* TODO: Notes towards some possible improvements in UniMath’s treatment of adjunctions, equivalences (and a few other unrelated things in the library):
 
   One really confusing point is having
   [adj_equivalence_of_precats] for the property of (or structure on) a functor,
@@ -185,7 +185,6 @@ Defined.
   Unrelated:
 
   - improve stuff on nat isos?  Move from current location to a more core one, and give good access functions, e.g. use it in lemmase like [functor_iso_from_pointwise_iso]?
-  - consolidated things with a “has_homsets” argument to have a “category” argument instead
 
   - Rename “transportb_transpose_right”.
 

--- a/TypeTheory/Categories/ess_alg_categories.v
+++ b/TypeTheory/Categories/ess_alg_categories.v
@@ -1,7 +1,7 @@
 
-(** (Pre)-categories in essentially algebraic style *)
+(** Categories in essentially algebraic style *)
 
-(** Such a (pre-)category is given by
+(** Such a category is given by
     - a type (set) of objects
     - a type (set) of morphisms
     - source and target maps

--- a/TypeTheory/Categories/ess_and_gen_alg_cats.v
+++ b/TypeTheory/Categories/ess_and_gen_alg_cats.v
@@ -27,12 +27,11 @@ Open Scope cat_deprecated.
 
 (** * From generalized algebraic precategories to essentially algebraic ones.*)
 
-(** We need extra assumption that the gen. alg. precategory has hom-sets *)
+(** We need extra assumption that the gen. alg. precategory is a category, i.e. has hom-sets *)
 
 Section ess_alg_from_gen_alg.
 
-Variable C : precategory.
-Variable hs : has_homsets C.
+Variable C : category.
 Variable H : isaset C.
 
 (* TODO: now we are writing compositional in diagrammatic order,
@@ -125,7 +124,7 @@ Proof.
  - split.
    + apply H. 
    + apply isaset_total2. apply isaset_dirprod; try assumption.
-     intro x; apply hs.
+     intro x; apply homset_property.
 Qed.
 
 End ess_alg_from_gen_alg.

--- a/TypeTheory/Cubical/FillFromComp.v
+++ b/TypeTheory/Cubical/FillFromComp.v
@@ -359,7 +359,7 @@ now rewrite <-!assoc, H2, H3, assoc, H4, id_left, id_right.
 Qed.
 
 (* We can lift the above operations to presheaves using yoneda *)
-Let yon := yoneda_functor_data C.
+Let yon := yoneda_functor_data C : functor_data C (PreShv C).
 
 Definition p_PreShv (I : C) : yon (I+) --> yon I := # yon (p_F I).
 
@@ -515,8 +515,7 @@ Qed.
 
 Lemma e₀_f_pb {I J} (f : J --> I) : isPullback (e₀_f f).
 Proof.
-apply Auxiliary.is_symmetric'_isPullback.
-apply functor_category_has_homsets.
+apply is_symmetric'_isPullback.
 apply pb_if_pointwise_pb; intros K.
 apply Auxiliary.isPullback_HSET; intros L f1 f2.
 now apply e₀_pb.

--- a/TypeTheory/Displayed_Cats/ComprehensionC.v
+++ b/TypeTheory/Displayed_Cats/ComprehensionC.v
@@ -65,7 +65,7 @@ Proof.
   - apply is_fibration_DM_disp.
   - intros c c' f d. 
     apply isPullback_cartesian_in_cod_disp.
-    apply isPullback_of_dm_sub_pb, homset_property.
+    apply isPullback_of_dm_sub_pb.
 Qed.
 
 Definition total_comprehension_of_dm_structure

--- a/TypeTheory/Displayed_Cats/DisplayedCatFromCwDM.v
+++ b/TypeTheory/Displayed_Cats/DisplayedCatFromCwDM.v
@@ -158,7 +158,6 @@ Proof.
     * apply sqr_comm_of_dm_sub_pb.
   + apply pullback_is_cartesian.
     apply isPullback_of_dm_sub_pb.
-    apply homset_property.
 Defined.
 
 End DM_Disp.

--- a/TypeTheory/OtherDefs/CwF_1.v
+++ b/TypeTheory/OtherDefs/CwF_1.v
@@ -274,12 +274,12 @@ Definition comp_law_4  {CC : precategory} {C : tt_reindx_type_struct CC}
 
 
 
-
-Definition cwf_laws {CC : precategory}(C : tt_reindx_type_struct CC) 
+(* Note: the restriction now from categories to precategories is deliberate — we are insisting that cwf’s have hom-sets. *)
+Definition cwf_laws {CC : category} (C : tt_reindx_type_struct CC) 
    :=
     (∑ T : reindx_laws C,
        (comp_laws_1_2 T × comp_law_3 T × comp_law_4 T)) ×
-    (has_homsets CC × (*∏ Γ, isaset (C⟨Γ⟩) × *) ∏ Γ (A : C⟨Γ⟩), isaset (C⟨Γ⊢ A⟩)). 
+    (∏ Γ (A : C⟨Γ⟩), isaset (C⟨Γ⊢ A⟩)). 
 
 (** * Definition of precategory with families *)
 (** A precategory with families [pre_cwf] is 
@@ -292,7 +292,7 @@ Definition cwf_laws {CC : precategory}(C : tt_reindx_type_struct CC)
 *)
 
 
-Definition cwf_struct (CC : precategory) : UU 
+Definition cwf_struct (CC : category) : UU 
   := ∑ C : tt_reindx_type_struct CC, cwf_laws C.
 
 (** * Various access functions to the components *)
@@ -300,36 +300,35 @@ Definition cwf_struct (CC : precategory) : UU
     generalized proofs of identity of types, terms (which form hsets) 
 *)
 
-Coercion cwf_data_from_cwf_struct (CC : precategory) (C : cwf_struct CC) : _ CC := pr1 C.
-Coercion cwf_laws_from_cwf_struct (CC : precategory) (C : cwf_struct CC) : cwf_laws C := pr2 C.
+Coercion cwf_data_from_cwf_struct (CC : category) (C : cwf_struct CC)
+  : tt_reindx_type_struct CC
+  := pr1 C.
 
+Coercion cwf_laws_from_cwf_struct (CC : category) (C : cwf_struct CC)
+  : cwf_laws C
+  := pr2 C.
 
-Coercion reindx_laws_from_cwf_struct (CC : precategory) (C : cwf_struct CC)
+Coercion reindx_laws_from_cwf_struct (CC : category) (C : cwf_struct CC)
   : reindx_laws C
   := pr1 (pr1 (pr2 C)).
 
-
-Definition cwf_comp_laws {CC : precategory} (C : cwf_struct CC)
+Definition cwf_comp_laws {CC : category} (C : cwf_struct CC)
   : (comp_laws_1_2 C × comp_law_3 C × comp_law_4 C)
   := pr2 (pr1 (pr2 C)).
 
-
-Definition has_homsets_cwf {CC : precategory} (C : cwf_struct CC) : has_homsets CC
-  := pr1 (pr2 (pr2 C)).
-
-Definition cwf_types_isaset {CC : precategory} (C : cwf_struct CC) Γ : isaset (C⟨Γ⟩)
+Definition cwf_types_isaset {CC : category} (C : cwf_struct CC) Γ : isaset (C⟨Γ⟩)
   := setproperty (C⟨Γ⟩).
 
-Definition cwf_terms_isaset  {CC : precategory} (C : cwf_struct CC) : ∏ Γ A, isaset (C⟨Γ ⊢ A⟩)
-  :=  (pr2 (pr2 (pr2 C))).
+Definition cwf_terms_isaset  {CC : category} (C : cwf_struct CC) : ∏ Γ A, isaset (C⟨Γ ⊢ A⟩)
+  :=  (pr2 (pr2 C)).
 
 
-Definition cwf_law_1 {CC : precategory} (C : cwf_struct CC) 
+Definition cwf_law_1 {CC : category} (C : cwf_struct CC) 
   Γ (A : C ⟨Γ⟩) Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢ A[[γ]]⟩)
   : (γ ♯ a) ;; (π _) = γ
   :=  pr1 (pr1 (cwf_comp_laws C) Γ A Γ' γ a).
 
-Definition cwf_law_2 {CC : precategory} (C : cwf_struct CC) 
+Definition cwf_law_2 {CC : category} (C : cwf_struct CC) 
   Γ (A : C ⟨Γ⟩) Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢ A[[γ]]⟩)
   : transportf (λ ι, C⟨Γ'⊢ A [[ι]]⟩) (cwf_law_1 C Γ A Γ' γ a)
     (transportf (λ B, C⟨Γ'⊢ B⟩) (!reindx_type_comp (π _)(γ ♯ a) _ ) 
@@ -337,7 +336,7 @@ Definition cwf_law_2 {CC : precategory} (C : cwf_struct CC)
     = a
   := pr2 ((pr1 (cwf_comp_laws C)) Γ A Γ' γ a).
 
-Definition cwf_law_2_gen {CC : precategory} (C : cwf_struct CC) 
+Definition cwf_law_2_gen {CC : category} (C : cwf_struct CC) 
   Γ (A : C ⟨Γ⟩) Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢ A[[γ]]⟩)
   :  ∏ (p : (A [[π A]]) [[γ ♯ a]] = A [[γ ♯ a;; π A]]) (p0 : γ ♯ a;; π A = γ),
    transportf (λ ι : Γ' --> Γ, C ⟨ Γ' ⊢ A [[ι]] ⟩) p0
@@ -346,17 +345,17 @@ Proof.
   intros p p'.
   etrans; [ | apply cwf_law_2].
   match goal with | [ |- _ = transportf _ ?p1 _ ] => assert (T : p' = p1) end. 
-  { apply (has_homsets_cwf C). }
+  { apply homset_property. }
   rewrite T; clear T. apply maponpaths.
   match goal with | [ |- _ = transportf _ ?p1 _ ] => assert (T : p = p1) end.
   { apply (cwf_types_isaset C). }
   rewrite T; apply idpath.
 Qed.  
 
-Definition cwf_law_3 {CC : precategory} (C : cwf_struct CC) : comp_law_3 C
+Definition cwf_law_3 {CC : category} (C : cwf_struct CC) : comp_law_3 C
   :=  pr1 (pr2 (cwf_comp_laws C)).
 
-Definition cwf_law_3_gen {CC : precategory} (C : cwf_struct CC) 
+Definition cwf_law_3_gen {CC : category} (C : cwf_struct CC) 
   (Γ : CC) (A : C ⟨ Γ ⟩) (Γ' Γ'' : CC) (γ : Γ' --> Γ) (γ' : Γ'' --> Γ')
   (a : C ⟨ Γ' ⊢ A [[γ]] ⟩) (p : (A [[γ]]) [[γ']] = A [[γ';; γ]]):
    γ';; γ ♯ a =
@@ -369,15 +368,12 @@ Proof.
   rewrite T; apply idpath.
 Qed.
 
-Definition cwf_law_4 {CC : precategory} (C : cwf_struct CC) : comp_law_4 C
+Definition cwf_law_4 {CC : category} (C : cwf_struct CC) : comp_law_4 C
   := pr2 (pr2 (cwf_comp_laws C)).
-
-
 
 Ltac imp := apply impred; intro.
 
-
-Lemma isPredicate_cwf_laws (CC : precategory)
+Lemma isPredicate_cwf_laws (CC : category)
 : isPredicate (@cwf_laws CC).
 Proof.
   intros T.
@@ -386,26 +382,17 @@ Proof.
   set (X:= tpair _ T H : cwf_struct CC).
   apply (isofhleveltotal2).
   - apply isofhleveltotal2.
-    + apply isofhleveltotal2.
-      * intros.
-        do 3 imp. apply (cwf_terms_isaset X).
-      * intros.
-        do 7 imp. apply (cwf_terms_isaset X).
+    + apply isofhleveltotal2;
+      intros; repeat imp; apply (cwf_terms_isaset X).
     + intros.
-      repeat (apply isofhleveldirprod).
-      *
-        {
-          do 5 imp.
-          apply (isofhleveltotal2 1).
-          - apply (has_homsets_cwf X).
-          - intros. apply (cwf_terms_isaset X).
-        }
-      * do 7 imp. apply (has_homsets_cwf X).
-      * do 2 imp. apply (has_homsets_cwf X).
+      repeat (apply isofhleveldirprod); repeat imp;
+        try apply homset_property.
+      apply (isofhleveltotal2 1).
+      * apply homset_property.
+      * intros. apply (cwf_terms_isaset X).
   - intros.
     repeat (apply isofhleveldirprod).
-    + apply isaprop_has_homsets.
-    + do 2 imp. apply isapropisaset.
+    do 2 imp. apply isapropisaset.
 Qed.
     
 
@@ -686,7 +673,7 @@ Proof.
   apply idpath.
 Qed.
 
-Definition dpr_q_pbpairing_precwf_unique (hs : has_homsets CC)
+Definition dpr_q_pbpairing_precwf_unique
   {Γ} (A : C⟨Γ⟩)
   {Γ'} (f : Γ' --> Γ)
   {X} (h : X --> Γ ∙ A) (k : X --> Γ') (H : h ;; π A = k ;; f)
@@ -697,10 +684,10 @@ Proof.
   destruct t as [hk [e2 e1] ]. 
   unshelve refine (@total2_paths_f _ _ (tpair _ hk (tpair _ e2 e1)) _ 
     (dpr_q_pbpairing_precwf_mapunique A f H hk e2 e1) _).
-  unshelve refine (total2_paths_f _ _); apply hs.
+  unshelve refine (total2_paths_f _ _); apply homset_property.
 Qed.
 
-Lemma is_pullback_reindx_cwf (hs : has_homsets CC) : ∏ (Γ : CC) (A : C⟨Γ⟩) (Γ' : CC) 
+Lemma is_pullback_reindx_cwf : ∏ (Γ : CC) (A : C⟨Γ⟩) (Γ' : CC) 
    (f : Γ' --> Γ),
    isPullback (dpr_q_precwf A f).
 Proof.
@@ -709,7 +696,6 @@ Proof.
   intros e h k H.
   exists (dpr_q_pbpairing_precwf _ _ h k H).
   apply dpr_q_pbpairing_precwf_unique.
-  assumption.
 Defined.
   
 End CwF_lemmas.

--- a/TypeTheory/OtherDefs/CwF_1.v
+++ b/TypeTheory/OtherDefs/CwF_1.v
@@ -5,7 +5,7 @@
 
   Contents:
 
-    - Definition of a precategory with families
+    - Definition of a category with families
     - Proof that reindexing forms a pullback
 
   The definition is based on Pitts, *Nominal Presentations of the Cubical Sets
@@ -36,8 +36,8 @@ Reserved Notation "'π' A" (at level 20).
 Reserved Notation "'ν' A" (at level 15).
 Reserved Notation "γ ♯ a" (at level 25).
 (*
-Record precwf_record : Type := {
-  C : precategory ;
+Record cwf_record : Type := {
+  C : category ;
   Ty : functor C HSET     where "C ⟨ Γ ⟩" := (Ty Γ) ;
   term : ∏ Γ : C, pr1hSet (Ty Γ) → UU     where "C ⟨ Γ ⊢ A ⟩" := (term Γ A) ;
 (*  rtype : ∏ {Γ Γ' : C} (A : pr1hSet (Ty Γ)) (γ : Γ' --> Γ), pr1hSetC⟨Γ'⟩ where "A [[ γ ]]" := (rtype A γ) ; *)
@@ -61,12 +61,12 @@ Record precwf_record : Type := {
   gen_element : ∏ Γ (A : C⟨Γ⟩), C⟨Γ∙A ⊢ A[[π _ ]]⟩ where "'ν' A" := (gen_element _ A) ;
   pairing : ∏ Γ (A : C⟨Γ⟩) Γ' (γ : Γ' --> Γ)(a : C⟨Γ'⊢ A[[γ]]⟩), Γ' --> Γ∙A 
      where "γ ♯ a" := (pairing _ _ _  γ a) ;
-  pre_cwf_law_1 : ∏ Γ (A : C ⟨Γ⟩) Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢ A[[γ]]⟩), 
+  cwf_law_1 : ∏ Γ (A : C ⟨Γ⟩) Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢ A[[γ]]⟩), 
           (γ ♯ a) ;; (π _) 
           = 
           γ ;
-  pre_cwf_law_2 : ∏ Γ (A : C ⟨Γ⟩) Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢ A[[γ]]⟩),
-          transportf (λ ι, C⟨Γ'⊢ A [[ι]]⟩) (pre_cwf_law_1 Γ A Γ' γ a)
+  cwf_law_2 : ∏ Γ (A : C ⟨Γ⟩) Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢ A[[γ]]⟩),
+          transportf (λ ι, C⟨Γ'⊢ A [[ι]]⟩) (cwf_law_1 Γ A Γ' γ a)
              (transportf (λ B, C⟨Γ'⊢ B⟩) (!reindx_type_comp (π _ )(γ ♯ a) _ )
                 ((ν A) ⟦γ ♯ a⟧))
           = 
@@ -77,10 +77,14 @@ End Record_Preview.
 
 
 (** * Type and terms of a [CwF] *)
+
+(* Note: in the end, we define not pre-cwfs but cwfs, assuming an underlying _category_ with homsets.  But for the “data” stages of the definition, we just take an underlying precategory. *)
+
 (** 
- A [tt_precategory] comes with a types, written [C⟨Γ⟩], 
+ A [cwf] comes with types, written [C⟨Γ⟩], 
    and terms [C⟨Γ ⊢ A⟩] 
 *)
+
 
 Definition tt_structure (C : precategory) :=
   ∑ f : functor C^op HSET, ∏ c : C, pr1hSet (f c) → UU.
@@ -281,9 +285,9 @@ Definition cwf_laws {CC : category} (C : tt_reindx_type_struct CC)
        (comp_laws_1_2 T × comp_law_3 T × comp_law_4 T)) ×
     (∏ Γ (A : C⟨Γ⟩), isaset (C⟨Γ⊢ A⟩)). 
 
-(** * Definition of precategory with families *)
-(** A precategory with families [pre_cwf] is 
-  - a precategory
+(** * Definition of category with families *)
+(** A category with families [cwf] is 
+  - a category
   - with type-and-term structure 
   - with reindexing 
   - with comprehension structure
@@ -403,7 +407,7 @@ Section CwF_lemmas.
 Generalizable Variable CC.
 Context `{C : cwf_struct CC}.
 
-Lemma map_to_comp_as_pair_precwf {Γ} {A : C⟨Γ⟩} {Γ'} (f : Γ' --> Γ∙A)
+Lemma map_to_comp_as_pair_cwf {Γ} {A : C⟨Γ⟩} {Γ'} (f : Γ' --> Γ∙A)
   :   (f ;; π A) ♯ (transportb _ (reindx_type_comp _ _ _) ((gen_elem A)⟦f⟧))
       = 
       f.
@@ -503,8 +507,8 @@ Proof.
   apply idpath.
 Qed.
 
-(* TODO: consider giving this instead of current [pre_cwf_law_2] ? *)
-Definition pre_cwf_law_2' Γ (A : C ⟨ Γ ⟩) Γ' (γ : Γ' --> Γ) (a : C ⟨ Γ' ⊢ A[[γ]] ⟩)
+(* TODO: consider giving this instead of current [cwf_law_2] ? *)
+Definition cwf_law_2' Γ (A : C ⟨ Γ ⟩) Γ' (γ : Γ' --> Γ) (a : C ⟨ Γ' ⊢ A[[γ]] ⟩)
   : (ν A) ⟦γ ♯ a⟧
   = transportf _ (reindx_type_comp _ _ _)
       (transportb _ (maponpaths (fun g => A[[g]]) (cwf_law_1 _ _ _ _ _ _))
@@ -530,7 +534,7 @@ Proof.
   apply id_right.
 Defined.
 
-Definition q_precwf {Γ} (A : C ⟨ Γ ⟩ ) {Γ'} (f : Γ' --> Γ)
+Definition q_cwf {Γ} (A : C ⟨ Γ ⟩ ) {Γ'} (f : Γ' --> Γ)
   : (comp_obj  Γ' (A[[f]])) --> (Γ ∙ A).
 Proof.
   set (T:= @pairing _ C).
@@ -539,12 +543,12 @@ Proof.
   apply gen_elem.
 Defined.
 
-Definition dpr_q_precwf 
+Definition dpr_q_cwf 
   {Γ} (A : C ⟨ Γ ⟩)
   {Γ'} (f : Γ' --> Γ)
-: (q_precwf A f) ;; (π A) = (π (A[[f]])) ;; f.
+: (q_cwf A f) ;; (π A) = (π (A[[f]])) ;; f.
 Proof.
-  unfold q_precwf.
+  unfold q_cwf.
   apply cwf_law_1.
 Qed.
 
@@ -552,15 +556,15 @@ Qed.
 Lemma rterm_univ {Γ} {A : C ⟨ Γ ⟩} {Γ'} (f : Γ' --> Γ)
   : ν (A[[f]])
    = transportf _ (reindx_type_comp _ _ _)
-       (transportf _ (maponpaths (fun g => A[[g]]) (dpr_q_precwf A f))
+       (transportf _ (maponpaths (fun g => A[[g]]) (dpr_q_cwf A f))
          (transportb _ (reindx_type_comp _ _ _)
-            ((ν A)⟦q_precwf A f⟧))).
+            ((ν A)⟦q_cwf A f⟧))).
 Proof.
   sym.
   rew_trans_@.
   etrans.
   - apply maponpaths.
-    apply pre_cwf_law_2'.
+    apply cwf_law_2'.
   - rew_trans_@.
     apply term_typeeq_transport_lemma_2.
     apply idpath.
@@ -576,7 +580,7 @@ We split this up into several lemmas:
 
 *)
 
-Definition dpr_q_pbpairing_precwf_aux
+Definition dpr_q_pbpairing_cwf_aux
   {Γ} (A : C ⟨ Γ ⟩)
   {Γ'} (f : Γ' --> Γ)
   {X} (h : X --> Γ ∙ A) (k : X --> Γ') (H : h ;; π A = k ;; f)
@@ -590,16 +594,16 @@ Definition dpr_q_pbpairing_commutes
   {Γ} (A : C ⟨ Γ ⟩)
   {Γ'} (f : Γ' --> Γ)
   {X} (h : X --> Γ ∙ A) (k : X --> Γ') (H : h ;; π A = k ;; f)
-  (hk := @pairing _ C Γ' (A[[f]]) X k (dpr_q_pbpairing_precwf_aux A f h k H))
-: (hk ;; q_precwf A f = h) × (hk ;; π (A[[f]]) = k).
+  (hk := @pairing _ C Γ' (A[[f]]) X k (dpr_q_pbpairing_cwf_aux A f h k H))
+: (hk ;; q_cwf A f = h) × (hk ;; π (A[[f]]) = k).
 Proof.
   split. 2: { apply cwf_law_1. }
-  unfold q_precwf.
+  unfold q_cwf.
   etrans.
-  2: { apply map_to_comp_as_pair_precwf. }
+  2: { apply map_to_comp_as_pair_cwf. }
   etrans.
     apply cwf_law_3.
-  assert ((k ♯ (dpr_q_pbpairing_precwf_aux A f h k H)) ;; (π (A [[f]]) ;; f) 
+  assert ((k ♯ (dpr_q_pbpairing_cwf_aux A f h k H)) ;; (π (A [[f]]) ;; f) 
           = h ;; π A) as e1.
     eapply pathscomp0. apply assoc.
     refine (_ @ !H).
@@ -610,7 +614,7 @@ Proof.
   eapply pathscomp0. apply transport_f_f.
   eapply pathscomp0. apply maponpaths. refine (! rterm_typeeq _ _ _).
   eapply pathscomp0. apply transport_f_f.
-  eapply pathscomp0. apply maponpaths, pre_cwf_law_2'.
+  eapply pathscomp0. apply maponpaths, cwf_law_2'.
   rew_trans_@.
   eapply pathscomp0. apply maponpaths, transportf_rtype_mapeq.
   repeat (eapply pathscomp0; [ apply transport_f_f | ]).
@@ -618,30 +622,30 @@ Proof.
   apply cwf_types_isaset.
 Qed.
 
-Definition dpr_q_pbpairing_precwf
+Definition dpr_q_pbpairing_cwf
   {Γ} (A : C ⟨ Γ ⟩)
   {Γ'} (f : Γ' --> Γ)
   {X} (h : X --> Γ ∙ A) (k : X --> Γ') (H : h ;; π A = k ;; f)
 : ∑ (hk : X --> Γ' ∙ (A[[f]])),
-    ( hk ;; q_precwf A f = h
+    ( hk ;; q_cwf A f = h
     × hk ;; π (A[[f]]) = k).
 Proof.
-  exists (@pairing _ C Γ' (A[[f]]) X k (dpr_q_pbpairing_precwf_aux A f h k H)).
+  exists (@pairing _ C Γ' (A[[f]]) X k (dpr_q_pbpairing_cwf_aux A f h k H)).
   apply dpr_q_pbpairing_commutes.
 Defined.
 
 
-Definition dpr_q_pbpairing_precwf_mapunique
+Definition dpr_q_pbpairing_cwf_mapunique
   {Γ} (A : C⟨Γ⟩)
   {Γ'} (f : Γ' --> Γ)
   {X} {h : X --> Γ ∙ A} {k : X --> Γ'} (H : h ;; π A = k ;; f)
   (hk : X --> Γ' ∙ (A [[f]]))
-  (e2 : hk ;; q_precwf A f = h)
+  (e2 : hk ;; q_cwf A f = h)
   (e1 : hk ;; π (A[[f]]) = k)
-: hk = pr1 (dpr_q_pbpairing_precwf A f h k H).
+: hk = pr1 (dpr_q_pbpairing_cwf A f h k H).
 Proof.
   eapply pathscomp0.
-    eapply pathsinv0. apply map_to_comp_as_pair_precwf.
+    eapply pathsinv0. apply map_to_comp_as_pair_cwf.
   eapply pathscomp0.
     apply (pairing_mapeq _ _ e1 _).
   simpl. apply maponpaths.
@@ -673,29 +677,29 @@ Proof.
   apply idpath.
 Qed.
 
-Definition dpr_q_pbpairing_precwf_unique
+Definition dpr_q_pbpairing_cwf_unique
   {Γ} (A : C⟨Γ⟩)
   {Γ'} (f : Γ' --> Γ)
   {X} (h : X --> Γ ∙ A) (k : X --> Γ') (H : h ;; π A = k ;; f)
   (t : ∑ hk : X --> Γ' ∙ (A [[f]]),
-       (hk ;; q_precwf A f = h) × (hk ;; π (A[[f]]) = k))
-: t = dpr_q_pbpairing_precwf A f h k H.
+       (hk ;; q_cwf A f = h) × (hk ;; π (A[[f]]) = k))
+: t = dpr_q_pbpairing_cwf A f h k H.
 Proof.
   destruct t as [hk [e2 e1] ]. 
   unshelve refine (@total2_paths_f _ _ (tpair _ hk (tpair _ e2 e1)) _ 
-    (dpr_q_pbpairing_precwf_mapunique A f H hk e2 e1) _).
+    (dpr_q_pbpairing_cwf_mapunique A f H hk e2 e1) _).
   unshelve refine (total2_paths_f _ _); apply homset_property.
 Qed.
 
 Lemma is_pullback_reindx_cwf : ∏ (Γ : CC) (A : C⟨Γ⟩) (Γ' : CC) 
    (f : Γ' --> Γ),
-   isPullback (dpr_q_precwf A f).
+   isPullback (dpr_q_cwf A f).
 Proof.
   intros.
   apply make_isPullback; try assumption.
   intros e h k H.
-  exists (dpr_q_pbpairing_precwf _ _ h k H).
-  apply dpr_q_pbpairing_precwf_unique.
+  exists (dpr_q_pbpairing_cwf _ _ h k H).
+  apply dpr_q_pbpairing_cwf_unique.
 Defined.
   
 End CwF_lemmas.

--- a/TypeTheory/OtherDefs/CwF_Pitts.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts.v
@@ -61,12 +61,12 @@ Record cwf_record : Type := {
   gen_element : ∏ Γ (A : C⟨Γ⟩), C⟨Γ∙A ⊢ A{{π _ }}⟩ where "'ν' A" := (gen_element _ A) ;
   pairing : ∏ Γ (A : C⟨Γ⟩) Γ' (γ : Γ' --> Γ)(a : C⟨Γ'⊢ A{{γ}}⟩), Γ' --> Γ∙A 
      where "γ ♯ a" := (pairing _ _ _  γ a) ;
-  pre_cwf_law_1 : ∏ Γ (A : C ⟨Γ⟩) Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢ A{{γ}}⟩), 
+  cwf_law_1 : ∏ Γ (A : C ⟨Γ⟩) Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢ A{{γ}}⟩), 
           (γ ♯ a) ;; (π _) 
           = 
           γ ;
-  pre_cwf_law_2 : ∏ Γ (A : C ⟨Γ⟩) Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢ A{{γ}}⟩),
-          transportf (λ ι, C⟨Γ'⊢ A {{ι}}⟩) (pre_cwf_law_1 Γ A Γ' γ a)
+  cwf_law_2 : ∏ Γ (A : C ⟨Γ⟩) Γ' (γ : Γ' --> Γ) (a : C⟨Γ'⊢ A{{γ}}⟩),
+          transportf (λ ι, C⟨Γ'⊢ A {{ι}}⟩) (cwf_law_1 Γ A Γ' γ a)
              (transportf (λ B, C⟨Γ'⊢ B⟩) (!reindx_type_comp (π _ )(γ ♯ a) _ )
                 ((ν A) ⟦γ ♯ a⟧))
           = 
@@ -267,7 +267,7 @@ Definition cwf_laws {CC : category} (C : tt_reindx_type_struct CC)
     × ∏ Γ (A : C⟨Γ⟩), isaset (C⟨Γ⊢ A⟩). 
 
 (** * Definition of category with families *)
-(** A category with families [pre_cwf] is 
+(** A category with families [cwf] is 
   - a category
   - with type-and-term structure 
   - with reindexing 
@@ -506,8 +506,8 @@ Proof.
   apply idpath.
 Qed.
 
-(* TODO: consider giving this instead of current [pre_cwf_law_2] ? *)
-Definition pre_cwf_law_2' Γ (A : C ⟨ Γ ⟩) Γ' (γ : Γ' --> Γ) (a : C ⟨ Γ' ⊢ A{{γ}} ⟩)
+(* TODO: consider giving this instead of current [cwf_law_2] ? *)
+Definition cwf_law_2' Γ (A : C ⟨ Γ ⟩) Γ' (γ : Γ' --> Γ) (a : C ⟨ Γ' ⊢ A{{γ}} ⟩)
   : (ν A) ⟦γ ♯ a⟧
   = transportf _ (reindx_type_comp C _ _ _)
       (transportb _ (maponpaths (fun g => A{{g}}) (cwf_law_1 _ _ _ _ _ _))
@@ -563,7 +563,7 @@ Proof.
   rew_trans_@.
   etrans.
   - apply maponpaths.
-    apply pre_cwf_law_2'.
+    apply cwf_law_2'.
   - rew_trans_@.
     apply term_typeeq_transport_lemma_2.
     apply idpath.
@@ -613,7 +613,7 @@ Proof.
   eapply pathscomp0. apply transport_f_f.
   eapply pathscomp0. apply maponpaths. refine (! rterm_typeeq _ _ _).
   eapply pathscomp0. apply transport_f_f.
-  eapply pathscomp0. apply maponpaths, pre_cwf_law_2'.
+  eapply pathscomp0. apply maponpaths, cwf_law_2'.
   rew_trans_@.
   eapply pathscomp0. apply maponpaths, transportf_rtype_mapeq.
   repeat (eapply pathscomp0; [ apply transport_f_f | ]).

--- a/TypeTheory/OtherDefs/CwF_Pitts.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts.v
@@ -676,7 +676,7 @@ Proof.
   apply idpath.
 Qed.
 
-Definition dpr_q_pbpairing_cwf_unique (hs : has_homsets CC)
+Definition dpr_q_pbpairing_cwf_unique
   {Γ} (A : C⟨Γ⟩)
   {Γ'} (f : Γ' --> Γ)
   {X} (h : X --> Γ ∙ A) (k : X --> Γ') (H : h ;; π A = k ;; f)
@@ -687,10 +687,10 @@ Proof.
   destruct t as [hk [e2 e1]]. 
   refine (@total2_paths_f _ _ (tpair _ hk (tpair _ e2 e1)) _ 
     (dpr_q_pbpairing_cwf_mapunique A f H hk e2 e1) _).
-  unshelve refine (total2_paths_f _ _); apply hs.
+  unshelve refine (total2_paths_f _ _); apply homset_property.
 Qed.
 
-Lemma is_pullback_reindx_cwf (hs : has_homsets CC) : ∏ (Γ : CC) (A : C⟨Γ⟩) (Γ' : CC) 
+Lemma is_pullback_reindx_cwf : ∏ (Γ : CC) (A : C⟨Γ⟩) (Γ' : CC) 
    (f : Γ' --> Γ),
    isPullback (dpr_q_cwf A f).
 Proof.
@@ -699,7 +699,6 @@ Proof.
   intros e h k H.
   exists (dpr_q_pbpairing_cwf _ _ h k H).
   apply dpr_q_pbpairing_cwf_unique.
-  assumption.
 Defined.
   
 End CwF_lemmas.

--- a/TypeTheory/OtherDefs/CwF_Pitts_completion.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_completion.v
@@ -1,9 +1,9 @@
 
-(** * From preCwFs to CwFs *)
+(** * From CwFs to univalent CwFs *)
 (**
   Contents:
 
-    - not much yet
+    - goal (not yet complete): transfer of CwF structure along the Rezk-completion construction
 *)
 
 Require Import UniMath.Foundations.Sets.
@@ -18,7 +18,7 @@ Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 Require Import TypeTheory.OtherDefs.CwF_Pitts.
 Require Import TypeTheory.Categories.category_of_elements.
 
-Arguments iso: clear implicits.
+Local Arguments iso: clear implicits.
 
 (** How to get a functor from RC(C) to D when having one from C to D **)
 

--- a/TypeTheory/OtherDefs/CwF_Pitts_natural.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_natural.v
@@ -30,12 +30,10 @@ Local Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op").
 (** * A "preview" of the definition *)
 
 Module Preview.
-
-Let hsHSET := has_homsets_HSET.
   
 Variable C : precategory.
 Variable hs : has_homsets C. 
-Variable Ty Tm: [C^op, HSET, hsHSET]. (* functor C^op HSET. *)
+Variable Ty Tm: [C^op, HSET]. (* functor C^op HSET. *)
 Variable p : _ ⟦Tm, Ty⟧. (* needs to be written as mor in a precat *)
 
 Variable comp : forall (Γ : C) (A : pr1hSet ((Ty : functor _ _ ) Γ)), C.
@@ -74,17 +72,15 @@ End Preview.
 
 Section definition.
 
-Let hsHSET := has_homsets_HSET.
-
 Variable C : precategory.
 Variable hsC : has_homsets C.
 
 Definition tt_structure : UU :=
-  ∑ TyTm : [C^op, HSET, hsHSET] × [C^op, HSET, hsHSET],
+  ∑ TyTm : [C^op, HSET] × [C^op, HSET],
            _ ⟦pr2 TyTm, pr1 TyTm⟧.
 
-Definition Ty (X : tt_structure) : [C^op, HSET, hsHSET] := pr1 (pr1 X).
-Definition Tm (X : tt_structure) : [C^op, HSET, hsHSET] := pr2 (pr1 X).
+Definition Ty (X : tt_structure) : [C^op, HSET] := pr1 (pr1 X).
+Definition Tm (X : tt_structure) : [C^op, HSET] := pr2 (pr1 X).
 Definition p (X : tt_structure) :  _ ⟦Tm X, Ty X⟧ := pr2 X.
 
 Definition comp_structure (X : tt_structure) : UU :=

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_DM.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_DM.v
@@ -96,14 +96,11 @@ Proof.
     + apply (π _ ). 
     + simpl. unfold dm_sub_struct_of_CwF.
       simpl.
-      set (T:= postcomp_pb_with_iso CC).
-      set (T':= T (homset_property _) _ _ _ _ (q_cwf A f) _ _ f _ (is_pullback_reindx_cwf (homset_property _) _ _ _ _ )).
-      refine (pr1 (T' _ _ _ _ )).
+      refine (pr1 (postcomp_pb_with_iso CC _ _ _ _ (q_cwf A f) _ _ f _
+            (is_pullback_reindx_cwf (homset_property _) _ _ _ _ ) _ _ _ _)).
       sym. assumption.
-    + 
-      set (T:= postcomp_pb_with_iso CC (homset_property _)).
-      set (T':= T _ _ _ _  (q_cwf A f) _ _ f _ (is_pullback_reindx_cwf (homset_property _) _ _ _ _ )).
-      eapply (pr2 (T' _ _ _ _ )).
+    + eapply (pr2 ( postcomp_pb_with_iso CC _ _ _ _  (q_cwf A f) _ _ f _
+              (is_pullback_reindx_cwf (homset_property _) _ _ _ _ ) _ _ _ _ )).
   - simpl.
     apply hinhpr.
     unfold iso_to_dpr.

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_DM.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_DM.v
@@ -97,10 +97,10 @@ Proof.
     + simpl. unfold dm_sub_struct_of_CwF.
       simpl.
       refine (pr1 (postcomp_pb_with_iso CC _ _ _ _ (q_cwf A f) _ _ f _
-            (is_pullback_reindx_cwf (homset_property _) _ _ _ _ ) _ _ _ _)).
+            (is_pullback_reindx_cwf _ _ _ _ ) _ _ _ _)).
       sym. assumption.
     + eapply (pr2 ( postcomp_pb_with_iso CC _ _ _ _  (q_cwf A f) _ _ f _
-              (is_pullback_reindx_cwf (homset_property _) _ _ _ _ ) _ _ _ _ )).
+              (is_pullback_reindx_cwf _ _ _ _ ) _ _ _ _ )).
   - simpl.
     apply hinhpr.
     unfold iso_to_dpr.

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat.v
@@ -52,9 +52,9 @@ End Prelims.
 (** * Type-cat from cat with Families *)
 
 (**
-Every pre-CwF gives rise to a type-category.
+Every CwF gives rise to a type-category.
 
-(TODO: moreover, this type-cat should be split; and there should be a function from split type-cats back to pre-CwFs making the two equivalent.)
+(TODO: moreover, this type-cat should be split; and there should be a function from split type-cats back to CwFs making the two equivalent.)
 
 Since the components of the type-cat structure are highly successively dependent, we construct most of them individually, before putting them together in [type_cat_of_cwf].
 *)
@@ -87,7 +87,7 @@ Defined.
 
 (** * Splitness of the constructed TypeCat *)
 
-(** Moreover, the type-cat of a pre-CwF is always split. *)
+(** Moreover, the type-cat of a CwF is always split. *)
 
 Definition issplit_type_cat_of_cwf
   : is_split_typecat type_cat_of_cwf.
@@ -160,7 +160,7 @@ Proof.
                        generalize e' end.
       clear p.
       intro p.
-      rewrite pre_cwf_law_2'.
+      rewrite cwf_law_2'.
       unfold transportb.
       rewrite transport_f_f.
       rewrite transport_f_f.
@@ -168,7 +168,7 @@ Proof.
       match goal with |[ |- _ = transportf _ ?e _ ⟦ _ ⟧ ] => generalize e end.
       intro q.
       etrans. 2: { apply rterm_typeeq. }
-      rewrite  pre_cwf_law_2'.
+      rewrite  cwf_law_2'.
       rewrite transport_f_f.
       unfold transportb.
       rewrite transport_f_f.

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat.v
@@ -84,7 +84,7 @@ Proof.
   exists (@q_cwf CC C).
   exists (@dpr_q_cwf CC C).
   intros; apply @is_symmetric_isPullback. { apply homs_sets. }
-  apply is_pullback_reindx_cwf. apply homs_sets.
+  apply is_pullback_reindx_cwf.
 Defined.
 
 (** * Splitness of the constructed TypeCat *)

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat.v
@@ -62,9 +62,7 @@ Since the components of the type-cat structure are highly successively dependent
 
 Section TypeCat_of_CwF.
 
-(* TODO: move the [has_homsets] assumption to the definition of a [pre_cwf]? 
-   TODO: discuss namine of [has_homsets]: wouldn’t e.g. [homs_are_sets] be clearer? *)
-Context (CC : category) (C : cwf_struct CC) (homs_sets : has_homsets CC).
+Context (CC : category) (C : cwf_struct CC).
 
 Definition type_cat1_of_cwf : typecat_structure1 CC.
 Proof.
@@ -83,7 +81,7 @@ Proof.
   exists (@proj_mor CC C).
   exists (@q_cwf CC C).
   exists (@dpr_q_cwf CC C).
-  intros; apply @is_symmetric_isPullback. { apply homs_sets. }
+  intros; apply @is_symmetric_isPullback. { apply homset_property. }
   apply is_pullback_reindx_cwf.
 Defined.
 

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat_to_DM.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat_to_DM.v
@@ -5,7 +5,7 @@
 
 Contents:
 
-  - Commutativity of the constructions between CwFs, type-(pre)cats, and DM-cats
+  - Commutativity of the constructions between CwFs, type-cats, and DM-cats
 
 *)
 

--- a/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat_to_DM.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_to_TypeCat_to_DM.v
@@ -26,7 +26,7 @@ Section compare_maps.
 
   Context (CC : category) (C : cwf_struct CC) (H : is_univalent CC).
 
-  Lemma maps_equal : DM_structure_of_TypeCat _ H (type_cat_of_cwf _ C (homset_property _)) = DM_structure_of_CwF _ C H.
+  Lemma maps_equal : DM_structure_of_TypeCat _ H (type_cat_of_cwf _ C) = DM_structure_of_CwF _ C H.
   Proof.
     apply DM_equal.
     - exact H.

--- a/TypeTheory/OtherDefs/DM.v
+++ b/TypeTheory/OtherDefs/DM.v
@@ -310,7 +310,7 @@ Definition sqr_comm_of_dm_sub_pb {CC : precategory} {C : dm_sub_pb CC}
 : _ ;; _ = _ ;; _ 
 := PullbackSqrCommutes (pr1 (pr2 C _ _ γ _ f )).
 
-Definition isPullback_of_dm_sub_pb {CC : precategory} (hs: has_homsets CC) {C : dm_sub_pb CC}
+Definition isPullback_of_dm_sub_pb {CC : category} {C : dm_sub_pb CC}
            {Δ Γ} (γ : DM C Δ Γ) {Γ'} (f : Γ' --> Γ)
 : isPullback _ :=
 isPullback_Pullback (pr1 (pr2 C _ _ γ _ f )).
@@ -372,10 +372,10 @@ Proof.
   apply sqr_comm_of_dm_sub_pb.
 Defined.
 
-Definition isPullback_of_DM {CC : precategory} (hs: has_homsets CC) {C : DM_structure CC} {Δ Γ} (γ : DM C Δ Γ) {Γ'} (f : Γ' --> Γ)
+Definition isPullback_of_DM {CC : category} {C : DM_structure CC} {Δ Γ} (γ : DM C Δ Γ) {Γ'} (f : Γ' --> Γ)
 : isPullback (sqr_comm_of_DM γ f).
 Proof.
-  apply isPullback_of_dm_sub_pb; assumption.
+  apply isPullback_of_dm_sub_pb.
 Defined.
 
 

--- a/TypeTheory/OtherDefs/DM_to_TypeCat.v
+++ b/TypeTheory/OtherDefs/DM_to_TypeCat.v
@@ -20,8 +20,7 @@ Require Import TypeTheory.Auxiliary.Auxiliary.
 
 Section DM_to_TypeCat.
 
-Variable CC : precategory.
-Variable hs : has_homsets CC. 
+Variable CC : category.
 Variable C : DM_structure CC.
 
 
@@ -60,9 +59,9 @@ Proof.
         - intros Γ A Γ' f.
           unshelve refine (sqr_comm_of_DM (( DM_from_DM_over A)) _ ).
         - intros.
-          apply is_symmetric_isPullback. { apply hs. }
-          refine (@isPullback_of_DM  _ _ _ _ _ _ _ _ ).
-          apply hs. }
+          apply is_symmetric_isPullback. { apply homset_property. }
+          refine (@isPullback_of_DM  _ _ _ _ _ _ _ ).
+      }
 Defined.
 
 Definition type_cat_struct_from_DM : typecat_structure CC.

--- a/TypeTheory/OtherDefs/DM_to_TypeCat_to_DM.v
+++ b/TypeTheory/OtherDefs/DM_to_TypeCat_to_DM.v
@@ -26,7 +26,7 @@ Variable CC : category.
 Variable H : is_univalent CC.  
 Variable C : DM_structure CC.
 
-Lemma DM_to_TypeCat_to_DM : DM_structure_of_TypeCat _ H (type_cat_struct_from_DM _ (homset_property _) C) = C.
+Lemma DM_to_TypeCat_to_DM : DM_structure_of_TypeCat _ H (type_cat_struct_from_DM _ C) = C.
 Proof.
   apply DM_equal.
   - assumption.

--- a/TypeTheory/OtherDefs/TypeCat_to_DM.v
+++ b/TypeTheory/OtherDefs/TypeCat_to_DM.v
@@ -83,13 +83,12 @@ Proof.
     + apply (dpr_typecat _ ).
     + simpl. unfold dm_sub_struct_of_TypeCat.
       simpl.
-      set (T:= postcomp_pb_with_iso CC (homset_property _)).
-      refine (pr1 (T _ _ _ _ (q_typecat A f) _ _ f _ _ _ _ _ _)).
+      (* TODO: improve implicit arguments of [postcomp_pb_with_iso] *)
+      refine (pr1 (postcomp_pb_with_iso CC _ _ _ _ _ _ _ _ _ _ _ _ _ _)).
       apply is_symmetric_isPullback. { apply homset_property. }
       apply reind_pb_typecat.
       sym. assumption.
-    + set (T:= postcomp_pb_with_iso CC (homset_property _)).
-      eapply (pr2 (T _ _ _ _ _ _ _ _ _ _ _ _ _ _)).
+    + eapply (pr2 (postcomp_pb_with_iso CC _ _ _ _ _ _ _ _ _ _ _ _ _ _)).
  - simpl.
     apply hinhpr.
     unfold iso_to_dpr.


### PR DESCRIPTION
Following UniMath/UniMath#1402 and #196 , this PR refactors throughout UniMath/TypeTheory to use more of the language of categories, and less of precategories.

I’ve aimed to be light-touch, and generally avoided changing mathematical content — where there were no [has_homsets] assumptions, I’ve left things in terms of precategories.  But wherever there were explicit has_homsets assumptions, I’ve repackaged in terms of categories, and similar.  Like with UniMath/UniMath#1402, I think this was in many places a clear improvement in readability, and never a worsening.