### PR TITLE
CI: Add Tactics and remove Bicategories and SubstitutionSystems.

### DIFF
--- a/.github/workflows/build-typetheory.yml
+++ b/.github/workflows/build-typetheory.yml
@@ -41,7 +41,7 @@ jobs:
           pwd
           git checkout master
           git show
-          make BUILD_COQ=yes PACKAGES="Foundations MoreFoundations Combinatorics Algebra NumberSystems PAdics CategoryTheory Bicategories Ktheory Topology SubstitutionSystems" install
+          make BUILD_COQ=yes PACKAGES="Foundations MoreFoundations Combinatorics Algebra NumberSystems PAdics CategoryTheory Ktheory Topology Tactics" install
           export PATH=$PATH:$PWD/sub/coq/bin/
           echo $PATH
           popd


### PR DESCRIPTION

Maybe the build in CI fails because PACKAGES does not contain Tactics? I have not been able to reproduce it locally. I also opted to remove Bicategories and SubstitutionSystems because they do not seem used at all by TypeTheory.

Marking this as draft just to see if the CI runs and it makes a difference.