### PR TITLE
added _RocqProject for VSCode

### DIFF
--- a/_RocqProject
+++ b/_RocqProject
@@ -1,0 +1,1 @@
+-Q TypeTheory TypeTheory


### PR DESCRIPTION
I’m revisiting this repo for the first couple of years, during which I migrated to VS Code from Emacs + Proof General.  VS Code handles the path/environment slightly differently from how Emacs+PG did, and in particular, all internal imports were failing for me in VSCode with "Cannot find a physical path bound to logical path TypeTheory…"

The minimal fix I can see is adding a basic `_RocqProject` file as in this PR; as far as I can see, that updates the path in VS Code and doesn’t interfere with the main build setup.  But I’m not fully on top of how the build infrastructure works, so I’m leaving these PR notes here in case anyone who knows it better thinks this wasn’t the right choice.