### PR TITLE
replaces uses of setquotprpathsandR from PAdics

### DIFF
--- a/TypeTheory/Initiality/InterpretationLemmas.v
+++ b/TypeTheory/Initiality/InterpretationLemmas.v
@@ -1,7 +1,6 @@
 (** Further lemmas on the interpretation function, separated here in order to keep [TypeTheory.Initiality.Interpretation] itself reasonably streamlined *)
 
 Require Import UniMath.MoreFoundations.All.
-Require Import UniMath.PAdics.lemmas. (* just for [setquotprpathsandR] *)
 
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
@@ -375,7 +374,7 @@ Section Trivial_Interpretation.
         use show_return_leq_partial.
         * cbn.
           assert (isd_Γi_T : ∥ [! Γ |- Γ i === T !] ∥).
-          { refine (setquotprpathsandR _ _ _ e_Γi_T
+          { refine (invmap (weqpathsinsetquot _ _ _) e_Γi_T
                                        (context_as_context_representative Γ)). }
           refine (hinhfun3 _ (context_derivable Γ) isd_T isd_Γi_T);
             intros d_Γ d_T d_Γi_T.

--- a/TypeTheory/Initiality/SyntacticCategory.v
+++ b/TypeTheory/Initiality/SyntacticCategory.v
@@ -6,7 +6,6 @@ Require Import UniMath.MoreFoundations.All.
 Require Import UniMath.CategoryTheory.Core.Prelude.
 Require Import UniMath.CategoryTheory.limits.pullbacks.
 Require Import UniMath.CategoryTheory.limits.graphs.terminal.
-Require UniMath.PAdics.lemmas. (* just for [setquotprpathsandR] *)
 
 Require Import TypeTheory.Auxiliary.Auxiliary.
 Require Import TypeTheory.Auxiliary.CategoryTheory.
@@ -275,7 +274,7 @@ Section Contexts_Modulo_Equality.
       {ΓΓ : context_mod_eq} (Γ Γ' : context_representative ΓΓ)
     : ∥ derivation_flat_cxteq Γ Γ' ∥.
   Proof.
-    refine (UniMath.PAdics.lemmas.setquotprpathsandR (derivable_cxteq) Γ Γ' _).
+    refine (invmap (weqpathsinsetquot (derivable_cxteq) Γ Γ') _).
     exact (pr2 Γ @ ! pr2 Γ').
   Defined.
 
@@ -611,7 +610,7 @@ Section Syntactic_Types.
       {n} {ΓΓ : _ n} {AA : type_mod_eq ΓΓ} (A A' : type_representative AA)
     : typeeq_eqrel A A'.
   Proof.
-    refine (UniMath.PAdics.lemmas.setquotprpathsandR typeeq_eqrel A A' _).
+    refine (invmap (weqpathsinsetquot typeeq_eqrel A A') _).
     exact (pr2 A @ ! pr2 A').
   Defined.
 


### PR DESCRIPTION
uses invmap(weqpathsinsetquot _ _ _) instead

is meant to resolve issue #225 