### PR TITLE
Replace `-type-in-type` with `Unset Universe Checking`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ include build/CoqMakefile.make
 endif
 everything: all html install
 OTHERFLAGS += $(MOREFLAGS)
-OTHERFLAGS += -noinit -indices-matter -type-in-type -w none
+OTHERFLAGS += -noinit -indices-matter -w none
 ifeq ($(VERBOSE),yes)
 OTHERFLAGS += -verbose
 endif
@@ -206,7 +206,6 @@ isolate-bug: sub/coq-tools/find-bug.py
 	rm -f $(ISOLATED_BUG_FILE) && \
 	../sub/coq-tools/find-bug.py --coqbin ../sub/coq/bin -R . UniMath \
 		--arg " -indices-matter" \
-		--arg " -type-in-type" \
 		$(BUGGY_FILE) $(ISOLATED_BUG_FILE)
 	@ echo "==="
 	@ echo "=== the isolated bug has been deposited in the file UniMath/$(ISOLATED_BUG_FILE)"

--- a/TypeTheory/.dir-locals.el
+++ b/TypeTheory/.dir-locals.el
@@ -2,5 +2,5 @@
   . ((eval . 
 	   (progn
 	     (make-local-variable 'coq-prog-args)
-	     (setq coq-prog-args `("-noinit" "-emacs" "-indices-matter" "-type-in-type"
+	     (setq coq-prog-args `("-noinit" "-emacs" "-indices-matter"
 				  "-Q" ,(expand-file-name (locate-dominating-file buffer-file-name ".dir-locals.el")) "TypeTheory" )))))))

--- a/TypeTheory/Auxiliary/Auxiliary.v
+++ b/TypeTheory/Auxiliary/Auxiliary.v
@@ -15,6 +15,8 @@ Require Import UniMath.Foundations.All.
 Require Import UniMath.MoreFoundations.All.
 Require Import UniMath.Combinatorics.StandardFiniteSets.
 
+Export Unset Universe Checking.
+
 (** * Notation scopes
 
 We open a few scopes that are used throughout the development, and add/tweak a few of UniMath’s notations.

--- a/TypeTheory/Auxiliary/CategoryTheoryImports.v
+++ b/TypeTheory/Auxiliary/CategoryTheoryImports.v
@@ -22,3 +22,5 @@ Require Export UniMath.CategoryTheory.Presheaf.
 Require Export UniMath.CategoryTheory.catiso.
 Require Export UniMath.CategoryTheory.ArrowCategory.
 Require Export UniMath.CategoryTheory.Equivalences.CompositesAndInverses.
+
+Export Unset Universe Checking.

--- a/TypeTheory/Auxiliary/SetQuotients.v
+++ b/TypeTheory/Auxiliary/SetQuotients.v
@@ -2,6 +2,7 @@
 Require Import UniMath.Foundations.All.
 Require Import UniMath.MoreFoundations.All.
 
+Unset Universe Checking.
 
   (* Upstream issues to possibly raise about [setquot]:
   - should [pr1] of [eqrel] coerce to [hrel], not directly to [Funclass]?

--- a/TypeTheory/Categories/ess_alg_categories.v
+++ b/TypeTheory/Categories/ess_alg_categories.v
@@ -11,6 +11,7 @@
 
 Require Import UniMath.Foundations.Sets.
 
+Unset Universe Checking.
 
 (** * Definition of a [graph] as two types with source and target maps *)
 

--- a/TypeTheory/Csystems/prelim.v
+++ b/TypeTheory/Csystems/prelim.v
@@ -5,6 +5,7 @@ by Vladimir Voevodsky, file created on Jan. 6, 2015 *)
 Require Import UniMath.Foundations.All.
 Require Export UniMath.Combinatorics.StandardFiniteSets.
 
+Export Unset Universe Checking.
 
 (* To upsetream files *)
 

--- a/TypeTheory/dune
+++ b/TypeTheory/dune
@@ -3,5 +3,5 @@
 
 (coq.theory
   (name TypeTheory)
-  (flags -noinit -indices-matter -type-in-type -w none)
+  (flags -noinit -indices-matter -w none)
   (theories UniMath))


### PR DESCRIPTION
Following UniMath/UniMath#1696, this replaces use of the `-type-in-type` flag (which was previously global for the repository, via the `Makefile` and `.dir-locals.el`) with an explicit `Export Unset Universe Checking` in `TypeTheory.Auxiliary.Auxiliary` and other root files of this development.

Summarising the positives and negatives from UniMath/UniMath#1696:

- one clear advantage — it allows potential per-file toggling of the option, so reducing which parts rely on type-in-type
- one questionable disadvantage — any repository importing this downstream may potentially inherit type-in-type (much less significant in `TypeTheory` than in `UniMath` itself)