### PR TITLE
Added UniMath package dependencies in github workflow, to (hopefully) fix #199

### DIFF
--- a/.github/workflows/build-typetheory.yml
+++ b/.github/workflows/build-typetheory.yml
@@ -39,7 +39,7 @@ jobs:
           pwd
           git checkout master
           git show
-          make PACKAGES="Foundations MoreFoundations Combinatorics Algebra NumberSystems CategoryTheory Topology Ktheory PAdics" install
+          make PACKAGES="Foundations MoreFoundations Combinatorics Algebra NumberSystems PAdics CategoryTheory Bicategories Ktheory Topology SubstitutionSystems" install
           export PATH=$PATH:$PWD/sub/coq/bin/
           echo $PATH
           popd


### PR DESCRIPTION
If this works, it fixes #199, the broken CI build due to expanded (non-linear) package dependencies in UniMath.  To test whether this works, we need to see the CI run on it — hopefully that should happen automatically when this PR is issued.  So this PR should presumably be merged if and only if the CI succeeds!