### PR TITLE
makes the satellite repo compile again after upstream changes (PR1633…

### DIFF
--- a/TypeTheory/Auxiliary/CategoryTheory.v
+++ b/TypeTheory/Auxiliary/CategoryTheory.v
@@ -264,8 +264,7 @@ Lemma ff_reflects_pullbacks {C D : category} {F : functor C D}
       (F_ff : fully_faithful F) : reflects_pullbacks F.
 Proof.
   do 10 intro.
-  use (isPullback_preimage_square _ _ _ _ _ _ X).
-  - apply homset_property.
+  use (isPullback_preimage_square _ _ _ _ _ X).
   - apply F_ff.
 Defined.
 

--- a/TypeTheory/Auxiliary/Pullbacks.v
+++ b/TypeTheory/Auxiliary/Pullbacks.v
@@ -109,7 +109,7 @@ Section Pullback_transfers.
 (* Various results, generally showing that perturbing a pullback squares by equalities and/or isos is still a pullback. *)
 
 Lemma square_morphism_equal
-    {C : precategory} {a b c d : C}
+    {C : category} {a b c d : C}
     {f : a --> b} {g : a --> c} {k : b --> d} {h : c --> d}
     (sqr_comm : f ;; k = g ;; h)
     {k'} (e : k' = k)

--- a/TypeTheory/Auxiliary/Pullbacks.v
+++ b/TypeTheory/Auxiliary/Pullbacks.v
@@ -14,7 +14,7 @@ Require Import TypeTheory.Auxiliary.CategoryTheory.
 Section Pullback_Basics.
 
 Definition map_into_Pb
-    {C : precategory} {a b c d : C}
+    {C : category} {a b c d : C}
     {f : a --> b} {g : a --> c} {k : b --> d} {h : c --> d}
     {sqr_comm : f ;; k = g ;; h}
     (Pb : isPullback sqr_comm)
@@ -26,7 +26,7 @@ Proof.
 Defined.
 
 Definition Pb_map_commutes_1
-    {C : precategory} {a b c d : C}
+    {C : category} {a b c d : C}
     {f : a --> b} {g : a --> c} {k : b --> d} {h : c --> d}
     {sqr_comm : f ;; k = g ;; h}
     (Pb : isPullback sqr_comm)
@@ -37,7 +37,7 @@ Proof.
 Qed.
 
 Definition Pb_map_commutes_2
-    {C : precategory} {a b c d : C}
+    {C : category} {a b c d : C}
     {f : a --> b} {g : a --> c} {k : b --> d} {h : c --> d}
     {sqr_comm : f ;; k = g ;; h}
     (Pb : isPullback sqr_comm)
@@ -48,7 +48,7 @@ Proof.
 Qed.
 
 Lemma map_into_Pb_unique
-    {C : precategory} {a b c d : C}
+    {C : category} {a b c d : C}
     {f : a --> b} {g : a --> c} {k : b --> d} {h : c --> d}
     {sqr_comm : f ;; k = g ;; h}
     (Pb : isPullback sqr_comm)
@@ -64,7 +64,7 @@ Qed.
 
 (* In fact this is trivial, since the equality doesn’t appear in the type of the pullback. However, it’s convenient for proof scripts. *)
 Lemma isPullback_indepdent_of_path
-    {C : precategory} {a b c d : C}
+    {C : category} {a b c d : C}
     {f : a --> b} {g : a --> c} {k : b --> d} {h : c --> d}
     {sqr_comm : f ;; k = g ;; h}
     (Pb : isPullback sqr_comm)
@@ -76,7 +76,7 @@ Defined.
 
 (* Duplicate of [is_symmetric_isPullback] from UniMath, but without the un-needed [has_homsets]/[category] assumption *)
 Lemma is_symmetric_isPullback
-    {C : precategory}
+    {C : category}
     {a b c d : C} {f : b --> a} {g : c --> a}
     {p1 : d --> b} {p2 : d --> c} {H : p1 · f = p2 · g}
     (pb : isPullback H)
@@ -91,7 +91,7 @@ Defined.
 
 (* Variant of [is_symmetric_isPullback], more convenient for applying when reasoning bottom-up. *)
 Lemma is_symmetric'_isPullback
-    {C : precategory}
+    {C : category}
     {a b c d : C} {f : b --> a} {g : c --> a}
     {p1 : d --> b} {p2 : d --> c} {H : p1 · f = p2 · g}
     (pb : isPullback (! H))
@@ -119,7 +119,7 @@ Proof.
 Defined.
 
 Lemma isPb_morphism_equal
-    {C : precategory} {a b c d : C}
+    {C : category} {a b c d : C}
     {f : a --> b} {g : a --> c} {k : b --> d} {h : c --> d}
     (sqr_comm : f ;; k = g ;; h)
     (Pb : isPullback sqr_comm)

--- a/TypeTheory/Cubical/FillFromComp.v
+++ b/TypeTheory/Cubical/FillFromComp.v
@@ -290,7 +290,7 @@ Lemma isPullback_pF_e₀ I J (f : J --> I) :
   isPullback (nat_trans_ax p_F f) → isPullback (nat_trans_ax e₀ f).
 Proof.
 intros H.
-apply (isPullback_two_pullback (homset_property _) _ _ _ _ _ _ H).
+apply (isPullback_two_pullback _ _ _ _ _ _ H).
 intros K g h Hgh.
 use (unique_exists h); simpl in *.
 - rewrite <- Hgh.
@@ -528,7 +528,6 @@ Defined.
 Lemma glued_square_pb {I J} (f : J --> I) : isPullback (glued_square f).
 Proof.
 apply isPullbackGluedSquare.
-- apply functor_category_has_homsets.
 - apply Hδ₀_pb.
 - apply e₀_f_pb.
 Qed.
@@ -547,7 +546,6 @@ Proof.
 use Hδ₀_unique.
 - apply plus_δ₀_prf.
 - use (isPullback_mor_paths _ _ _ _ _ (plus_δ₀_prf f) (glued_square_pb f)); trivial.
-  + apply functor_category_has_homsets.
   + apply TerminalArrowUnique.
 Qed.
 

--- a/TypeTheory/CwF_TypeCat/CwF_SplitTypeCat_Maps.v
+++ b/TypeTheory/CwF_TypeCat/CwF_SplitTypeCat_Maps.v
@@ -592,8 +592,7 @@ Qed.
 
 Lemma isPullback_Yo_of_qq : isPullback Yo_of_qq_commutes_1.
 Proof.
-  simple refine (isPullback_two_pullback _ _ _ _ _ _ _ _ _ _ ).
-  - apply homset_property.
+  simple refine (isPullback_two_pullback _ _ _ _ _ _ _ _ _ ).
   - apply (TY X).
   - apply (TM Y).
   - apply (yy A).
@@ -634,8 +633,7 @@ Qed.
 
 Definition isPullback_qq : isPullback (!qq_commutes_1).
 Proof.
-  use (isPullback_preimage_square _ _ _ Yo).
-  - apply homset_property.
+  use (isPullback_preimage_square _ _ Yo).
   - apply yoneda_fully_faithful.
   - assert (XT:= isPullback_Yo_of_qq).
     match goal with |[|- isPullback ?HHH] => generalize HHH end.

--- a/TypeTheory/OtherDefs/CwF_Pitts_natural.v
+++ b/TypeTheory/OtherDefs/CwF_Pitts_natural.v
@@ -98,7 +98,7 @@ Definition pullback_structure {X : tt_structure} (Y : comp_structure X) : UU
           invmap (yoneda_weq C _ (Tm X)) (q Y Γ A) ;; p X 
           =
           #(yoneda _ ) (pi Y Γ A) ;; invmap (yoneda_weq _ _ (Ty X)) A , 
-         isPullback H.
+         isPullback(C:=[(C^op)%Cat, SET]) H.
 
 Definition comp_comm {X : tt_structure } {Y : comp_structure X} (Z : pullback_structure Y) 
   : forall Γ (A : Ty X $p Γ),
@@ -109,7 +109,7 @@ Definition comp_comm {X : tt_structure } {Y : comp_structure X} (Z : pullback_st
 
 Definition is_Pullback_comp {X : tt_structure } {Y : comp_structure X} (Z : pullback_structure Y) 
   : forall Γ (A : Ty X $p Γ),
-      isPullback (comp_comm Z _ _ ) 
+      isPullback(C:=[(C^op)%Cat, SET]) (comp_comm Z _ _ ) 
   := fun Γ A => pr2 (Z Γ A).
 
 Definition is_natural_CwF : UU 

--- a/TypeTheory/OtherDefs/DM.v
+++ b/TypeTheory/OtherDefs/DM.v
@@ -39,7 +39,7 @@ Reserved Notation "γ ⋆ f" (at level 25).
 
 
 Record CwDM := {
-  C : precategory ;
+  C : category ;
   DM : ∏ {Δ Γ : C}, Δ --> Γ → hProp ;
   pb : ∏ {Δ Γ : C} (γ : ∑ f : Δ --> Γ, DM f) {Γ'} (f : Γ' --> Γ), C  where "γ ⋆ f" := (pb γ f) ;
   pb_DM_of_DM : ∏  {Δ Γ} (γ : ∑ f : Δ --> Γ, DM f) {Γ'} (f : Γ' --> Γ),  ∑ f : (γ⋆f) --> Γ', DM f ;
@@ -125,18 +125,18 @@ Definition dm_sub_closed_under_iso {CC : precategory} (C : dm_sub_struct CC)
 *)
 
 
-Definition pb_of_DM_struct {CC : precategory} (H : dm_sub_struct CC)
+Definition pb_of_DM_struct {CC : category} (H : dm_sub_struct CC)
 : UU
   := ∏ Δ Γ (γ : DM H Δ Γ), ∏ Γ' (f : Γ' --> Γ),
        ∑ P : Pullback γ f, DM_type H (PullbackPr2 P).
 
-Definition dm_sub_pb (CC : precategory) : UU :=
+Definition dm_sub_pb (CC : category) : UU :=
   ∑ DM : dm_sub_struct CC, pb_of_DM_struct DM.
 
-Coercion dm_sub_of_dm_sub_pb {CC : precategory} (C : dm_sub_pb CC) : dm_sub_struct CC := pr1 C.
-Coercion pb_of_dm_sub_pb {CC : precategory} (C : dm_sub_pb CC) : pb_of_DM_struct C := pr2 C.
+Coercion dm_sub_of_dm_sub_pb {CC : category} (C : dm_sub_pb CC) : dm_sub_struct CC := pr1 C.
+Coercion pb_of_dm_sub_pb {CC : category} (C : dm_sub_pb CC) : pb_of_DM_struct C := pr2 C.
 
-Definition pb_ob_of_DM {CC : precategory} {C : dm_sub_pb CC}
+Definition pb_ob_of_DM {CC : category} {C : dm_sub_pb CC}
            {Δ Γ} (γ : DM C Δ Γ) {Γ'} (f : Γ' --> Γ)
 : CC
   := PullbackObject (pr1 (pr2 C _ _ γ _  f)).
@@ -144,21 +144,21 @@ Definition pb_ob_of_DM {CC : precategory} {C : dm_sub_pb CC}
 Notation "γ ⋆ f" := (pb_ob_of_DM γ f) (at level 45, format "γ ⋆ f").
 (* written "\st" in Agda input mode *)
                         
-Definition pb_mor_of_DM {CC : precategory} {C : dm_sub_pb CC}
+Definition pb_mor_of_DM {CC : category} {C : dm_sub_pb CC}
            {Δ Γ} (γ : DM C Δ Γ) {Γ'} (f : Γ' --> Γ)
   :  (γ⋆f) -->  Γ'.
 Proof.
   apply (PullbackPr2 (pr1 (pr2 C _ _ γ _ f))).
 Defined.
 
-Definition pb_mor_of_mor {CC : precategory} {C : dm_sub_pb CC}
+Definition pb_mor_of_mor {CC : category} {C : dm_sub_pb CC}
            {Δ Γ} (γ : DM C Δ Γ) {Γ'} (f : Γ' --> Γ)
 : γ⋆f --> Δ.
 Proof.
   apply (PullbackPr1 (pr1 (pr2 C _ _ γ _ f))).
 Defined.
 
-Definition sqr_comm_of_dm_sub_pb {CC : precategory} {C : dm_sub_pb CC}
+Definition sqr_comm_of_dm_sub_pb {CC : category} {C : dm_sub_pb CC}
            {Δ Γ} (γ : DM C Δ Γ) {Γ'} (f : Γ' --> Γ)
 : _ ;; _ = _ ;; _ 
 := PullbackSqrCommutes (pr1 (pr2 C _ _ γ _ f )).
@@ -171,7 +171,7 @@ isPullback_Pullback (pr1 (pr2 C _ _ γ _ f )).
 
 (** ** DM structure: putting the pieces together *)
 
-Definition DM_structure (CC : precategory) : UU
+Definition DM_structure (CC : category) : UU
   := ∑ C : dm_sub_pb CC,
    (*        dm_closed_under_pb C *)
           dm_sub_closed_under_iso C
@@ -202,7 +202,7 @@ Proof.
   apply pb_mor_of_mor.
 Defined.
 
-Definition sqr_comm_of_DM {CC : precategory} {C : DM_structure CC}  {Δ Γ} (γ : DM C Δ Γ) {Γ'} (f : Γ' --> Γ)
+Definition sqr_comm_of_DM {CC : category} {C : DM_structure CC}  {Δ Γ} (γ : DM C Δ Γ) {Γ'} (f : Γ' --> Γ)
 :  pb_arrow_of_arrow _ _  ;; γ = pb_DM_of_DM γ f  ;; f.
 Proof. 
   apply sqr_comm_of_dm_sub_pb.

--- a/TypeTheory/RelUniv/RelUnivTransfer.v
+++ b/TypeTheory/RelUniv/RelUnivTransfer.v
@@ -538,7 +538,6 @@ Section RelUniv_Transfer.
         apply id_left.
 
      - use (isPullback_image_square _ _ invS).
-       + apply homset_property.
        + apply (right_adj_equiv_is_ff _ _ S AE).
        + apply (right_adj_equiv_is_ess_sur _ _ S AE).
        + apply pb'_isPullback.

--- a/TypeTheory/RelUniv/RelativeUniverses.v
+++ b/TypeTheory/RelUniv/RelativeUniverses.v
@@ -825,8 +825,7 @@ Proof.
     + cbn. 
       match goal with |[|- isPullback (?HH)] => generalize HH end.
       intro HH.
-      use (isPullback_preimage_square _ _ _ _ S_ff). 
-      { apply homset_property. }
+      use (isPullback_preimage_square _ _ _ S_ff). 
       match goal with |[|- isPullback (?HH)] => generalize HH end.
       assert (XR := homotweqinvweq (weq_from_fully_faithful S_ff (J Xf) tU )).
       simpl in XR. rewrite XR.

--- a/TypeTheory/RelUniv/Transport_along_Equivs.v
+++ b/TypeTheory/RelUniv/Transport_along_Equivs.v
@@ -172,7 +172,6 @@ Lemma preserves_pullbacks_ext
 Proof.
   intros ? ? ? ? ? ? ? ? ? ?.
   apply isPullback_image_square.
-  apply functor_category_has_homsets.
   apply right_adj_equiv_is_ff.
   apply right_adj_equiv_is_ess_sur.
   assumption.

--- a/TypeTheory/TypeCat/TypeCat.v
+++ b/TypeTheory/TypeCat/TypeCat.v
@@ -48,7 +48,7 @@ Reserved Notation "A {{ f }}" (at level 30).
 Reserved Notation "'π' A" (at level 5).
 
 Record type_precat_record : Type := {
-  C : precategory ;
+  C : category ;
   ty : C -> Type                       where "C ⟨ Γ ⟩" := (ty Γ);
   ext : ∏ Γ, C⟨Γ⟩ -> C                  where "Γ ◂ A" := (ext Γ A);
   dpr : ∏ Γ (A : C⟨Γ⟩), Γ ◂ A --> Γ     where "'π' A" := (dpr _ A);
@@ -124,7 +124,7 @@ Notation "A {{ f }}" := (reind_typecat A f) (at level 30).
 
 (** * Pullback of dependent projections *)
 
-Definition typecat_structure2 {CC : precategory} (C : typecat_structure1 CC) :=
+Definition typecat_structure2 {CC : category} (C : typecat_structure1 CC) :=
   ∑ (dpr : ∏ Γ (A : C Γ), Γ◂A --> Γ)
     (q : ∏ Γ (A : C Γ) Γ' (f : Γ' --> Γ), (Γ'◂A{{f}}) --> Γ◂A )
     (dpr_q : ∏ Γ (A : C Γ) Γ' (f : Γ' --> Γ), 
@@ -133,31 +133,31 @@ Definition typecat_structure2 {CC : precategory} (C : typecat_structure1 CC) :=
       isPullback (!dpr_q _ A _ f).
 (* TODO: change name [dpr_q] to [q_dpr] throughout, now that composition is diagrammatic order? *)
 
-Definition typecat_structure (CC : precategory) 
+Definition typecat_structure (CC : category) 
   := ∑ C : typecat_structure1 CC , typecat_structure2 C.
 
-Definition typecat1_from_typecat (CC : precategory)(C : typecat_structure CC) 
+Definition typecat1_from_typecat (CC : category)(C : typecat_structure CC) 
   : typecat_structure1 _  := pr1 C.
 Coercion typecat1_from_typecat : typecat_structure >-> typecat_structure1.
 
-Definition dpr_typecat {CC : precategory}
+Definition dpr_typecat {CC : category}
     {C : typecat_structure CC} {Γ} (A : C Γ)
   : (Γ◂A) --> Γ
 := pr1 (pr2 C) Γ A.
 
-Definition q_typecat {CC : precategory}
+Definition q_typecat {CC : category}
     {C : typecat_structure CC} {Γ} (A : C Γ) {Γ'} (f : Γ' --> Γ)
   : (Γ' ◂ A{{f}}) --> (Γ ◂ A) 
 :=
   pr1 (pr2 (pr2 C)) _ A _ f.
 
-Definition dpr_q_typecat {CC : precategory}
+Definition dpr_q_typecat {CC : category}
     {C : typecat_structure CC} {Γ} (A : C Γ) {Γ'} (f : Γ' --> Γ)
   : (q_typecat A f) ;; (dpr_typecat A) = (dpr_typecat (A{{f}})) ;; f
 :=
   pr1 (pr2 (pr2 (pr2 C))) _ A _ f.
 
-Definition reind_pb_typecat {CC : precategory}
+Definition reind_pb_typecat {CC : category}
     {C : typecat_structure CC} {Γ} (A : C Γ) {Γ'} (f : Γ' --> Γ)
   : isPullback (!dpr_q_typecat A f)
 :=
@@ -165,7 +165,7 @@ Definition reind_pb_typecat {CC : precategory}
 
 (** * Type-saturation *)
 
-Definition is_type_saturated_typecat {CC : precategory}
+Definition is_type_saturated_typecat {CC : category}
     (C : typecat_structure CC) : UU
 := ∏ Γ, isincl (λ A : C Γ, tpair (λ X, X --> Γ) (Γ ◂ A) (dpr_typecat A)).
 
@@ -276,7 +276,7 @@ Notation "A {{ f }}" := (reind_typecat A f) (at level 30).
 
 Section lemmas.
 
-Context {CC : precategory} {C : typecat_structure CC}.
+Context {CC : category} {C : typecat_structure CC}.
 
 Lemma transportf_dpr_typecat
     {Γ : CC} {A B : C Γ} (p : A = B)

--- a/TypeTheory/TypeCat_CompCat/TypeCat_ComprehensionCat.v
+++ b/TypeTheory/TypeCat_CompCat/TypeCat_ComprehensionCat.v
@@ -71,7 +71,7 @@ Section TypeCat_ObjExt.
     : obj_ext_typecat Γ A --> Γ
     := pr2 (pr2 TC) Γ A.
   
-  Definition typecat_obj_ext_from_typecat (C : precategory) (TC : typecat_structure C) 
+  Definition typecat_obj_ext_from_typecat (C : category) (TC : typecat_structure C) 
     : typecat_obj_ext_structure _  := (_ ,, _ ,, @dpr_typecat _ TC).
   Coercion typecat_obj_ext_from_typecat : typecat_structure >-> typecat_obj_ext_structure.
 


### PR DESCRIPTION
… to UniMath)

this concerns mainly the move from precategory to category in the notion of pullback

only compiles after PR1633 to UniMath has been merged