### PR TITLE
Small cleanup

### DIFF
--- a/TypeTheory/Auxiliary/CategoryTheory.v
+++ b/TypeTheory/Auxiliary/CategoryTheory.v
@@ -31,7 +31,6 @@ Notation "C '^op'" := (opp_precat C) (at level 3, format "C ^op") : precat.
 Delimit Scope precat with precat.
 
 Open Scope cat.
-Open Scope cat_deprecated.
 
 (** * Isomorphism lemmas *)
 

--- a/TypeTheory/CompCats/DiscreteComprehensionCat.v
+++ b/TypeTheory/CompCats/DiscreteComprehensionCat.v
@@ -26,8 +26,6 @@ Require Import UniMath.Foundations.All.
 Require Import UniMath.MoreFoundations.All.
 Require Import TypeTheory.Auxiliary.CategoryTheoryImports.
 
-Require Import UniMath.CategoryTheory.categories.HSET.Univalence.
-
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
 Require Import UniMath.CategoryTheory.DisplayedCats.Functors.
 Require Import UniMath.CategoryTheory.DisplayedCats.Fibrations.
@@ -238,7 +236,7 @@ Section MorWithUniqueLift.
     apply funextsec; intros A.
     apply funextsec; intros A'.
     apply funextsec; intros f.
-    apply univalenceweq.
+    apply univalence.
     apply (pr2 D_mor).
   Defined.
 
@@ -252,7 +250,7 @@ Section MorWithUniqueLift.
       apply funextsec; intros A.
       apply funextsec; intros A'.
       apply funextsec; intros f.
-      apply univalenceweq.
+      apply univalence.
       apply (pr2 D_mor).
     - apply funextsec; intros Γ.
       apply funextsec; intros Γ'.


### PR DESCRIPTION
Removes use of [univalenceweq] which is a duplicate of [univalence]. Also removes the scope [cat_deprecated]. This scope is essentially empty and unused in TypeTheory.