### PR TITLE
Workaround coq bug.

### DIFF
--- a/.github/workflows/build-typetheory.yml
+++ b/.github/workflows/build-typetheory.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        coq-version: [latest, 8.16, 8.15]
+        coq-version: [dev, latest, 8.16, 8.15]
         ocaml-version: [4.14-flambda]
     name: Build with ${{ matrix.coq-version }}
     runs-on: ubuntu-22.04

--- a/TypeTheory/CompCats/DiscreteComprehensionCat.v
+++ b/TypeTheory/CompCats/DiscreteComprehensionCat.v
@@ -550,8 +550,8 @@ Section DiscreteComprehensionCats.
       exists (_ ,, FF_axioms).
       exact is_cartesian_FF.
 
-    - apply idpath.
-    - apply idpath.
+    - exact idpath.
+    - exact idpath.
   Defined.
 
   (* A variation of [discrete_comprehension_cat_structure] with a convenient rearrangement of fields *)


### PR DESCRIPTION
TypeTheory breaks with recent coq-dev, reported upstream here: coq/coq#17461. 

This patch is a workaround.