### PR TITLE
propagates correction of a misnamed construction

### DIFF
--- a/TypeTheory/Auxiliary/CategoryTheory.v
+++ b/TypeTheory/Auxiliary/CategoryTheory.v
@@ -506,7 +506,7 @@ Definition nat_z_iso_from_pointwise_z_iso (D : precategory) (E : category)
   (H : is_nat_trans _ _ a)
   : z_iso F G.
 Proof.
-  use z_iso_from_z_nat_iso.
+  use z_iso_from_nat_z_iso.
   use tpair.
   - use tpair.
     + intro d. apply a.

--- a/TypeTheory/RelUniv/RelUnivTransfer.v
+++ b/TypeTheory/RelUniv/RelUnivTransfer.v
@@ -352,10 +352,10 @@ Section RelUniv_Transfer.
     Let AE := adjointificiation E.
     Let η' := pr1 (pr121 AE) : nat_trans (functor_identity _) (S ∙ invS).
     Let ε' := pr2 (pr121 AE) : nat_trans (invS ∙ S) (functor_identity _).
-    Let η := z_iso_from_z_nat_iso
+    Let η := z_iso_from_nat_z_iso
                _ (η',,pr12 (adjointificiation E))
             : z_iso (C:=[D, D]) (functor_identity D) (S ∙ invS).
-    Let ε := z_iso_from_z_nat_iso
+    Let ε := z_iso_from_nat_z_iso
                 _ (ε',,pr22 (adjointificiation E))
             : z_iso (C:=[D', D']) (invS ∙ S) (functor_identity D').
 
@@ -832,7 +832,7 @@ Section WeakRelUniv_Transfer.
     use (isotoid _ (is_univalent_functor_category _ _ _)).
     apply weak_reluniv_cat_is_univalent.
     apply D'cat.
-    apply z_iso_from_z_nat_iso.
+    apply z_iso_from_nat_z_iso.
     apply weak_relu_square_commutes.
   Defined.
 


### PR DESCRIPTION
This will be needed to restore compilation after merging PR 1532 of UniMath.